### PR TITLE
refactor(cli): centralize CLI async-runner boilerplate

### DIFF
--- a/canfar/cli/_run.py
+++ b/canfar/cli/_run.py
@@ -1,0 +1,28 @@
+"""Shared async-runner helper for CLI commands.
+
+CLI command callbacks are synchronous but drive asynchronous Session work.
+Each one defines a coroutine and hands it to :func:`run`, keeping the
+``asyncio`` entry point in a single place.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Coroutine
+
+T = TypeVar("T")
+
+
+def run(coro: Coroutine[object, object, T]) -> T:
+    """Run a coroutine to completion from a synchronous CLI command.
+
+    Args:
+        coro: The coroutine to execute.
+
+    Returns:
+        The value returned by the coroutine.
+    """
+    return asyncio.run(coro)

--- a/canfar/cli/create.py
+++ b/canfar/cli/create.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import TYPE_CHECKING, Annotated, Any, get_args
 
 import click
 import typer
 
+from canfar.cli._run import run
 from canfar.cli.machine import maybe_emit_banner
 from canfar.cli.output import OutputMode
 from canfar.hooks.typer.aliases import AliasGroup
@@ -151,6 +151,7 @@ def creation(
             environment[key] = value
 
     async def _create() -> None:
+        """Create the requested session(s) on the science platform server."""
         log_level = "DEBUG" if debug else "INFO"
         async with AsyncSession(loglevel=log_level) as session:
             try:
@@ -215,4 +216,4 @@ def creation(
         console.print("[yellow]Dry run complete.[/yellow]")
         return
 
-    asyncio.run(_create())
+    run(_create())

--- a/canfar/cli/delete.py
+++ b/canfar/cli/delete.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import Annotated
 
 import typer
 from rich.prompt import Confirm
 
+from canfar.cli._run import run
 from canfar.cli.machine import maybe_emit_banner
 from canfar.cli.output import OutputMode
 from canfar.hooks.typer.aliases import AliasGroup
@@ -60,6 +60,7 @@ def delete_sessions(
         )
 
     async def _delete() -> None:
+        """Delete the requested sessions from the science platform server."""
         async with AsyncSession(loglevel="DEBUG" if debug else "INFO") as session:
             try:
                 deleted = await session.destroy(ids=session_ids)
@@ -71,4 +72,4 @@ def delete_sessions(
                 console.print(f"[bold red]Error during deletion: {err}[/bold red]")
 
     if proceed:
-        asyncio.run(_delete())
+        run(_delete())

--- a/canfar/cli/events.py
+++ b/canfar/cli/events.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import re
 from typing import Annotated
 
@@ -10,6 +9,7 @@ import typer
 from rich import box
 from rich.table import Table
 
+from canfar.cli._run import run
 from canfar.cli.machine import maybe_emit_banner
 from canfar.cli.output import OutputMode
 from canfar.sessions import AsyncSession
@@ -40,6 +40,7 @@ def get_events(
     maybe_emit_banner(OutputMode.HUMAN)
 
     async def _get_events() -> None:
+        """Fetch events for the requested sessions and render them."""
         log_level = "DEBUG" if debug else "INFO"
         async with AsyncSession(loglevel=log_level) as session:
             all_events = await session.events(ids=session_ids)
@@ -74,4 +75,4 @@ def get_events(
 
                 console.print(table)
 
-    asyncio.run(_get_events())
+    run(_get_events())

--- a/canfar/cli/info.py
+++ b/canfar/cli/info.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from datetime import datetime, timezone
 from typing import Annotated, Any
 
@@ -12,6 +11,7 @@ from pydantic import ValidationError
 from rich import box
 from rich.table import Table
 
+from canfar.cli._run import run
 from canfar.cli.machine import maybe_emit_banner
 from canfar.cli.output import OutputMode
 from canfar.models.session import FetchResponse
@@ -186,4 +186,4 @@ def get_info(
 ) -> None:
     """Get detailed information about one or more sessions."""
     maybe_emit_banner(OutputMode.HUMAN)
-    asyncio.run(_get_info(session_ids, debug))
+    run(_get_info(session_ids, debug))

--- a/canfar/cli/logs.py
+++ b/canfar/cli/logs.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import Annotated
 
 import typer
 
+from canfar.cli._run import run
 from canfar.cli.machine import maybe_emit_banner
 from canfar.cli.output import OutputMode
 from canfar.sessions import AsyncSession
@@ -37,6 +37,7 @@ def get_logs(
     maybe_emit_banner(OutputMode.HUMAN)
 
     async def _get_logs() -> None:
+        """Fetch logs for the requested sessions and render them."""
         log_level = "DEBUG" if debug else "INFO"
         async with AsyncSession(loglevel=log_level) as session:
             try:
@@ -57,4 +58,4 @@ def get_logs(
             )
             console.print(log_text)
 
-    asyncio.run(_get_logs())
+    run(_get_logs())

--- a/canfar/cli/open.py
+++ b/canfar/cli/open.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import asyncio
 import webbrowser
 from typing import Annotated
 
 import typer
 
+from canfar.cli._run import run
 from canfar.cli.machine import maybe_emit_banner
 from canfar.cli.output import OutputMode
 from canfar.sessions import AsyncSession
@@ -37,6 +37,7 @@ def open_sessions(
     maybe_emit_banner(OutputMode.HUMAN)
 
     async def _open_sessions() -> None:
+        """Look up the requested sessions and open their connect URLs."""
         log_level = "DEBUG" if debug else "INFO"
         async with AsyncSession(loglevel=log_level) as session:
             sessions_info = await session.info(ids=session_ids)
@@ -52,4 +53,4 @@ def open_sessions(
             else:
                 typer.echo(f"No connectURL found for session {session_info.get('id')}.")
 
-    asyncio.run(_open_sessions())
+    run(_open_sessions())

--- a/canfar/cli/prune.py
+++ b/canfar/cli/prune.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import TYPE_CHECKING, Annotated, get_args
 
 import click
 import typer
 import typer.core
 
+from canfar.cli._run import run
 from canfar.cli.machine import maybe_emit_banner
 from canfar.cli.output import OutputMode
 from canfar.models.types import Pruneable, Status
@@ -88,6 +88,7 @@ def prune_sessions(
     maybe_emit_banner(OutputMode.HUMAN)
 
     async def _prune() -> None:
+        """Delete matching sessions from the science platform server."""
         log_level = "DEBUG" if debug else "INFO"
         async with AsyncSession(loglevel=log_level) as session:
             response = await session.destroy_with(
@@ -97,4 +98,4 @@ def prune_sessions(
                 f"[bold green] Deleted {len(response)} sessions.[/bold green]"
             )
 
-    asyncio.run(_prune())
+    run(_prune())

--- a/canfar/cli/ps.py
+++ b/canfar/cli/ps.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from datetime import datetime, timezone
 from typing import Annotated, get_args
 
@@ -14,6 +13,7 @@ from rich import box
 from rich.table import Table
 
 from canfar.cli import output
+from canfar.cli._run import run
 from canfar.cli.machine import JsonOption, YamlOption, maybe_emit_banner, resolve_mode
 from canfar.hooks.typer.aliases import AliasGroup
 from canfar.models.session import FetchResponse
@@ -156,4 +156,4 @@ def show(
             for message in dict.fromkeys(anomalies):
                 console.print(f"[dim]- {message}[/dim]")
 
-    asyncio.run(_list_sessions())
+    run(_list_sessions())

--- a/canfar/cli/stats.py
+++ b/canfar/cli/stats.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import Annotated
 
 import typer
 from rich import box
 from rich.table import Table
 
+from canfar.cli._run import run
 from canfar.cli.machine import maybe_emit_banner
 from canfar.cli.output import OutputMode
 from canfar.sessions import AsyncSession
@@ -35,6 +35,7 @@ def get_stats(
     maybe_emit_banner(OutputMode.HUMAN)
 
     async def _get_stats() -> None:
+        """Fetch cluster-wide statistics and render them."""
         log_level = "DEBUG" if debug else "INFO"
         async with AsyncSession(loglevel=log_level) as session:
             data = await session.stats()
@@ -75,4 +76,4 @@ def get_stats(
             "[dim]Based on best-case scenario, and may not be achievable.[/dim]"
         )
 
-    asyncio.run(_get_stats())
+    run(_get_stats())

--- a/tests/test_cli_runner.py
+++ b/tests/test_cli_runner.py
@@ -1,0 +1,29 @@
+"""Tests for the shared CLI async-runner helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from canfar.cli._run import run
+
+
+def test_run_executes_coroutine_and_returns_result() -> None:
+    """The runner drives a coroutine to completion and returns its value."""
+
+    async def _coro() -> str:
+        """Return a sentinel value."""
+        return "done"
+
+    assert run(_coro()) == "done"
+
+
+def test_run_propagates_coroutine_exception() -> None:
+    """Exceptions raised inside the coroutine surface to the caller."""
+
+    async def _coro() -> None:
+        """Raise to exercise exception propagation."""
+        message = "boom"
+        raise RuntimeError(message)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        run(_coro())


