### PR TITLE
Add CANFAR agent infrastructure and stabilize non-slow tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Repository Instructions
+
+- Always use conventional commit standard for creating commit messages.
+- Prefer `rg` and `rg --files` for code search.
+- Use `uv` for project commands.
+- Keep docs truthful to implemented behavior. Do not document CLI commands, flags, or Python surfaces that do not exist.
+- Treat full integration tests as CANFAR-auth-dependent. They require a valid CANFAR account and X.509 certificate/config.
+
+## Repo Map
+
+- `canfar/models/` contains Pydantic models for persisted config, auth contexts, server metadata, registry data, and session request/response shapes.
+- `canfar/client.py` owns HTTP client composition, credential precedence, auth hooks, timeouts, and sync/async `httpx` clients.
+- `canfar/sessions.py`, `canfar/images.py`, `canfar/context.py`, and `canfar/overview.py` expose library modules for Science Platform operations.
+- `canfar/cli/` contains Typer CLI adapters. Keep command output, exit behavior, and library calls aligned.
+- `canfar/auth/`, `canfar/hooks/`, and `canfar/utils/` contain auth flows, HTTP/Typer hooks, discovery, display, logging, and request builders.
+- `tests/` mirrors source modules. Prefer focused tests near the module changed.
+- `docs/` is the MkDocs site. Client and CLI behavior documented here must match current code.
+
+## Validation
+
+- Fast lint: `uv run --no-sync ruff check . --no-cache`
+- Type check: `uv run --no-sync mypy canfar --config-file pyproject.toml`
+- Deterministic non-slow tests: `env HOME=/private/tmp/canfar-empty-home uv run --no-sync pytest tests -m "not slow" --no-cov -q -o cache_dir=/tmp/canfar-pytest-cache`
+- Docs build: `uv run --group docs mkdocs build`
+- Full test suite: `uv run --no-sync pytest`
+
+Run the full test suite only when a valid CANFAR auth context and certificate are available. Otherwise use the deterministic non-slow test command.
+
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs are tracked in GitHub Issues for `opencadc/canfar`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Use the canonical triage label vocabulary in GitHub. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This repo uses a single-context domain glossary at root `CONTEXT.md`; ADRs are created lazily under `docs/adr/`. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,61 @@
+# CANFAR
+
+CANFAR is a science platform context for authenticated astronomical compute, container images, and user sessions. This glossary names domain concepts only; implementation details live in code and ADRs.
+
+## Language
+
+**CANFAR Science Platform**:
+Cloud-native environment for astronomical research workflows.
+_Avoid_: Skaha, client, service
+
+**Science Platform Server**:
+Deployable CANFAR-compatible server endpoint that accepts authenticated platform requests.
+_Avoid_: Base URL, host, cluster
+
+**Authentication Context**:
+Saved profile that selects one Science Platform Server and its credentials.
+_Avoid_: Account, config, login
+
+**Authentication Mode**:
+Credential mechanism used by an Authentication Context.
+_Avoid_: Provider, method
+
+**Session**:
+User-owned compute environment launched on a Science Platform Server.
+_Avoid_: Job, pod, container
+
+**Session Kind**:
+Category of Session experience requested by a user.
+_Avoid_: Type, app
+
+**Container Image**:
+Reusable software environment used to start a Session.
+_Avoid_: Container, package
+
+**Container Registry**:
+Image catalog where CANFAR Container Images are published and discovered.
+_Avoid_: Harbor, image server
+
+**Resource Allocation Mode**:
+Policy for how CPU, memory, and GPU resources are requested for a Session.
+_Avoid_: Resource profile, quota
+
+## Relationships
+
+- A **CANFAR Science Platform** exposes one or more **Science Platform Servers**.
+- An **Authentication Context** belongs to exactly one **Science Platform Server**.
+- An **Authentication Context** uses one **Authentication Mode**.
+- A **Session** runs on one **Science Platform Server**.
+- A **Session** has one **Session Kind**.
+- A **Session** starts from one **Container Image**.
+- A **Container Registry** publishes many **Container Images**.
+- A **Resource Allocation Mode** shapes resources requested for a **Session**.
+
+## Example dialogue
+
+> **Dev:** "When user switches Authentication Context, does existing Session move?"
+> **Domain expert:** "No. Authentication Context changes where new requests go; existing Session remains on Science Platform Server where it was launched."
+
+## Flagged ambiguities
+
+- "context" can mean Python execution context, config context, or **Authentication Context**. In CANFAR domain docs, use **Authentication Context** for saved server-plus-credential profiles.

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -1,0 +1,33 @@
+# Agent Architecture Notes
+
+Use these notes as navigation guardrails. They are not a refactor backlog.
+
+## Module Map
+
+- Domain request/response and config shapes live in `canfar/models/`.
+- HTTP composition, credential precedence, sync/async clients, and auth hooks live in `canfar/client.py`.
+- User-facing library operations live in `canfar/sessions.py`, `canfar/images.py`, `canfar/context.py`, and `canfar/overview.py`.
+- Typer command adapters live in `canfar/cli/` and should stay thin over library modules.
+- Auth flows live in `canfar/auth/`; request/response hooks live in `canfar/hooks/`.
+- Discovery, display, logging, request builders, and other helper modules live in `canfar/utils/`.
+
+## Current Seams
+
+- `Configuration` is the persistent config seam. Tests that construct it must isolate `CONFIG_PATH` from the developer's real `~/.canfar/config.yaml`.
+- `HTTPClient` is the transport seam. It decides runtime credential precedence before creating `httpx` clients.
+- `Session` and `AsyncSession` duplicate many operations in sync/async form. Keep behavior aligned when changing either adapter.
+- CLI modules are adapters over library modules. Prefer testing command parsing/output separately from library behavior.
+- Request builders in `canfar/utils/build.py` are useful test surfaces for payload shape and validation.
+
+## Test Caveats
+
+- Some tests touch live CANFAR endpoints even if they are not long-running. They must be marked `slow` and `integration`.
+- `pytest -m "not slow"` should be deterministic without real CANFAR credentials.
+- Full `uv run --no-sync pytest` requires valid CANFAR auth and may depend on platform availability.
+
+## Change Rules
+
+- Match CLI behavior to docs and docs to CLI behavior in the same change.
+- Avoid new seams until at least two adapters need them.
+- Prefer Pydantic models for structured request/config data instead of ad hoc dict handling at call sites.
+- Keep secret-bearing config output redacted or explicitly justified.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,24 @@
+# Domain Docs
+
+Engineering skills should consume CANFAR domain docs before architecture, diagnosis, TDD, or issue-writing work.
+
+## Layout
+
+This is a single-context repo:
+
+- `CONTEXT.md` at the repository root is the domain glossary.
+- `docs/adr/` holds architecture decision records when they exist.
+
+If `docs/adr/` does not exist, proceed silently. Create it only when a real ADR is needed.
+
+## Consumer Rules
+
+- Read `CONTEXT.md` before naming domain concepts in issues, plans, tests, or architecture reviews.
+- Use glossary vocabulary exactly. Do not drift from **Authentication Context**, **Science Platform Server**, **Session**, **Container Image**, or other defined terms.
+- Keep `CONTEXT.md` implementation-free. It is a glossary, not a spec.
+- If a concept is missing or overloaded, use `grill-with-docs` to resolve the term and update `CONTEXT.md`.
+- If a proposal contradicts an ADR, surface that conflict explicitly.
+
+## ADR Policy
+
+Create ADRs sparingly under `docs/adr/` only when a decision is hard to reverse, surprising without context, and based on a real trade-off.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,23 @@
+# Issue Tracker: GitHub
+
+Issues and PRDs for this repo live in GitHub Issues for `opencadc/canfar`.
+
+Use the `gh` CLI from the repository checkout so the repository is inferred from `git remote -v`.
+
+## Conventions
+
+- Create issue: `gh issue create --title "..." --body "..."`
+- Read issue: `gh issue view <number> --comments`
+- List issues: `gh issue list --state open --json number,title,body,labels,comments`
+- Comment: `gh issue comment <number> --body "..."`
+- Add label: `gh issue edit <number> --add-label "..."`
+- Remove label: `gh issue edit <number> --remove-label "..."`
+- Close issue: `gh issue close <number> --comment "..."`
+
+## Skill Rules
+
+When a skill says "publish to the issue tracker", create a GitHub issue.
+
+When a skill says "fetch the relevant ticket", run `gh issue view <number> --comments`.
+
+Do not use Jira, local markdown, or another tracker for repo work unless the user explicitly overrides this file.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,13 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to exact GitHub label strings used in this repo.
+
+| Label in mattpocock/skills | Label in GitHub | Meaning |
+| --- | --- | --- |
+| `needs-triage` | `needs-triage` | Maintainer needs to evaluate this issue |
+| `needs-info` | `needs-info` | Waiting on reporter for more information |
+| `ready-for-agent` | `ready-for-agent` | Fully specified, ready for an AFK agent |
+| `ready-for-human` | `ready-for-human` | Requires human implementation |
+| `wontfix` | `wontfix` | Will not be actioned |
+
+Use these exact labels when triaging. Do not create duplicate labels with alternate spellings.

