### PR TITLE
docs: add deployments documentation link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ hide:
     - [:simple-python: __Python API__ <small>for access and automation</small>](client/home.md)
     - [:simple-gnubash: __CLI__ <small>for terminal users</small>](cli/quick-start.md)
     - [:simple-doi: __Publications__ <small>of DataCite DOIs</small>](platform/doi.md)
-    - [:material-kubernetes: __Deployments__ <small>Helm charts and operations</small>](https://www.opencadc.org/deployments/)
+    - [:material-kubernetes: __Platform Operations__ <small>Deployments and infrastructure</small>](https://www.opencadc.org/deployments/)
     - [:octicons-sparkles-fill-16: __Release Notes__ <small>for the latest updates</small>](release-notes.md)
     - [:simple-rocket: __Try out__ <small>CANFAR Science Platform</small>](https://www.canfar.net)
     - [:octicons-telescope-fill-16: and much more...](platform/concepts.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -236,7 +236,7 @@ nav:
       - Contributing: contributing.md
       - Testing: client/testing.md
     - Operations:
-      - Deployments: https://www.opencadc.org/deployments/
+      - Platform Deployments: https://www.opencadc.org/deployments/
     - Security Issues: security.md
     - Changelog: changelog.md
   - About:


### PR DESCRIPTION
## Summary

Add links to the new deployments documentation site from the CANFAR main documentation.

- Add Deployments card to home page with Kubernetes icon
- Add Operations > Deployments navigation link
- Links point to https://www.opencadc.org/deployments/

## Changes

- `docs/index.md`: Added Deployments card in the home page grid
- `mkdocs.yml`: Added Operations > Deployments link to navigation

## Testing

Tested locally with `mkdocs serve` to verify:
- Card displays correctly on home page
- Navigation link appears in Contribute section
- Links resolve correctly once deployments site is published