### PR TITLE
fix(client): skip expiry hook when runtime credentials active (#115)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 ## Repo Map
 
 - `canfar/models/` contains Pydantic models for persisted config, auth contexts, server metadata, registry data, and session request/response shapes.
-- `canfar/client.py` owns HTTP client composition, credential precedence, auth hooks, timeouts, and sync/async `httpx` clients.
+- `canfar/client.py` owns HTTP client composition, credential precedence, auth hooks, timeouts, and sync/async `httpx` clients. Runtime `token`/`certificate` precedence applies to httpx hook wiring too, not only headers and SSL.
 - `canfar/sessions.py`, `canfar/images.py`, `canfar/context.py`, and `canfar/overview.py` expose library modules for Science Platform operations.
 - `canfar/cli/` contains Typer CLI adapters. Keep command output, exit behavior, and library calls aligned.
 - `canfar/auth/`, `canfar/hooks/`, and `canfar/utils/` contain auth flows, HTTP/Typer hooks, discovery, display, logging, and request builders.
@@ -46,7 +46,7 @@ This repo uses root `CONTEXT.md` as the current domain glossary. Specs and decis
 - During design grilling, ask one question at a time and converge decisions incrementally.
 - During broad refactors, preserve existing tests and avoid API/CLI output regressions unless the user explicitly approves those changes.
 - Do not introduce a separate DTO/request model layer; use the domain Pydantic models under `canfar/models/` directly and serialize the same model for `--json` output.
-- Prefer Python stdlib utilities (for example `pathlib`, `email.utils`, `itertools`) over custom helper or safeguard code.
+- Prefer Python stdlib utilities and Pydantic built-ins (`model_dump`, `model_dump_json`) over custom serialization or config glue; keep the smallest footprint that preserves behavior.
 
 ## Learned Workspace Facts
 
@@ -55,10 +55,11 @@ This repo uses root `CONTEXT.md` as the current domain glossary. Specs and decis
 - Triage is status-based in Jira: `needs-triage` -> To Do, `needs-info` -> On Hold, `ready-for-agent` -> In Progress, `ready-for-human` -> Review, `wontfix` -> On Hold.
 - Domain documentation currently uses root `CONTEXT.md` as the glossary.
 - Specs and PRDs are Jira-first; durable agent decision records live under `docs/agents/adrs/`, separate from Jira spec tracking.
-- Client configuration stores `servers` and `authentication` as dicts keyed by Server Name and IDP; Server Selection and `active` references use server names, not IVOA URIs.
+- Client configuration stores `servers` and `authentication` as dicts keyed by Server Name and IDP; `Server.name` and credential `idp` may duplicate those keys in nested values; Server Selection and `active` references use server names, not IVOA URIs.
 - `Session.create` and `AsyncSession.create` should preserve parity and return `list[str]`, using `[]` on total HTTP/network failure without raising.
 - CLI layout is kubectl-style: `canfar auth` (bare runs `show`; canonical subcommand names only, `ls`/`rm`), `canfar server`, and `canfar login` (`canfar auth login` is a deprecated alias; `canfar context` was removed).
-- CLI machine output (`--json`/`--yaml`) must be data-only on stdout; the human-mode active-server banner must not precede JSON/YAML payloads.
+- CLI machine output (`--json`/`--yaml`) must be data-only on stdout; the human-mode active-server banner must not precede JSON/YAML payloads; serialize via Pydantic `model_dump(mode="json")` rather than custom redaction helpers.
 - Built-in default CADC/CANFAR server metadata lists `x509` only; `oidc` and other auth modes are merged from VOSI capabilities enrichment after discovery/login, not static defaults.
 - `canfar ps -q` must print all matching session IDs and apply the same `--all`/running-only status filter as table mode.
 - `canfar.helpers.distributed` is documented public API used in user batch scripts, not internal/dead code.
+- When `HTTPClient` has runtime `token` or `certificate`, skip saved Authentication Record expiry and OIDC refresh httpx hooks (`uses_runtime_credentials`); saved-config hooks apply only without runtime credentials.

--- a/canfar/client.py
+++ b/canfar/client.py
@@ -143,6 +143,11 @@ class HTTPClient(BaseSettings):
             log.debug("Asynchronous HTTPx client created")
         return self._asynclient
 
+    @property
+    def uses_runtime_credentials(self) -> bool:
+        """Return whether runtime token or certificate credentials are active."""
+        return bool(self.token or self.certificate)
+
     @field_validator("loglevel", mode="before")
     @classmethod
     def _validate_loglevel(cls, value: int | str) -> str:
@@ -248,12 +253,15 @@ class HTTPClient(BaseSettings):
         Returns:
             dict[str, Any]: Keyword arguments for creating an HTTPx client.
         """
-        checker = expiry.acheck(self) if asynchronous else expiry.check(self)
         catcher = errors.acatch if asynchronous else errors.catch
         response_hooks = [catcher] if self.raise_http_errors else []
+        request_hooks: list[Any] = []
+        if not self.uses_runtime_credentials:
+            checker = expiry.acheck(self) if asynchronous else expiry.check(self)
+            request_hooks.append(checker)
         kwargs: dict[str, Any] = {
             "timeout": Timeout(self.timeout),
-            "event_hooks": {"request": [checker], "response": response_hooks},
+            "event_hooks": {"request": request_hooks, "response": response_hooks},
             "base_url": self._get_base_url(),
         }
         # Configure connection pooling for async clients

--- a/canfar/hooks/httpx/expiry.py
+++ b/canfar/hooks/httpx/expiry.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable
 
+from canfar import get_logger
 from canfar.auth import x509
 from canfar.exceptions.context import AuthExpiredError
+
+log = get_logger(__name__)
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable
@@ -33,6 +36,13 @@ def check(client: HTTPClient) -> Callable[[httpx.Request], None]:
             AuthExpiredError: If the active Authentication credential is expired.
 
         """
+        if client.uses_runtime_credentials:
+            log.debug(
+                "Skipping saved Authentication Record expiry check; "
+                "runtime credentials are active."
+            )
+            return
+
         try:
             expired = client.config.context.expired
         except x509.CertificateError as err:
@@ -66,6 +76,13 @@ def acheck(client: HTTPClient) -> Callable[[httpx.Request], Awaitable[None]]:
         Raises:
             AuthExpiredError: If the active Authentication credential is expired.
         """
+        if client.uses_runtime_credentials:
+            log.debug(
+                "Skipping saved Authentication Record expiry check; "
+                "runtime credentials are active."
+            )
+            return
+
         try:
             expired = client.config.context.expired
         except x509.CertificateError as err:

--- a/docs/releases/2026-2.md
+++ b/docs/releases/2026-2.md
@@ -95,6 +95,7 @@
             - `canfar auth login` is deprecated and will be removed in a future release. Switch to `canfar login`.
             - Persisted client configuration now uses an explicit `version: 1` schema.
         - `canfar.authentication` and `canfar.server` Python modules provide noninteractive helpers for authentication and server discovery, validation, and selection in scripts.
+        - Runtime `token`/`certificate` skip saved-auth expiry hooks — no false `AuthExpiredError` with stale x509 config ([#115](https://github.com/opencadc/canfar/issues/115)).
 
     ### 📦 Deployment Notes
     - Improved and simplified deployment documentation

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -23,6 +23,7 @@ from canfar.models.config import Configuration
 from canfar.models.http import Server
 from canfar.models.registry import ContainerRegistry
 from tests.helpers.config import configuration_from_legacy_context
+from tests.test_auth_x509 import generate_cert
 
 
 # Test Fixtures
@@ -698,6 +699,60 @@ class TestContextManagerBehavior:
 
 class TestSSLContextAndClientKwargs:
     """Test SSL context creation and client kwargs generation."""
+
+    def test_expiry_hook_omitted_for_runtime_token(
+        self, canfar_client_fixture, tmp_path
+    ) -> None:
+        """Runtime token must not install saved-config expiry request hook."""
+        cert_path = tmp_path / "expired.pem"
+        generate_cert(cert_path, expired=True)
+        x509_context = X509(
+            server=Server(
+                name="TestX509",
+                uri=AnyUrl("ivo://test.org/skaha"),
+                url=AnyHttpUrl("https://x509.example.com"),
+                version="v1",
+            ),
+            path=cert_path,
+        )
+        config = configuration_from_legacy_context("x509", x509_context)
+        client = canfar_client_fixture(
+            config=config,
+            token=SecretStr("runtime-token"),
+            url="https://runtime.com",
+        )
+
+        sync_kwargs = client._get_client_kwargs(asynchronous=False)
+        async_kwargs = client._get_client_kwargs(asynchronous=True)
+
+        assert sync_kwargs["event_hooks"]["request"] == []
+        assert async_kwargs["event_hooks"]["request"] == []
+
+    def test_expiry_hook_present_for_saved_expired_x509(
+        self, canfar_client_fixture, tmp_path
+    ) -> None:
+        """Saved expired x509 config must still install expiry request hook."""
+        cert_path = tmp_path / "expired.pem"
+        generate_cert(cert_path, expired=True)
+        x509_context = X509(
+            server=Server(
+                name="TestX509",
+                uri=AnyUrl("ivo://test.org/skaha"),
+                url=AnyHttpUrl("https://x509.example.com"),
+                version="v1",
+            ),
+            path=cert_path,
+        )
+        config = configuration_from_legacy_context("x509", x509_context)
+        client = canfar_client_fixture(config=config)
+
+        sync_kwargs = client._get_client_kwargs(asynchronous=False)
+        async_kwargs = client._get_client_kwargs(asynchronous=True)
+
+        assert len(sync_kwargs["event_hooks"]["request"]) == 1
+        assert len(async_kwargs["event_hooks"]["request"]) == 1
+        assert sync_kwargs["event_hooks"]["request"][0].__name__ == "hook"
+        assert async_kwargs["event_hooks"]["request"][0].__name__ == "hook"
 
     def test_get_client_kwargs_with_certificate(
         self, canfar_client_fixture, tmp_path

--- a/tests/test_hooks_httpx_expiry.py
+++ b/tests/test_hooks_httpx_expiry.py
@@ -5,14 +5,16 @@ from unittest.mock import Mock
 
 import httpx
 import pytest
+from pydantic import SecretStr
 
 from canfar.auth import x509
 from canfar.client import HTTPClient
 from canfar.exceptions.context import AuthExpiredError
 from canfar.hooks.httpx.expiry import acheck, check
-from canfar.models.auth import OIDC
+from canfar.models.auth import OIDC, X509
 from canfar.models.http import Server
 from tests.helpers.config import configuration_from_legacy_context
+from tests.test_auth_x509 import generate_cert
 
 
 class TestCheck:
@@ -21,6 +23,7 @@ class TestCheck:
     def test_check_with_valid_context(self) -> None:
         """Test check hook with valid (non-expired) context."""
         mock_client = Mock()
+        mock_client.uses_runtime_credentials = False
         mock_client.config.context.expired = False
 
         hook_func = check(mock_client)
@@ -31,6 +34,7 @@ class TestCheck:
     def test_check_with_expired_context(self) -> None:
         """Test check hook with expired context (covers line 36)."""
         mock_client = Mock()
+        mock_client.uses_runtime_credentials = False
         mock_client.config.context.expired = True
         mock_client.config.context.mode = "OIDC"
 
@@ -81,11 +85,55 @@ class TestCheck:
                 msg = "detailed certificate issue"
                 raise x509.CertificateError(msg)
 
-        hook = check(SimpleNamespace(config=SimpleNamespace(context=Context())))
+        hook = check(
+            SimpleNamespace(
+                config=SimpleNamespace(context=Context()),
+                uses_runtime_credentials=False,
+            )
+        )
         request = httpx.Request("GET", "https://example.com")
 
         with pytest.raises(AuthExpiredError, match="detailed certificate issue"):
             hook(request)
+
+    def test_skip_if_runtime_credentials_used(self, tmp_path) -> None:
+        """Expiry hook must not check saved config when runtime token is active."""
+        cert_path = tmp_path / "expired.pem"
+        generate_cert(cert_path, expired=True)
+        x509_context = X509(
+            server=Server(
+                name="TestX509", url="https://x509.example.com", version="v0"
+            ),
+            path=cert_path,
+        )
+        config = configuration_from_legacy_context("TestX509", x509_context)
+        client = HTTPClient(
+            config=config,
+            token=SecretStr("runtime-token"),
+            url="https://runtime.com",
+        )
+        hook_func = check(client)
+        request = httpx.Request("GET", "/")
+
+        hook_func(request)
+
+    def test_raises_without_runtime_credentials(self, tmp_path) -> None:
+        """Expiry hook still checks saved config when no runtime credentials."""
+        cert_path = tmp_path / "expired.pem"
+        generate_cert(cert_path, expired=True)
+        x509_context = X509(
+            server=Server(
+                name="TestX509", url="https://x509.example.com", version="v0"
+            ),
+            path=cert_path,
+        )
+        config = configuration_from_legacy_context("TestX509", x509_context)
+        client = HTTPClient(config=config)
+        hook_func = check(client)
+        request = httpx.Request("GET", "/")
+
+        with pytest.raises(AuthExpiredError):
+            hook_func(request)
 
 
 class TestACheck:
@@ -95,6 +143,7 @@ class TestACheck:
     async def test_acheck_with_valid_context(self) -> None:
         """Test acheck hook with valid (non-expired) context."""
         mock_client = Mock()
+        mock_client.uses_runtime_credentials = False
         mock_client.config.context.expired = False
 
         hook_func = acheck(mock_client)
@@ -106,6 +155,7 @@ class TestACheck:
     async def test_acheck_with_expired_context(self) -> None:
         """Test acheck hook with expired context (covers line 62)."""
         mock_client = Mock()
+        mock_client.uses_runtime_credentials = False
         mock_client.config.context.expired = True
         mock_client.config.context.mode = "X509"
 
@@ -158,7 +208,12 @@ class TestACheck:
                 msg = "detailed certificate issue"
                 raise x509.CertificateError(msg)
 
-        hook = acheck(SimpleNamespace(config=SimpleNamespace(context=Context())))
+        hook = acheck(
+            SimpleNamespace(
+                config=SimpleNamespace(context=Context()),
+                uses_runtime_credentials=False,
+            )
+        )
         request = httpx.Request("GET", "https://example.com")
 
         with pytest.raises(AuthExpiredError, match="detailed certificate issue"):
@@ -175,8 +230,54 @@ class TestACheck:
             def expired(self) -> bool:
                 return True
 
-        hook = acheck(SimpleNamespace(config=SimpleNamespace(context=Context())))
+        hook = acheck(
+            SimpleNamespace(
+                config=SimpleNamespace(context=Context()),
+                uses_runtime_credentials=False,
+            )
+        )
         request = httpx.Request("GET", "https://example.com")
 
         with pytest.raises(AuthExpiredError, match="auth expired"):
             await hook(request)
+
+    @pytest.mark.anyio
+    async def test_skip_if_runtime_credentials_used(self, tmp_path) -> None:
+        """Async expiry hook must not check saved config with runtime token."""
+        cert_path = tmp_path / "expired.pem"
+        generate_cert(cert_path, expired=True)
+        x509_context = X509(
+            server=Server(
+                name="TestX509", url="https://x509.example.com", version="v0"
+            ),
+            path=cert_path,
+        )
+        config = configuration_from_legacy_context("TestX509", x509_context)
+        client = HTTPClient(
+            config=config,
+            token=SecretStr("runtime-token"),
+            url="https://runtime.com",
+        )
+        hook_func = acheck(client)
+        request = httpx.Request("GET", "/")
+
+        await hook_func(request)
+
+    @pytest.mark.anyio
+    async def test_raises_without_runtime_credentials(self, tmp_path) -> None:
+        """Async expiry hook still checks saved config without runtime credentials."""
+        cert_path = tmp_path / "expired.pem"
+        generate_cert(cert_path, expired=True)
+        x509_context = X509(
+            server=Server(
+                name="TestX509", url="https://x509.example.com", version="v0"
+            ),
+            path=cert_path,
+        )
+        config = configuration_from_legacy_context("TestX509", x509_context)
+        client = HTTPClient(config=config)
+        hook_func = acheck(client)
+        request = httpx.Request("GET", "/")
+
+        with pytest.raises(AuthExpiredError):
+            await hook_func(request)

--- a/uv.lock
+++ b/uv.lock
@@ -726,11 +726,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.29.1"
+version = "3.29.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1f/f9/f38573ed5844586db374d085911740a501ccfa373b455fc9413f09f85237/filelock-3.29.1.tar.gz", hash = "sha256:d97e6b1b9757569626c58caa07dc4beb1613f4a2938b1e8cc81afca398906c9e", size = 59335, upload-time = "2026-06-03T15:19:04.053Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/f5/3557bf28e0f1943e4849154c821533706e6dea010f96fb6aa0b6949037d1/filelock-3.29.3.tar.gz", hash = "sha256:7fc1b3f39cf172fd8203812043c57b8a65aef9969f38b6704f628b881f761a84", size = 61956, upload-time = "2026-06-10T17:37:11.832Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/a0/614c5fe402fd88951df45f4dda2fa3b4e17a99ecd92340771929169b3b95/filelock-3.29.1-py3-none-any.whl", hash = "sha256:85199dfd706869641b72b2e8955d5416a4b2b7dc4b0e8e6d97b4cc1299a6983b", size = 40750, upload-time = "2026-06-03T15:19:02.959Z" },
+    { url = "https://files.pythonhosted.org/packages/81/8f/b61d427c4f49a8bdadc93f4e7e74df8a6df6f77ee6e26bf0df53d3925363/filelock-3.29.3-py3-none-any.whl", hash = "sha256:e58333029cc9b925f39aad59b1d8f0a1ad836af4e60d7217f4a4dba87461261d", size = 42324, upload-time = "2026-06-10T17:37:10.37Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Runtime token/certificate clients no longer install or execute saved authentication record expiry checks, preventing false `AuthExpiredError` when legacy x509 config is expired or missing.