--- a/tests/test_async_session.py
+++ b/tests/test_async_session.py
@@ -24,6 +24,8 @@ def asession():
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.slow
 async def test_fetch_with_kind(asession: AsyncSession) -> None:
     """Test fetching images with kind."""
     await asession.fetch(kind="headless")

--- a/tests/test_async_session.py
+++ b/tests/test_async_session.py
@@ -2,11 +2,12 @@
 
 from asyncio import sleep
 from time import time
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
+import httpx
 import pytest
-from pydantic import ValidationError
+from pydantic import SecretStr, ValidationError
 
 from canfar.sessions import AsyncSession
 
@@ -29,6 +30,84 @@ def asession():
 async def test_fetch_with_kind(asession: AsyncSession) -> None:
     """Test fetching images with kind."""
     await asession.fetch(kind="headless")
+
+
+def _sync_response(json_data=None, text: str = "") -> MagicMock:
+    response = MagicMock()
+    response.json.return_value = json_data
+    response.text = text
+    return response
+
+
+def _http_error(method: str, url: str) -> httpx.HTTPStatusError:
+    request = httpx.Request(method, url)
+    response = httpx.Response(500, request=request)
+    return httpx.HTTPStatusError("boom", request=request, response=response)
+
+
+@pytest.mark.asyncio
+async def test_async_session_methods_handle_success_and_failures() -> None:
+    """AsyncSession methods return parsed data and tolerate per-ID failures."""
+    session = AsyncSession(
+        token=SecretStr("token"), url="https://example.test/skaha/v1", concurrency=2
+    )
+    client = MagicMock()
+    client.get = AsyncMock()
+    client.post = AsyncMock()
+    client.delete = AsyncMock()
+    session._asynclient = client  # noqa: SLF001
+
+    client.get.return_value = _sync_response([{"id": "s1"}])
+    assert await session.fetch(kind="headless") == [{"id": "s1"}]
+
+    client.get.return_value = _sync_response({"cores": {}})
+    assert await session.stats() == {"cores": {}}
+
+    client.get.side_effect = [
+        _sync_response({"id": "s1"}),
+        RuntimeError("info failed"),
+    ]
+    with patch("canfar.sessions._log_http_task_failure") as log_failure:
+        assert await session.info(["s1", "s2"]) == [{"id": "s1"}]
+    log_failure.assert_called_once()
+
+    client.get.side_effect = [
+        _sync_response(text="log text"),
+        RuntimeError("logs failed"),
+    ]
+    with patch("canfar.sessions._log_http_task_failure") as log_failure:
+        assert await session.logs(["s1", "s2"]) == {"s1": "log text"}
+    log_failure.assert_called_once()
+
+    client.post.side_effect = [
+        _sync_response(text="created-1\n"),
+        RuntimeError("create failed"),
+    ]
+    with patch("canfar.sessions._log_http_task_failure") as log_failure:
+        assert await session.create(
+            name="batch",
+            image="skaha/terminal:latest",
+            kind="headless",
+            replicas=2,
+        ) == ["created-1"]
+    log_failure.assert_called_once()
+
+    client.get.side_effect = [
+        _sync_response(text="event text"),
+        RuntimeError("events failed"),
+    ]
+    with patch("canfar.sessions._log_http_task_failure") as log_failure:
+        assert await session.events(["s1", "s2"]) == [{"s1": "event text"}]
+    log_failure.assert_called_once()
+
+    client.get.side_effect = [_sync_response(text="event text")]
+    assert await session.events("s1", verbose=True) is None
+
+    client.delete.side_effect = [
+        None,
+        _http_error("DELETE", "https://example.test/skaha/v1/session/s2"),
+    ]
+    assert await session.destroy(["s1", "s2"]) == {"s1": True, "s2": False}
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
+from pydantic import BaseModel
 from typer.testing import CliRunner
 
