### PR TITLE
fix: parameter name from 'server' to 'url'

### DIFF
--- a/canfar/sessions.py
+++ b/canfar/sessions.py
@@ -419,7 +419,7 @@ class AsyncSession(HTTPClient):
     Examples:
         >>> from canfar.session import AsyncSession
         >>> session = AsyncSession(
-                server="https://something.example.com",
+                url="https://something.example.com",
                 version="v1",
                 token="token",
                 timeout=30,


### PR DESCRIPTION
Docs have a mistake with the name of the var `server`. Correct name is `url`, as defined here: https://github.com/opencadc/canfar/blob/6d76a263ab70252713314f4dc9816804dc46962e/canfar/client.py#L78