### PR TITLE
fix(ci): relax coverage checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0%
+        base: auto
+      main:
+        target: 75%
+        threshold: 0%
+        base: auto
+        branches:
+          - main
+    patch:
+      default:
+        target: auto
+        threshold: 0%
+        base: auto

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -268,7 +268,7 @@ addopts = [
     "--cov-report=term-missing:skip-covered",
     "--cov-report=html",
     "--cov-report=xml",
-    "--cov-fail-under=80",
+    "--cov-fail-under=75",
     "-n=auto",  # Enable parallel execution with pytest-xdist
     "--dist=loadfile",  # Use loadfile distribution to ensure tests in same file run in same worker (required for pytest-order)
 ]


### PR DESCRIPTION
## Summary
- Lower the pytest coverage failure threshold from 80% to 75%.
- Add Codecov status configuration so project and patch coverage statuses follow the intended thresholds.

## Why
Recent CI coverage checks are sensitive to unstable network-dependent test behavior. This keeps CI coverage enforcement aligned with the current practical baseline while preserving Codecov reporting.

## Validation
- ruby -e "require 'yaml'; YAML.load_file('codecov.yml'); puts 'codecov ok'"
- uv run --no-sync python -c "import pathlib, tomllib; tomllib.loads(pathlib.Path('pyproject.toml').read_text()); print('pyproject ok')"
- pre-commit hooks from commit: check yaml, radon, secret detection, and other applicable hooks passed