-from canfar.cli.config import config
+from canfar.cli.config import _format_value, config
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -61,3 +62,51 @@ def test_config_set_invalid_value_fails_validation(tmp_path: Path) -> None:
     ):
         result = runner.invoke(config, ["set", "console.width", "not_an_int"])
         assert result.exit_code == 1
+
+
+class ExampleModel(BaseModel):
+    """Tiny model for config formatting tests."""
+
+    value: int
+
+
+def test_config_show_path_format_and_errors(tmp_path: Path) -> None:
+    """Test config show/path/format helpers and handled error paths."""
+    config_path = tmp_path / "config.yaml"
+
+    with (
+        patch("canfar.cli.config.CONFIG_PATH", config_path),
+        patch("canfar.models.config.CONFIG_PATH", config_path),
+    ):
+        result = runner.invoke(config, ["show"])
+
+    assert result.exit_code == 0
+    assert "showing defaults" in result.stdout
+
+    result = runner.invoke(config, ["path"])
+    assert result.exit_code == 0
+    assert ".canfar" in result.stdout
+
+    assert _format_value(ExampleModel(value=7)) == '{\n  "value": 7\n}'
+    assert _format_value({"a": [1]}) == '{\n  "a": [\n    1\n  ]\n}'
+    assert _format_value(None) == "null"
+
+    with patch("canfar.cli.config.Configuration", side_effect=RuntimeError("bad")):
+        result = runner.invoke(config, ["show"])
+
+    assert result.exit_code == 1
+    assert "bad" in result.stdout
+
+    with patch("canfar.cli.config.Configuration") as cfg:
+        cfg.return_value.get_value.side_effect = KeyError("missing")
+        result = runner.invoke(config, ["get", "missing"])
+
+    assert result.exit_code == 1
+    assert "missing" in result.stdout
+
+    with patch("canfar.cli.config.Configuration") as cfg:
+        cfg.return_value.set_value.side_effect = TypeError("wrong")
+        result = runner.invoke(config, ["set", "console.width", "120"])
+
+    assert result.exit_code == 1
+    assert "wrong" in result.stdout

