### PR TITLE
refactor(cli): remove disabled Instances column from stats

### DIFF
--- a/canfar/cli/stats.py
+++ b/canfar/cli/stats.py
@@ -47,31 +47,8 @@ def get_stats(
             header_style="bold blue",
         )
 
-        # Disable Instances column until the underlying query can be made to work
-        # efficiently.
-        # jenkinsd 2025.11.20
-        #
         table.add_column("CPU", justify="center")
         table.add_column("RAM", justify="center")
-
-        # Nested table for Instances
-        instances = data.get("instances", {})
-        instances_table = Table(box=box.MINIMAL, show_header=False)
-        instances_table.add_column("Kind", justify="left")
-        instances_table.add_column("Count", justify="left")
-        # Change DesktopApp to Desktop in the instances table
-        if "desktopApp" in instances:
-            instances["Desktops"] = instances.pop("desktopApp")
-
-        for key, value in instances.items():
-            if key == "total":
-                pass
-            else:
-                instances_table.add_row(key.capitalize(), str(value))
-        if "total" in instances:
-            instances_table.add_row(
-                "Total", str(instances["total"]), style="bold italic"
-            )
 
         # Nested table for Cores
         cores = data.get("cores", {})
@@ -88,11 +65,6 @@ def get_stats(
         ram_table.add_column("Value", justify="left")
         ram_table.add_row("Usage", f"{ram.get('requestedRAM', 'N/A')}")
         ram_table.add_row("Total", f"{ram.get('ramAvailable', 'N/A')}")
-
-        # Commenting out Instances column until the underlying query can be made to work
-        # efficiently.
-        # jenkinsd 2025.11.20
-        #
 
         # Add the first row with nested tables
         table.add_row(cores_table, ram_table)

--- a/tests/test_cli_stats_ps.py
+++ b/tests/test_cli_stats_ps.py
@@ -314,6 +314,35 @@ def test_stats_outputs_cluster_tables() -> None:
     session_cls.assert_called_once_with(loglevel="DEBUG")
 
 
+def test_stats_renders_only_cpu_and_ram_columns() -> None:
+    """Pin that ``canfar stats`` shows CPU/RAM but never the Instances column.
+
+    The Instances column is intentionally not rendered; this characterization
+    test guards that removing the disabled inline code leaves the human output
+    unchanged, i.e. no per-instance labels or counts leak into stdout.
+    """
+    with patch("canfar.cli.stats.AsyncSession") as session_cls:
+        session = _mock_async_session(session_cls)
+        session.stats.return_value = {
+            "instances": {"desktopApp": 2, "notebook": 3, "total": 5},
+            "cores": {"requestedCPUCores": 4, "cpuCoresAvailable": 64},
+            "ram": {"requestedRAM": "8Gi", "ramAvailable": "128Gi"},
+        }
+        result = runner.invoke(stats, ["--debug"])
+
+    assert result.exit_code == 0
+    # The CPU/RAM table and its values are rendered.
+    assert "CPU" in result.stdout
+    assert "RAM" in result.stdout
+    assert "64" in result.stdout
+    assert "128Gi" in result.stdout
+    # The Instances column/data is not rendered (dead UI code).
+    assert "Instances" not in result.stdout
+    assert "Notebook" not in result.stdout
+    assert "Desktop" not in result.stdout
+    assert "desktopApp" not in result.stdout
+
+
 @pytest.mark.slow
 def test_stats_command_integration() -> None:
     """Test stats command integration (may fail without proper auth/config)."""


### PR DESCRIPTION
## Summary
Removes the disabled, never-rendered "Instances" nested table and its two `jenkinsd 2025.11.20` comment annotations from `canfar/cli/stats.py`. The instances table was built but never added to the main `canfar stats` table, so the counts never reached stdout — pure dead UI code. The intent to re-enable the column once the underlying query is efficient is now tracked in a dedicated issue (#140) instead of as inline comments.

## What changed
- `canfar/cli/stats.py`: deleted the `instances` / `instances_table` block (build + `desktopApp` -> `Desktops` remap + total row) and both "Instances column" comment annotations.
- `tests/test_cli_stats_ps.py`: added `test_stats_renders_only_cpu_and_ram_columns`, a characterization test pinning that `canfar stats` renders only the CPU/RAM columns and that no per-instance labels/counts leak into stdout.

## Behavior
Zero behavior change. `canfar stats` human output is byte-for-byte identical (verified by capturing rendered output before and after). The command has no `--json`/`--yaml` path. Exit codes and library API unchanged.

## Acceptance criteria
- [x] Commented "Instances column" block removed from `canfar/cli/stats.py`
- [x] `canfar stats` human and `--json`/`--yaml` output unchanged (existing tests pass; no JSON/YAML path exists for stats)
- [x] The "re-enable Instances column" intent is tracked separately (#140), not as a code comment
- [x] `ruff`, `mypy canfar`, `pytest -m "not slow"` pass

## Validation
- `uv run --no-sync ruff check . --no-cache` -> All checks passed!
- `uv run --no-sync mypy canfar --config-file pyproject.toml` -> Success: no issues found in 72 source files
- `uv run --no-sync pytest tests -m "not slow"` -> 706 passed

Refs #131