### PR TITLE
update documentation on CASA

### DIFF
--- a/docs/platform/community/CASA_and_more.md
+++ b/docs/platform/community/CASA_and_more.md
@@ -1,0 +1,55 @@
+#Notes on CASA containers and adjacent software
+
+This page contains a summary of additional packages included in CASA containers, known issues and work-arounds for specific containers, as well as a brief summary on other radio astronomy tools available.
+
+## CASA add-on tools and packages
+### Astroquery / astropy
+
+The [astroquery tool](https://astroquery.readthedocs.io/en/latest/) is presently only installed on newer CASA containers (6.4.4 and above).  To use astroquery from an appropriate CASA container, type the following to initiate an astroquery-compatible version of python:
+`/opt/casa/bin/python3`
+As per the [astroquery documentation](https://astroquery.readthedocs.io/en/latest/), the tool can then be used on the command line within the python environment.  For example, the following sequence of commands
+
+`from astroquery.simbad import Simbad`
+
+`result_table = Simbad.query_object("m1")`
+
+`result_table.pprint()`
+
+yield a one-line table listing some basic information about M1.
+
+### Analysis Utilities
+The [analysisUtils package](https://casaguides.nrao.edu/index.php/Analysis_Utilities) package is pre-installed on every CASA container, and is ready to use.  You may need to type
+`import analysisUtils as au`
+to load it.
+
+### Firefox
+The Firefox web-browser, needed for CASA commands where you are interacting with the weblogs, should available for CASA versions 6.1.0 to 6.4.3.  Error messages will pop up in your terminal window, but minimal testing suggests that it is sufficiently functional.
+
+### UVMultiFit
+The [UVMultiFit](https://github.com/onsala-space-observatory/UVMultiFit/blob/master/INSTALL.md) package is presently installed and working for all CASA 5.X versions except 5.8.  To load the UVMultiFit package, initiate casa and then type
+
+`from NordicARC import uvmultifit as uvm`
+
+## Known CASA Container Bugs
+1) CASA versions 6.5.0 to 6.5.2 initially launch with some display errors in the logger window.  Exiting casa (but not the container) and re-starting casa fixes the issue, i.e.,
+
+`casa`
+
+`exit`
+
+`casa`
+
+
+2) Running multi-thread pipeline scripts (MPI CASA) may generate error messages, as described [here](https://casadocs.readthedocs.io/en/latest/notebooks/frequently-asked-questions.html) under the 'Running pipeline in non-interactive mode' section.  A CANFAR ALMA user reports success initiating MPI CASA in a Desktop container as follows:
+
+`xvfb-run -a mpicasa casa —nologger —nogui -agg -c casa_script.py`
+
+
+## CASA Adjacent Containers 
+### Galario
+The UV data analysis package [galario](https://mtazzari.github.io/galario) is available under the radio-submm menu.  Note that this container has had minimal testing, and the uvplot package commands in the quickstart.py script are not presently working, although all preceeding commands in the quickstart.py script do work.
+
+### Starlink
+The JCMT's [Starlink](https://starlink.eao.hawaii.edu/starlink) package is available under the radio-submm menu, including image analysis tools and the gaia image viewer.  Note that the [starlink-pywrapper](https://starlink-pywrapper.readthedocs.io/en/latest/) add-on package is presently not working.  Minimal testing has been done on the Starlink container.
+
+

--- a/docs/platform/community/index.md
+++ b/docs/platform/community/index.md
@@ -2,4 +2,6 @@
 
 As teams and projects grow, it's important to share knowledge and best practices. This section provides resources and tutorials for specific communities and their use cases within the CANFAR ecosystem.
 
+**[CASA and adjacent radio astronomy tools](CASA_and_more.md)**
+
 If you have a specific use case or community you'd like to see represented here, please contribute to the [documentation](https://github.com/opencadc/canfar) or [contact us](mailto:support@canfar.net).

--- a/docs/platform/containers/build.md
+++ b/docs/platform/containers/build.md
@@ -121,7 +121,7 @@ Always extend existing CANFAR base images rather than starting from scratch:
 FROM images.canfar.net/skaha/astroml:latest
 
 # For radio astronomy
-FROM images.canfar.net/skaha/casa:latest
+FROM images.canfar.net/skaha/casa:[version]
 
 # For minimal environments
 FROM images.canfar.net/skaha/base:latest

--- a/docs/platform/sessions/desktop.md
+++ b/docs/platform/sessions/desktop.md
@@ -207,9 +207,9 @@ Click the shortcut icon on the desktop for immediate access to:
 To use CASA with its graphical interface:
 
 1. Launch CASA from the **Astro Software** menu
-2. CASA runs in a dedicated container with full GUI support
-3. Access CASA's plotting and visualisation tools
-4. Use CASA's built-in task interfaces and parameter editors
+2. Start CASA in the terminal by typing either `casa` or `casa --pipeline` as appropriate. 
+3. Run CASA tasks as usual via command line or scripts (e.g., calibration or imaging). 
+4. Access CASA's plotting and visualization tools (e.g., plotms or interactive clean).
 
 ## 🔧 Desktop Session Features
 
@@ -228,6 +228,7 @@ Since different containers may run on separate remote computers, text transfer b
 The Clipboard functions as an intermediary for text transfer:
 
 **Transfer Process:**
+
 1. **Copy text**: Highlight text in source application, use `Ctrl+Shift+C`
 2. **Transfer to Clipboard**: Text appears in the Clipboard application
 3. **Select in Clipboard**: Highlight the text and copy with `Ctrl+Shift+C`


### PR DESCRIPTION
Updates to several directories within the documentation, mostly minor tweaks related to casa.  Each directory has a separate git commit note with details.  The largest change is in the Community section, where a new page is added with information on specific CASA containers: additional packages/tools which are available and how to initiate them, known bugs & work-arounds, and also a few CASA-adjacent containers available.  This content is basically identical to a similar page on the old documentation.  Note: I was unable to figure out how to get the full documentation menu bar on the left hand side to display properly on the new page, nor does the new page appear as a separate listing on the Community section, although I did add a link on the Community index.md page to make it somewhat accessible.  Hopefully someone can help with those additional small tweaks; I didn't see any particular coding on similar pages in other sections to show me what else I needed to set up.  Many thanks!