--- a/tests/test_cli_delete.py
+++ b/tests/test_cli_delete.py
@@ -1,0 +1,41 @@
+"""Tests for the delete CLI module."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from typer.testing import CliRunner
+
+from canfar.cli.delete import delete
+
+runner = CliRunner()
+
+
+def _mock_async_session(mock_session_cls: MagicMock) -> AsyncMock:
+    mock_session = AsyncMock()
+    mock_session_cls.return_value.__aenter__.return_value = mock_session
+    return mock_session
+
+
+def test_delete_force_success_error_and_cancel() -> None:
+    """Test forced delete, handled delete error, and prompt cancellation."""
+    with patch("canfar.cli.delete.AsyncSession") as session_cls:
+        session = _mock_async_session(session_cls)
+        session.destroy.return_value = {"abc": True}
+        result = runner.invoke(delete, ["--force", "abc"])
+
+    assert result.exit_code == 0
+    assert "Successfully deleted" in result.stdout
+
+    with patch("canfar.cli.delete.AsyncSession") as session_cls:
+        session = _mock_async_session(session_cls)
+        session.destroy.side_effect = RuntimeError("delete failed")
+        result = runner.invoke(delete, ["--force", "abc"])
+
+    assert result.exit_code == 0
+    assert "Error during deletion: delete failed" in result.stdout
+
+    with patch("canfar.cli.delete.Confirm.ask", return_value=False):
+        result = runner.invoke(delete, ["abc"])
+
+    assert result.exit_code == 0

--- a/tests/test_cli_logs.py
+++ b/tests/test_cli_logs.py
@@ -1,0 +1,49 @@
+"""Tests for the logs CLI module."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from typer.testing import CliRunner
+
+from canfar.cli.logs import logs
+
+runner = CliRunner()
+
+
+def _mock_async_session(mock_session_cls: MagicMock) -> AsyncMock:
+    mock_session = AsyncMock()
+    mock_session_cls.return_value.__aenter__.return_value = mock_session
+    return mock_session
+
+
+def test_logs_outputs_logs_and_empty_message() -> None:
+    """Test logs command output and empty result message."""
+    with patch("canfar.cli.logs.AsyncSession") as session_cls:
+        session = _mock_async_session(session_cls)
+        session.logs.return_value = {"abc": "hello\nworld"}
+        result = runner.invoke(logs, ["abc"])
+
+    assert result.exit_code == 0
+    assert "Logs for session abc" in result.stdout
+    assert "hello" in result.stdout
+
+    with patch("canfar.cli.logs.AsyncSession") as session_cls:
+        session = _mock_async_session(session_cls)
+        session.logs.return_value = {}
+        result = runner.invoke(logs, ["abc"])
+
+    assert result.exit_code == 0
+    assert "No logs found" in result.stdout
+
+
+def test_logs_reports_fetch_error() -> None:
+    """Test logs command reports fetch errors."""
+    with patch("canfar.cli.logs.AsyncSession") as session_cls:
+        session = _mock_async_session(session_cls)
+        session.logs.side_effect = RuntimeError("boom")
+        result = runner.invoke(logs, ["abc"])
+
+    assert result.exit_code == 1
+    assert "Could not fetch logs" in result.stdout
+    assert "boom" in result.stdout

