### PR TITLE
Docs/legacy pages

### DIFF
--- a/docs/platform/guides/index.md
+++ b/docs/platform/guides/index.md
@@ -32,11 +32,9 @@ Run "headless" containers, understand batch systems, manage logs, and use APIs f
 
 Specialized workflows for CASA, ALMA data reduction, CARTA visualization, and other radio astronomy tools.
 
-### [🗂️ Legacy Documentation](../legacy/)
+### [🗂️ Legacy Documentation]()
 
-In addition to the core modules (Accounts, Storage, Containers, Interactive Sessions, etc.), a set of legacy documents is also available. These cover earlier CANFAR service portals and workflows (e.g., Cloud Services, Storage, Publication), which historically paralleled features such as Group Management, Science Portal, and CADC Search.  
-
-While these materials are maintained for reference, they represent historical workflows and are not part of the recommended practices for current users.
+In addition to the core modules (Accounts, Storage, Containers, Interactive Sessions, etc.), a set of legacy documents is also available. These cover earlier CANFAR service portals and workflows - [Cloud Services](../legacy/cloud-services.md), which historically paralleled features such as Group Management, Science Portal, and CADC Search.  
 
 ---
 

--- a/docs/platform/legacy/cloud-services.md
+++ b/docs/platform/legacy/cloud-services.md
@@ -1,4 +1,4 @@
-# Cloud Services Overview {#cloud-services-overview}
+# CANFAR Cloud Services {#cloud-services-overview}
 
 !!! abstract "🎯 What You'll Learn"
     - What cloud services power CANFAR (via Digital Research Alliance Canada OpenStack)  
@@ -7,42 +7,42 @@
     - Where to find the correct cloud portals (Arbutus, Arbutus-CANFAR)  
     - Best practices for using shared cloud allocation resources  
 
-All CANFAR cloud services are hosted on the Digital Research Alliance Canada (DRAC) OpenStack infrastructure.  
-Access is integrated with CADC credentials and customized portals, ensuring consistency and security across CANFAR workflows.  
-When you request access, the CANFAR team will review it and arrange your registration with the Digital Research Alliance Canada (DRAC) infrastructure.
+- All CANFAR cloud services are hosted on the Digital Research Alliance Canada (DRAC) OpenStack Infrastructure.  
+- Access is integrated with CADC credentials and customized portals, ensuring consistency and security across CANFAR workflows.  
+- When you request access, the CANFAR team will review it and arrange your registration with the DRAC.
 
 For a typical workflow with OpenStack Cloud Services and batch processing on CANFAR, see the tutorial below.
 
 ## Key differences from DRAC defaults {#key-differences}
