### PR TITLE
feat(docs): updates to documentation theme and features

### DIFF
--- a/canfar/client.py
+++ b/canfar/client.py
@@ -43,6 +43,7 @@ class HTTPClient(BaseSettings):
     variables, or a configuration file.
 
     The client prioritizes credentials in the following order:
+
     1.  **Runtime Arguments/Environment Variables**: A `token` or `certificate`
         provided at instantiation (e.g., `CANFAR_TOKEN="..."`).
     2.  **Active Configuration Context**: The context specified by `active_context`

--- a/docs/cli/authentication-contexts.md
+++ b/docs/cli/authentication-contexts.md
@@ -245,5 +245,5 @@ canfar auth login --debug
 !!! tip "Support Resources"
     - 📖 [CLI Reference](cli-help.md) - Complete command documentation
     - 💬 [Community Discussions](https://github.com/opencadc/canfar/discussions) - Ask questions
-    - 🐛 [Report Issues](../bug-reports.mdbug-reports.md) - Bug reports and feature requests
+    - 🐛 [Report Issues](../bug-reports.md) - Bug reports and feature requests
 ```

--- a/docs/client/client.md
+++ b/docs/client/client.md
@@ -89,14 +89,8 @@ except HTTPStatusError as e:
     handler: python
     options:
       members:
-        - __init__
         - client
         - asynclient
-        - expiry
-        - _create_client
-        - _create_asynclient
-        - _get_headers
-        - _get_ssl_context
       show_root_heading: true
       show_source: false
       heading_level: 3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,17 +11,24 @@ remote_branch: gh-pages
 theme:
   name: material
   palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/link
+        name: Switch to light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
+      primary: indigo
+      accent: indigo
       toggle:
         icon: material/toggle-switch
-        name: Hello darkness, my old friend
-    # Palette toggle for dark mode
+        name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
+      primary: black
+      accent: indigo
       toggle:
-        icon: material/toggle-switch-off-outline
-        name: Flash the neon lights
+        icon: material/toggle-switch-off
+        name: Switch to system preference
   font:
     text: Roboto
     code: Roboto Mono
@@ -58,11 +65,30 @@ theme:
     - search.suggest
 
 plugins:
-  - search
-  - mkdocstrings
+  - search:
+      separator: '[\s\u200b\-_,:!=\[\]()"`/]+|\.(?!\d)|&[lg]t;|(?!\b)(?=[A-Z][a-z])'
+  - mkdocstrings:
+      handlers:
+      python:
+        options:
+          show_symbol_type_toc: true
+          show_signature: true
+          separate_signature: true
+          line_length: 88
+          annotations_path: brief
+          docstring_style: google
+          docstring_section_style: spacy
+          docstring_options:
+            ignore_init_summary: true
+            trim_doctest_flags: true
   - git-revision-date-localized:
         type: date
+        enable_creation_date: true
         fallback_to_build_date: true
+  - git-committers:
+      enabled: true
+      repository: opencadc/canfar
+      branch: main
   - termynal
 
 extra:
@@ -72,7 +98,22 @@ extra:
   social:
     - icon: fontawesome/brands/discord
       link: https://discord.gg/vcCQ8QBvBa
-
+    - icon: fontawesome/brands/github
+      link: https://github.com/opencadc/canfar
+    - icon: fontawesome/brands/python
+      link: https://pypi.org/project/canfar
+  analytics:
+    feedback:
+      title: Was this page helpful?
+      ratings:
+        - icon: material/emoticon-happy-outline
+          name: This page was helpful
+          data: 1
+          note: Thanks for your feedback!
+        - icon: material/emoticon-sad-outline
+          name: This page could be improved
+          data: 0
+          note: Let us know how we can improve this page.
 
 # Extensions
 markdown_extensions:
@@ -170,7 +211,7 @@ nav:
     - Code of Conduct: conduct.md
     - OpenSSF Report: https://scorecard.dev/viewer/?uri=github.com/opencadc/canfar
     - License: license.md
-  - Bug Reports:
-    - Bugs: bug-reports.md
-    - Security Issues: security.md
-  - CHANGELOG: changelog.md
+    - Bug Reports:
+      - Bugs: bug-reports.md
+      - Security Issues: security.md
+    - Changelog: changelog.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,8 +81,8 @@ docs = [
     "mkdocs-git-revision-date-localized-plugin>=1.4.7",
     "mkdocs-material>=9.6.14",
     "mkdocstrings[python]>=0.29.1",
-    "mkdocstrings[python]>=0.25.0",
     "termynal>=0.13.0",
+    "mkdocs-git-committers-plugin-2>=2.5.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -151,6 +151,7 @@ dev = [
 ]
 docs = [
     { name = "mike" },
+    { name = "mkdocs-git-committers-plugin-2" },
     { name = "mkdocs-git-revision-date-localized-plugin" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
@@ -195,9 +196,9 @@ dev = [
 ]
 docs = [
     { name = "mike", specifier = ">=2.1.3" },
+    { name = "mkdocs-git-committers-plugin-2", specifier = ">=2.5.0" },
     { name = "mkdocs-git-revision-date-localized-plugin", specifier = ">=1.4.7" },
     { name = "mkdocs-material", specifier = ">=9.6.14" },
-    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.25.0" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.1" },
     { name = "termynal", specifier = ">=0.13.0" },
 ]
@@ -1099,6 +1100,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/f5/ed29cd50067784976f25ed0ed6fcd3c2ce9eb90650aa3b2796ddf7b6870b/mkdocs_get_deps-0.2.0.tar.gz", hash = "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c", size = 10239, upload-time = "2023-11-20T17:51:09.981Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/d4/029f984e8d3f3b6b726bd33cafc473b75e9e44c0f7e80a5b29abc466bdea/mkdocs_get_deps-0.2.0-py3-none-any.whl", hash = "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134", size = 9521, upload-time = "2023-11-20T17:51:08.587Z" },
+]
+
+[[package]]
+name = "mkdocs-git-committers-plugin-2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitpython" },
+    { name = "mkdocs" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/8a/4ca4fb7d17f66fa709b49744c597204ad03fb3b011c76919564843426f11/mkdocs_git_committers_plugin_2-2.5.0.tar.gz", hash = "sha256:a01f17369e79ca28651681cddf212770e646e6191954bad884ca3067316aae60", size = 15183, upload-time = "2025-01-30T07:30:48.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/f5/768590251839a148c188d64779b809bde0e78a306295c18fc29d7fc71ce1/mkdocs_git_committers_plugin_2-2.5.0-py3-none-any.whl", hash = "sha256:1778becf98ccdc5fac809ac7b62cf01d3c67d6e8432723dffbb823307d1193c4", size = 11788, upload-time = "2025-01-30T07:30:45.748Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- A new Material for MkDocs theme with a dark/light mode toggle.
- The addition of the `mkdocs-git-committers-plugin-2` to display commit authors.
- Improved search functionality and styling for mkdocstrings.
- Analytics and user feedback capabilities on documentation pages.
- General cleanup and link fixes.