--- a/tests/test_cli_open.py
+++ b/tests/test_cli_open.py
@@ -1,0 +1,47 @@
+"""Tests for the open CLI module."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from typer.testing import CliRunner
+
+from canfar.cli.open import open_command
+
+runner = CliRunner()
+
+
+def _mock_async_session(mock_session_cls: MagicMock) -> AsyncMock:
+    mock_session = AsyncMock()
+    mock_session_cls.return_value.__aenter__.return_value = mock_session
+    return mock_session
+
+
+def test_open_command_opens_url_and_reports_missing_data() -> None:
+    """Test open command opens sessions that include connect URLs."""
+    with (
+        patch("canfar.cli.open.AsyncSession") as session_cls,
+        patch("canfar.cli.open.webbrowser.open_new_tab") as open_tab,
+    ):
+        session = _mock_async_session(session_cls)
+        session.info.return_value = [
+            {"id": "abc", "connectURL": "https://example.test/session/abc"},
+            {"id": "missing"},
+        ]
+        result = runner.invoke(open_command, ["abc", "missing"])
+
+    assert result.exit_code == 0
+    assert "Opening session abc" in result.stdout
+    assert "No connectURL found for session missing" in result.stdout
+    open_tab.assert_called_once_with("https://example.test/session/abc")
+
+
+def test_open_command_no_session_info() -> None:
+    """Test open command reports missing session info."""
+    with patch("canfar.cli.open.AsyncSession") as session_cls:
+        session = _mock_async_session(session_cls)
+        session.info.return_value = []
+        result = runner.invoke(open_command, ["abc"])
+
+    assert result.exit_code == 0
+    assert "No information found" in result.stdout

--- a/tests/test_cli_prune.py
+++ b/tests/test_cli_prune.py
@@ -1,0 +1,34 @@
+"""Tests for the prune CLI module."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from typer.testing import CliRunner
+
+from canfar.cli.prune import PruneUsageMessage, prune
+
+runner = CliRunner()
+
+
+def _mock_async_session(mock_session_cls: MagicMock) -> AsyncMock:
+    mock_session = AsyncMock()
+    mock_session_cls.return_value.__aenter__.return_value = mock_session
+    return mock_session
+
+
+def test_prune_success_and_usage_message() -> None:
+    """Test prune command and custom usage message."""
+    with patch("canfar.cli.prune.AsyncSession") as session_cls:
+        session = _mock_async_session(session_cls)
+        session.destroy_with.return_value = {"abc": True, "def": False}
+        result = runner.invoke(prune, ["batch", "headless", "Succeeded"])
+
+    assert result.exit_code == 0
+    assert "Deleted 2 sessions" in result.stdout
+    session.destroy_with.assert_awaited_once_with(
+        prefix="batch", kind="headless", status="Succeeded"
+    )
+
+    usage = PruneUsageMessage(name="prune").get_usage(MagicMock())
+    assert "canfar prune" in usage

--- a/tests/test_cli_stats_ps.py
+++ b/tests/test_cli_stats_ps.py
@@ -2,12 +2,22 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 from typer.testing import CliRunner
 
 from canfar.cli.main import cli
+from canfar.cli.ps import ps
+from canfar.cli.stats import stats
 
 runner = CliRunner()
