### PR TITLE
refactor(models): break config↔selection import cycle

### DIFF
--- a/canfar/models/config.py
+++ b/canfar/models/config.py
@@ -27,6 +27,24 @@ from pydantic_settings import (
 from pydantic_settings.sources import EnvSettingsSource
 
 from canfar import CONFIG_PATH, get_logger
+from canfar.config.editor import get_value as _get_value
+from canfar.config.editor import set_value as _set_value
+from canfar.config.selection import active_context as _active_context
+from canfar.config.selection import get_active_server as _get_active_server
+from canfar.config.selection import get_credential as _get_credential
+from canfar.config.selection import (
+    get_remembered_server_for_idp as _get_remembered_server_for_idp,
+)
+from canfar.config.selection import get_server_by_uri as _get_server_by_uri
+from canfar.config.selection import get_server_for_idp as _get_server_for_idp
+from canfar.config.selection import legacy_contexts as _legacy_contexts
+from canfar.config.selection import (
+    server_selection_history as _server_selection_history,
+)
+from canfar.config.selection import set_active_selection as _set_active_selection
+from canfar.config.selection import set_legacy_context as _set_legacy_context
+from canfar.config.selection import upsert_server as _upsert_server
+from canfar.config.selection import with_active_selection as _with_active_selection
 from canfar.models.active import ActiveConfig
 from canfar.models.auth import AuthenticationCredential, X509Credential
 from canfar.models.config_compat import AuthContext, LegacyContextsMapping
@@ -257,15 +275,11 @@ class Configuration(BaseSettings):
 
     def get_value(self, path: str) -> Any:
         """Get a nested configuration value via dotted path (e.g. 'console.width')."""
-        from canfar.config.editor import get_value  # noqa: PLC0415
-
-        return get_value(self, path)
+        return _get_value(self, path)
 
     def set_value(self, path: str, value: Any) -> Configuration:
         """Return a new validated Configuration with a dotted-path value updated."""
-        from canfar.config.editor import set_value  # noqa: PLC0415
-
-        return set_value(self, path, value)
+        return _set_value(self, path, value)
 
     def get_credential(self, idp: str) -> AuthenticationCredential:
         """Return the saved authentication credential for an IDP key.
@@ -279,9 +293,7 @@ class Configuration(BaseSettings):
         Raises:
             KeyError: If no credential exists for ``idp``.
         """
-        from canfar.config.selection import get_credential  # noqa: PLC0415
-
-        return get_credential(self, idp)
+        return _get_credential(self, idp)
 
     def get_server_by_uri(self, uri: str | AnyUrl) -> Server:
         """Return a known server by IVOA URI.
@@ -295,9 +307,7 @@ class Configuration(BaseSettings):
         Raises:
             KeyError: If no server exists for ``uri``.
         """
-        from canfar.config.selection import get_server_by_uri  # noqa: PLC0415
-
-        return get_server_by_uri(self, uri)
+        return _get_server_by_uri(self, uri)
 
     def get_active_server(self) -> Server:
         """Return the active science platform server record.
@@ -305,9 +315,7 @@ class Configuration(BaseSettings):
         Raises:
             KeyError: If no active server is selected.
         """
-        from canfar.config.selection import get_active_server  # noqa: PLC0415
-
-        return get_active_server(self)
+        return _get_active_server(self)
 
     def get_server_for_idp(self, idp: str) -> Server:
         """Return the best-known server for an IDP.
@@ -324,9 +332,7 @@ class Configuration(BaseSettings):
         Raises:
             KeyError: If no server exists for ``idp``.
         """
-        from canfar.config.selection import get_server_for_idp  # noqa: PLC0415
-
-        return get_server_for_idp(self, idp)
+        return _get_server_for_idp(self, idp)
 
     def get_remembered_server_for_idp(self, idp: str) -> Server | None:
         """Return the last selected server for ``idp`` when still valid.
@@ -338,17 +344,11 @@ class Configuration(BaseSettings):
             Matching server record, or ``None`` when no remembered selection is
             available for ``idp``.
         """
-        from canfar.config.selection import (  # noqa: PLC0415
-            get_remembered_server_for_idp,
-        )
-
-        return get_remembered_server_for_idp(self, idp)
+        return _get_remembered_server_for_idp(self, idp)
 
     def _server_selection_history(self) -> dict[str, str]:
         """Return remembered selections seeded with the current active pair."""
-        from canfar.config.selection import server_selection_history  # noqa: PLC0415
-
-        return server_selection_history(self)
+        return _server_selection_history(self)
 
     def set_active_selection(self, idp: str, server: Server) -> None:
         """Persist ``idp`` and ``server`` as the active pair.
@@ -360,9 +360,7 @@ class Configuration(BaseSettings):
         Raises:
             ValueError: If the server has no Server Name.
         """
-        from canfar.config.selection import set_active_selection  # noqa: PLC0415
-
-        set_active_selection(self, idp, server)
+        _set_active_selection(self, idp, server)
 
     def with_active_selection(self, idp: str, server: Server) -> Configuration:
         """Return a copy using ``idp`` and ``server`` as the active pair.
@@ -378,9 +376,7 @@ class Configuration(BaseSettings):
         Raises:
             ValueError: If the server has no Server Name.
         """
-        from canfar.config.selection import with_active_selection  # noqa: PLC0415
-
-        return with_active_selection(self, idp, server)
+        return _with_active_selection(self, idp, server)
 
     @property
     def context(self) -> AuthContext:
@@ -389,16 +385,12 @@ class Configuration(BaseSettings):
         Returns:
             Legacy ``OIDC`` or ``X509`` model with embedded active server.
         """
-        from canfar.config.selection import active_context  # noqa: PLC0415
-
-        return active_context(self)
+        return _active_context(self)
 
     @property
     def contexts(self) -> LegacyContextsMapping:
         """Return a legacy dict-like view keyed by IDP."""
-        from canfar.config.selection import legacy_contexts  # noqa: PLC0415
-
-        return legacy_contexts(self)
+        return _legacy_contexts(self)
 
     def set_legacy_context(self, idp: str, context: AuthContext) -> None:
         """Update saved authentication (and optional server) from legacy context.
@@ -407,15 +399,11 @@ class Configuration(BaseSettings):
             idp: Canonical identity provider key.
             context: Legacy ``AuthContext`` view to persist.
         """
-        from canfar.config.selection import set_legacy_context  # noqa: PLC0415
-
-        set_legacy_context(self, idp, context)
+        _set_legacy_context(self, idp, context)
 
     def _upsert_server(self, server: Server) -> None:
         """Insert or replace a server record keyed by Server Name."""
-        from canfar.config.selection import upsert_server  # noqa: PLC0415
-
-        upsert_server(self, server)
+        _upsert_server(self, server)
 
 
 __all__ = ["CONFIG_PATH", "AuthContext", "Configuration", "ConsoleConfig"]

--- a/tests/test_import_isolation.py
+++ b/tests/test_import_isolation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import os
 import subprocess
 import sys
@@ -59,3 +60,74 @@ import canfar  # noqa: F401
 
     assert result.returncode != 0
     assert "ValidationError" in result.stderr
+
+
+def _function_local_imports(source: str) -> list[tuple[str, str]]:
+    """Return (function_name, module) pairs for every function-local import."""
+    tree = ast.parse(source)
+    results: list[tuple[str, str]] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for child in ast.walk(node):
+            if child is node:
+                continue
+            if isinstance(child, ast.Import):
+                results.extend((node.name, alias.name) for alias in child.names)
+            elif isinstance(child, ast.ImportFrom):
+                module = child.module or ""
+                results.append((node.name, module))
+    return results
+
+
+def test_no_function_local_selection_imports_in_models_config() -> None:
+    """No function-local imports from ``config.selection`` in ``models/config.py``.
+
+    The import cycle between ``canfar.models.config`` and
+    ``canfar.config.selection`` must be broken: all ``selection`` imports
+    belong at module level in ``models/config.py``.
+    """
+    config_source = Path("canfar/models/config.py").read_text(encoding="utf-8")
+    local_imports = _function_local_imports(config_source)
+
+    offenders = [
+        (fn, mod) for fn, mod in local_imports if "canfar.config.selection" in mod
+    ]
+    assert offenders == [], (
+        f"Function-local selection imports found in models/config.py: {offenders}"
+    )
+
+
+def test_no_function_local_editor_imports_in_models_config() -> None:
+    """No function-local imports from ``config.editor`` in ``models/config.py``."""
+    config_source = Path("canfar/models/config.py").read_text(encoding="utf-8")
+    local_imports = _function_local_imports(config_source)
+
+    offenders = [
+        (fn, mod) for fn, mod in local_imports if "canfar.config.editor" in mod
+    ]
+    assert offenders == [], (
+        f"Function-local editor imports found in models/config.py: {offenders}"
+    )
+
+
+def test_selection_importable_before_config() -> None:
+    """``canfar.config.selection`` can be imported before ``canfar.models.config``."""
+    script = """
+import sys
+# Clear any cached canfar modules
+for k in list(sys.modules.keys()):
+    if "canfar" in k:
+        del sys.modules[k]
+
+import canfar.config.selection  # noqa: F401
+import canfar.models.config  # noqa: F401
+"""
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

- Moves all function-local `canfar.config.selection` and `canfar.config.editor` imports in `canfar/models/config.py` to module-level imports
- Removes twelve `# noqa: PLC0415` markers that existed to suppress the \"import not at top of file\" lint rule
- Adds three characterization tests in `tests/test_import_isolation.py` to pin the absence of function-local selection/editor imports and verify both modules are importable in any order

## What changed

`canfar/config/selection.py` and `canfar/config/editor.py` both guard their `Configuration` type annotation import under `TYPE_CHECKING` — they do not import `canfar.models.config` at runtime. The function-local imports in `config.py` were therefore unnecessary: lifting them to module level is safe and makes the dependency direction explicit to type-checkers and IDEs.

The remaining `save()` method still uses a function-local import for `canfar.config.store` (a separate, narrower cycle) and `_CheckedYamlConfigSettingsSource.__init__` still defers `canfar.config.migration` — both are out of scope for this issue.

## Acceptance criteria

- [x] No function-local imports between `models/config.py` and `config/selection.py`; the `# noqa: PLC0415` markers for them are gone
- [x] No import cycle remains between the two modules (importable in any order)
- [x] `Configuration` public behavior (server selection, active context, credentials, history) unchanged
- [x] `ruff`, `mypy canfar`, `pytest -m "not slow"` pass

Refs #135