-- **Credentials**: sign in with **CADC** `<USERNAME>` and password (not a DRAC account).
-- **Portal**: use [:material-open-in-new: arbutus-canfar](https://arbutus-canfar.cloud.computecanada.ca/) (instead of [arbutus](https://arbutus.cloud.computecanada.ca/)).
+- **Credentials**: Sign in with **CADC Username/Password** (not a DRAC account).
+- **Portal**: [:material-open-in-new: Use the arbutus-canfar portal](https://arbutus-canfar.cloud.computecanada.ca/) (instead of [arbutus](https://arbutus.cloud.computecanada.ca/)).
 - **Resource policy**: interactive analysis gets reasonable quotas; **batch processing** can scale to large footprints.
 
-## Registration & allocation {#registration}
+## Registration & Allocation {#registration}
 A CADC account is required to access cloud services.
 
 1. Register a CADC account.
 2. Email CANFAR support with:
-   - CADC account `<USERNAME>`
-   - Estimated resources (storage, compute; whether you need batch)
-   - A short description of your use case (2–3 sentences)
+    - Project Name
+    - CADC Account `Username`
+    - Estimated resources (storage, compute; whether you need batch)
+    - A short description of your use case (2–3 sentences)
 
 CANFAR will review and coordinate project/quotas on the DRAC side.
 
 ---
 
-## Batch tutorial {#batch-tutorial}
-This tutorial builds a basic **source detection** pipeline for CFHT MegaCam images on a CANFAR VM with fast access to the CADC archive and VOSpace, then runs it on the CANFAR batch system.
+## Batch Tutorial {#batch-tutorial}
+This tutorial builds a basic **source detection** pipeline for CFHT MegaCam images on a CANFAR VM with fast access to the CADC archive and VOSpace, that runs it on the CANFAR batch system.
 
-**You will:**
-- Create/manage VMs on DRAC OpenStack / CANFAR
-- Access CADC VOSpace
-- Submit batch jobs that run your pipeline
+!!! note "You will learn to"
+    - Create/manage VMs on DRAC OpenStack / CANFAR
+    - Access CADC VOSpace
+    - Submit batch jobs that run your pipeline
 
 !!! tip "Only need persistent (non-batch) VMs?"
-    If you just need persistent VMs, follow DRAC VM docs and skip the batch sections here.
-
-Throughout: `<USERNAME>` = CADC username; `<VOSPACE>` = your VOSpace; `<PROJECT>` = OpenStack project.
+    - If you just need persistent VMs, follow DRAC VM docs and skip the batch sections here.
+    - Throughout the guide, `<USERNAME>` refers to your CADC username; `<VOSPACE>` maps to your VOSpace; `<PROJECT>` is the OpenStack Project.
 
 
 ## Create and Connect to a VM

--- a/docs/platform/legacy/index.md
+++ b/docs/platform/legacy/index.md
@@ -1,7 +1,0 @@
-# Legacy Documentation
-
-These documents reflect earlier CANFAR service portals and workflows. They are preserved for reference only.
-
-- [☁️ Cloud Services](cloud-services-proto.md)  
-- [💾 Storage (Legacy)](storage-proto.md)  
-- [📑 Publication](publication-proto.md)  

--- a/docs/platform/legacy/publication.md
+++ b/docs/platform/legacy/publication.md
@@ -1,35 +1,34 @@
 # Publications (DOIs) {#publications-dois}
 
+## Purpose {#purpose}
+The **CANFAR Data Publication Service (DPS)** links a paper to the **data package** used in the research. DPS provides storage and registers a **DOI** with **DataCite**; the DOI permanently resolves to your landing page and data directory.
+
+## Access {#access}
+- [CANFAR Science Portal](https://www.canfar.net/) → **Data Publication**
+- [Data Publication Service](https://www.canfar.net/citation/)
+
+## Account requirements {#account}
+The first author needs a CADC account to access the DPS UI and, later, the user‑managed storage (VOSpace).
+
 !!! abstract "What you'll learn"
     - Request a DOI
     - Upload the data package
     - (Optional) Provide referee access
     - Publish via DataCite
-
-## Purpose {#purpose}
-The **CANFAR Data Publication Service (DPS)** links a paper to the **data package** used in the research. DPS provides storage and registers a **DOI** with **DataCite**; the DOI permanently resolves to your landing page and data directory.
-
-## Access {#access}
-- Portal: [canfar.net](https://www.canfar.net/) → **Data Publication**
-- Direct: [DPS](https://www.canfar.net/citation/)
-
-## Account requirements {#account}
-The first author needs a CADC account to access the DPS UI and, later, the user‑managed storage (VOSpace).
-
 ---
 
 ## DOI guide {#doi-guide}
 
 ### 1) Request a DOI {#request}
 - A DOI is reserved for your package (e.g., [10.11570/20.0006](http://doi.org/10.11570/20.0006)).
-- A **Data Directory** (VOSpace folder) is created and accessible via the Web UI or `vos` tools. Example: [example Data Directory](https://www.canfar.net/storage/vault/list/AstroDataCitationDOI/CISTI.CANFAR/20.0006/data)
-- A **landing page** is generated, e.g., [example landing page](https://www.canfar.net/citation/landing?doi=20.0006).
+- A [**Data Directory** (VOSpace)](https://www.canfar.net/storage/vault/list/AstroDataCitationDOI/CISTI.CANFAR/20.0006/data) is created and accessible via the Web UI or `vos` tools.
+- A [**landing page**](https://www.canfar.net/citation/landing?doi=20.0006) is generated.
 
 ### 2) Upload the data package {#upload}
 Choose a method based on size and file count:
 
-- Few/small files → Web Storage UI (see [Storage](guides/storage/))
-- Large or many files → `vcp`/`vos` CLI (see [Storage → The `vos` CLI](guides/storage/#vos-cli))
+- Few/small files → [Use the Web Storage UI](storage.md)
+- Large or many files → [Use the `vos, vcp` CLI tools](storage.md/#vos-cli)
 
 More details: [DOI Data Package](#data-package).
 
@@ -59,8 +58,9 @@ Use **New** from the list or go to the [request page](https://www.canfar.net/cit
 
 After submission, a **DOI Reference** number is assigned and displayed.
 
-### DOI details {#details}
+### DOI Details {#details}
 On the details page (e.g., [DOI.20.0016](https://www.canfar.net/citation/request?doi=20.0016)) you’ll find:
+
 - DOI number / Title
 - Authors / Journal reference
 - DOI status
@@ -101,8 +101,8 @@ Example: [Data Directory](https://www.canfar.net/storage/vault/list/AstroDataCit
 You decide what to include: data, figures, software, etc. We recommend a top‑level `README` describing layout and usage.
 
 ### Uploading {#uploading}
-- Few/small files: Web Storage UI (see [Storage](guides/storage/)).
-- Large/many files: `vcp`/CLI (see [Storage → The `vos` CLI](guides/storage/#vos-cli)).
+- Few/small files: [Web Storage UI](storage.md).
+- Large/many files: [Use `vcp`, `vos` CLI Tools](./storage.md#vos-cli).
 
 ### Refereeing access {#ref-access}
 Contact support to obtain a read‑only account and share with the editor/referee. They may request changes prior to publication.
@@ -114,8 +114,3 @@ After acceptance, click **Publish** to mint the DOI. The directory and metadata 
 Finally, link the **data package DOI** to the **journal DOI** (currently manual):
 - Email support with the publication DOI and updated reference details.
 - Provide the data package DOI to the journal so it appears in the paper.
-
----
-
-## Need help? {#help}
-Questions or feedback? Contact [CANFAR support](mailto:support@canfar.net).

--- a/docs/platform/legacy/storage.md
+++ b/docs/platform/legacy/storage.md
@@ -47,7 +47,7 @@ Access requires a CADC account.
 
 !!! tip "Related"
     - Python client & CLI examples are below.
-    - Publications/DOIs: see [Publications](../../publication/).
+    - [Publications/DOIs](publication.md).
 
 ## The `vos` CLI {#vos-cli}
 Use the `vos` command-line client for scripts and terminals.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -140,10 +140,10 @@ nav:
       - Radio Astronomy:
         - Home: platform/guides/radio-astronomy/index.md
         - CASA Workflows: platform/guides/radio-astronomy/casa-workflows.md
+      - Publications: platform/legacy/publication.md
       - Legacy:
-        - Publication Proto: platform/legacy/publication-proto.md
-        - Cloud Services Proto: platform/legacy/cloud-services-proto.md
-        - Storage Proto: platform/legacy/storage-proto.md
+        - Cloud Services: platform/legacy/cloud-services.md
+        - VOS Storage: platform/legacy/storage.md
     - Help & Support: platform/help.md
   - Python Client:
     - Home: client/home.md


### PR DESCRIPTION
- Updated mkdocs.yml to use minimal relative paths under `nav`.
- Adjusted navigation for:
  - Publication (DOIs): platform/publication.md
  - Legacy pages: Storage, OpenStack Cloud Portal
  - Platform Concepts section

Verified locally with `mkdocs serve`; added screenshot of rendered navigation for reference.

<img width="1294" height="755" alt="Screenshot 2025-08-18 at 11 05 25 PM" src="https://github.com/user-attachments/assets/78fbb3bf-8029-401f-9a81-f577970bc25a" />
<img width="1272" height="759" alt="Screenshot 2025-08-18 at 11 05 00 PM" src="https://github.com/user-attachments/assets/a1fe20b6-ffa4-40a9-9915-1360f85f88d1" />
<img width="1209" height="770" alt="Screenshot 2025-08-19 at 10 18 48 AM" src="https://github.com/user-attachments/assets/7bf2205d-3ba2-471b-9e59-bc1a4d4dcd98" />