+
+
+def _mock_async_session(mock_session_cls: MagicMock) -> AsyncMock:
+    mock_session = AsyncMock()
+    mock_session_cls.return_value.__aenter__.return_value = mock_session
+    return mock_session
 
 
 def test_stats_command_help() -> None:
@@ -20,6 +30,97 @@ def test_ps_command_help() -> None:
     """Test ps command help executes successfully."""
     result = runner.invoke(cli, ["ps", "--help"])
     assert result.exit_code == 0
+
+
+def test_ps_outputs_running_table_and_debug_anomalies() -> None:
+    """Test ps table rendering with debug anomaly output."""
+    payloads = [
+        {
+            "id": "running-1",
+            "name": "run",
+            "type": "headless",
+            "status": "Running",
+            "image": "images.canfar.net/skaha/terminal:latest",
+            "startTime": "2025-01-01T00:00:00Z",
+            "isFixedResources": True,
+            "supplementalGroups": ["bad-group"],
+        },
+        {
+            "id": "done-1",
+            "name": "done",
+            "type": "headless",
+            "status": "Completed",
+            "image": "images.canfar.net/skaha/terminal:latest",
+            "startTime": "2025-01-02T00:00:00Z",
+            "isFixedResources": True,
+        },
+    ]
+
+    with patch("canfar.cli.ps.AsyncSession") as session_cls:
+        session = _mock_async_session(session_cls)
+        session.fetch.return_value = payloads
+        result = runner.invoke(ps, ["--debug"])
+
+    assert result.exit_code == 0
+    assert "running-1" in result.stdout
+    assert "done-1" not in result.stdout
+    assert "Session Response Warnings" in result.stdout
+    session.fetch.assert_awaited_once_with(kind=None, status=None)
+
+
+def test_ps_quiet_prints_first_session_id() -> None:
+    """Test ps quiet mode prints the first session ID."""
+    with patch("canfar.cli.ps.AsyncSession") as session_cls:
+        session = _mock_async_session(session_cls)
+        session.fetch.return_value = [
+            {
+                "id": "first-id",
+                "name": "run",
+                "type": "headless",
+                "status": "Running",
+                "isFixedResources": True,
+            }
+        ]
+        result = runner.invoke(ps, ["--quiet"])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "first-id"
+
+
+def test_ps_allows_empty_running_view() -> None:
+    """Test ps reports empty running view when only completed sessions exist."""
+    with patch("canfar.cli.ps.AsyncSession") as session_cls:
+        session = _mock_async_session(session_cls)
+        session.fetch.return_value = [
+            {
+                "id": "done",
+                "name": "done",
+                "type": "headless",
+                "status": "Completed",
+                "isFixedResources": True,
+            },
+        ]
+        result = runner.invoke(ps, [])
+
+    assert result.exit_code == 0
+    assert "No pending or running sessions found" in result.stdout
+
+
+def test_stats_outputs_cluster_tables() -> None:
+    """Test stats renders cluster table data."""
+    with patch("canfar.cli.stats.AsyncSession") as session_cls:
+        session = _mock_async_session(session_cls)
+        session.stats.return_value = {
+            "instances": {"desktopApp": 2, "notebook": 3, "total": 5},
+            "cores": {"requestedCPUCores": 4, "cpuCoresAvailable": 64},
+            "ram": {"requestedRAM": "8Gi", "ramAvailable": "128Gi"},
+        }
+        result = runner.invoke(stats, ["--debug"])
+
+    assert result.exit_code == 0
+    assert "CANFAR Platform Load" in result.stdout
+    assert "Maximum Requests Size" in result.stdout
+    session_cls.assert_called_once_with(loglevel="DEBUG")
 
 
 @pytest.mark.slow

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,5 +1,7 @@
 """Test Canfar Context API."""
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from canfar.context import Context
@@ -18,3 +20,14 @@ def context():
 def test_context(context) -> None:
     """Test context fetch."""
     assert "cores" in context.resources()
+
+
+def test_context_resources_use_http_client() -> None:
+    """Resources returns decoded context payload."""
+    context = Context(token="token", url="https://example.test/skaha/v1")
+    mock_client = MagicMock()
+    mock_client.get.return_value.json.return_value = {"cores": {"default": 1}}
+    context._client = mock_client  # noqa: SLF001
+
+    assert context.resources() == {"cores": {"default": 1}}
+    mock_client.get.assert_called_once_with(url="context")

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -13,6 +13,8 @@ def context():
     del context
 
 