### PR DESCRIPTION
## Summary

Part of the codebase de-bloat effort (PRD #129). Nine Session CLI commands each imported `asyncio` and called `asyncio.run(...)` on a locally defined coroutine to drive Science Platform Server work from a synchronous Typer callback. This centralizes that pattern behind a single helper so the `asyncio` entry point lives in one place.

## What changed

- Add `canfar/cli/_run.py` with a single typed `run(coro)` helper (a thin, return-preserving wrapper over `asyncio.run`).
- Replace `import asyncio` + `asyncio.run(...)` with `from canfar.cli._run import run` + `run(...)` in: `create`, `delete`, `events`, `info`, `logs`, `open`, `prune`, `ps`, `stats`.
- Add `tests/test_cli_runner.py` characterizing the helper (runs a coroutine to completion, returns its value, propagates exceptions).
- Add one-line docstrings to the nested coroutines in the touched commands so the docstring-coverage gate (interrogate) stays green for the modified files (documentation only, no behavior change).

`login_auth.py` is intentionally left untouched: its test patches `canfar.cli.login_auth.asyncio.run`, so that module keeps its direct `asyncio` usage.

## Behavior

Zero behavior change. Human output, `--json`/`--yaml` output, and exit codes are identical. The existing `CliRunner` tests mock `AsyncSession` (not `asyncio.run`), so they exercise the real `run()` path end to end.

## Acceptance criteria

- [x] One shared async-runner helper exists and is used by the affected CLI commands
- [x] Each command's human and machine output and exit codes are unchanged
- [x] Net reduction in duplicated `asyncio.run` boilerplate (9 call sites + 9 `import asyncio` collapse to one helper)
- [x] `ruff`, `mypy canfar`, `pytest -m "not slow"` pass

Refs #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)