+@pytest.mark.integration
+@pytest.mark.slow
 def test_context(context) -> None:
     """Test context fetch."""
     assert "cores" in context.resources()

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -16,11 +16,15 @@ def images():
     del images
 
 
+@pytest.mark.integration
+@pytest.mark.slow
 def test_images_fetch(images: Images) -> None:
     """Test fetching images."""
     assert len(images.fetch()) > 0
 
 
+@pytest.mark.integration
+@pytest.mark.slow
 def test_images_with_kind(images: Images) -> None:
     """Test fetching images with kind."""
     assert "images.canfar.net/skaha/base-notebook:latest" in images.fetch(

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,6 +1,6 @@
 """Test Canfar Images API."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -51,3 +51,18 @@ def test_images_details_returns_models() -> None:
     assert results[0].id == payload[0]["id"]
     assert results[0].types == payload[0]["types"]
     assert results[0].digest == payload[0]["digest"]
+
+
+def test_images_fetch_uses_http_client_params() -> None:
+    """Fetch returns image IDs and passes optional kind as request parameter."""
+    images = Images(token="token", url="https://example.test/skaha/v1")
+    mock_client = MagicMock()
+    mock_client.get.return_value.json.return_value = [
+        {"id": "images.canfar.net/skaha/terminal:latest"}
+    ]
+    images._client = mock_client  # noqa: SLF001
+
+    assert images.fetch() == ["images.canfar.net/skaha/terminal:latest"]
+    assert images.fetch(kind="headless") == ["images.canfar.net/skaha/terminal:latest"]
+    mock_client.get.assert_any_call("image", params={})
+    mock_client.get.assert_any_call("image", params={"type": "headless"})

--- a/tests/test_models_config.py
+++ b/tests/test_models_config.py
@@ -20,9 +20,11 @@ from canfar.models.registry import ContainerRegistry
 class TestConfigurationDefaults:
     """Test default state and initialization."""
 
-    def test_default_initialization(self) -> None:
+    def test_default_initialization(self, tmp_path: Path) -> None:
         """Test Configuration with correct defaults when no arguments provided."""
-        config = Configuration()
+        config_path = tmp_path / "config.yaml"
+        with patch("canfar.models.config.CONFIG_PATH", config_path):
+            config = Configuration()
 
         # Test default active context
         assert config.active == "default"

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -1,6 +1,10 @@
 """Test Canfar Overview API."""
 
+from unittest.mock import MagicMock, patch
+
+import httpx
 import pytest
+from pydantic import SecretStr
 
 from canfar.overview import Overview
 
@@ -18,3 +22,59 @@ def overview():
 def test_available(overview: Overview) -> None:
     """Test available."""
     assert overview.availability(), "Server should be available"
+
+
+def _sync_response(text: str) -> MagicMock:
+    response = MagicMock()
+    response.text = text
+    return response
+
+
+def test_overview_updates_base_url_and_parses_availability() -> None:
+    """Overview strips version from base URL and parses available true."""
+    sync_client = MagicMock()
+    sync_client.base_url = httpx.URL("https://example.test/skaha/v1/")
+    async_client = MagicMock()
+    async_client.base_url = httpx.URL("https://example.test/skaha/v1/")
+    sync_client.get.return_value = _sync_response(
+        '<vosi:availability xmlns:vosi="http://www.ivoa.net/xml/'
+        'VOSIAvailability/v1.0"><vosi:available>true</vosi:available>'
+        "<vosi:note>ok</vosi:note></vosi:availability>"
+    )
+
+    with (
+        patch("canfar.client.HTTPClient._create_sync_client", return_value=sync_client),
+        patch(
+            "canfar.client.HTTPClient._create_async_client", return_value=async_client
+        ),
+    ):
+        overview = Overview(
+            token=SecretStr("token"), url="https://example.test/skaha/v1"
+        )
+
+    assert str(overview.client.base_url) == "https://example.test/skaha"
+    assert str(overview.asynclient.base_url) == "https://example.test/skaha"
+    assert overview.availability() is True
+
+
+def test_overview_availability_false_paths() -> None:
+    """Overview availability returns false for empty or unavailable responses."""
+    overview = Overview.model_construct()
+    client = MagicMock()
+    overview._client = client  # noqa: SLF001
+
+    client.get.return_value = _sync_response("")
+    assert overview.availability() is False
+
+    client.get.return_value = _sync_response(
+        '<vosi:availability xmlns:vosi="http://www.ivoa.net/xml/'
+        'VOSIAvailability/v1.0"><vosi:note>missing</vosi:note></vosi:availability>'
+    )
+    assert overview.availability() is False
+
+    client.get.return_value = _sync_response(
+        '<vosi:availability xmlns:vosi="http://www.ivoa.net/xml/'
+        'VOSIAvailability/v1.0"><vosi:available>false</vosi:available>'
+        "</vosi:availability>"
+    )
+    assert overview.availability() is False

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -13,6 +13,8 @@ def overview():
     del overview
 
 
+@pytest.mark.integration
+@pytest.mark.slow
 def test_available(overview: Overview) -> None:
     """Test available."""
     assert overview.availability(), "Server should be available"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -28,6 +28,8 @@ def session():
     del session
 
 
+@pytest.mark.integration
+@pytest.mark.slow
 def test_fetch_with_kind(session: Session) -> None:
     """Test fetching images with kind."""
     session.fetch(kind="headless")

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2,11 +2,12 @@
 
 from time import sleep, time
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
+import httpx
 import pytest
-from pydantic import ValidationError
+from pydantic import SecretStr, ValidationError
 
 from canfar.models.session import CreateRequest
 from canfar.sessions import Session
@@ -33,6 +34,53 @@ def session():
 def test_fetch_with_kind(session: Session) -> None:
     """Test fetching images with kind."""
     session.fetch(kind="headless")
+
+
+def _sync_response(json_data: Any = None, text: str = "") -> MagicMock:
+    response = MagicMock()
+    response.json.return_value = json_data
+    response.text = text
+    return response
+
+
+def _http_error(method: str, url: str) -> httpx.HTTPStatusError:
+    request = httpx.Request(method, url)
+    response = httpx.Response(500, request=request)
+    return httpx.HTTPStatusError("boom", request=request, response=response)
+
+
+def test_sync_session_methods_handle_success_and_failures() -> None:
+    """Sync Session methods return parsed data and tolerate per-ID failures."""
+    session = Session(token=SecretStr("token"), url="https://example.test/skaha/v1")
+    client = MagicMock()
+    session._client = client  # noqa: SLF001
+
+    client.get.return_value = _sync_response([{"id": "s1"}])
+    assert session.fetch(kind="headless") == [{"id": "s1"}]
+    client.get.assert_called_with(url="session", params={"type": "headless"})
+
+    client.get.return_value = _sync_response({"cores": {}})
+    assert session.stats() == {"cores": {}}
+    client.get.assert_called_with("session", params={"view": "stats"})
+
+    client.get.side_effect = [
+        _sync_response({"id": "s1"}),
+        _http_error("GET", "https://example.test/skaha/v1/session/s2"),
+    ]
+    with patch("canfar.sessions._log_http_task_failure") as log_failure:
+        assert session.info(["s1", "s2"]) == [{"id": "s1"}]
+    log_failure.assert_called_once()
+
+    client.get.side_effect = None
+    client.get.return_value = _sync_response(text="hello")
+    assert session.logs("s1") == {"s1": "hello"}
+    assert session.logs("s1", verbose=True) is None
+
+    client.delete.side_effect = [
+        None,
+        _http_error("DELETE", "https://example.test/skaha/v1/session/s2"),
+    ]
+    assert session.destroy(["s1", "s2"]) == {"s1": True, "s2": False}
 
 
 def test_fetch_malformed_kind(session: Session) -> None:


### PR DESCRIPTION
## Summary
- Added repo-level agent instructions in `AGENTS.md` plus supporting docs under `docs/agents/` for issue tracking, triage labels, domain docs, and architecture notes.
- Bootstrapped a root `CONTEXT.md` glossary for CANFAR domain language and kept it implementation-free.
- Created the missing GitHub triage labels: `needs-info`, `ready-for-agent`, and `ready-for-human`.
- Tightened test isolation by making `test_default_initialization` ignore the developer’s local CANFAR config path, and marked live endpoint tests as `slow` and `integration`.

## Testing
- `ruff check` and `ruff format --check` passed.
- `mypy canfar --config-file pyproject.toml` passed.
- Deterministic non-slow pytest run passed: `517 passed`.
- `mkdocs build` passed.
- `git diff --check` passed.
- Full auth-dependent pytest was not run; it remains optional and requires valid CANFAR auth/cert state.