### PR TITLE
refactor(hooks): extract shared core from sync/async httpx hook pairs

### DIFF
--- a/canfar/hooks/httpx/auth.py
+++ b/canfar/hooks/httpx/auth.py
@@ -40,7 +40,7 @@ from canfar.models.auth import OIDC
 from canfar.utils import jwt
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
+    from collections.abc import Awaitable, MutableMapping
 
     import httpx
 
@@ -51,6 +51,48 @@ log = get_logger(__name__)
 
 class AuthenticationError(Exception):
     """Exception raised when authentication refresh fails."""
+
+
+def _apply_refreshed_token(
+    client: HTTPClient,
+    ctx: OIDC,
+    token: SecretStr,
+    httpx_client_headers: MutableMapping[str, str],
+    request: httpx.Request,
+) -> None:
+    """Persist a refreshed access token to config, headers, and the outgoing request.
+
+    Shared by both ``refresh`` (sync) and ``arefresh`` (async); only the
+    source of ``token`` (sync vs. async network call) and the target of
+    ``httpx_client_headers`` (``client.client.headers`` for sync vs.
+    ``client.asynclient.headers`` for async) differ between the two callers.
+
+    Args:
+        client: The CANFAR HTTPClient whose config is updated.
+        ctx: The current OIDC Authentication Record.
+        token: The new access token returned by the OIDC provider.
+        httpx_client_headers: The header mapping of the underlying httpx client.
+        request: The outgoing httpx request whose Authorization header is updated.
+    """
+    access_value = token.get_secret_value()
+    new_context = ctx.model_copy(
+        update={
+            "token": ctx.token.model_copy(update={"access": SecretStr(access_value)}),
+            "expiry": ctx.expiry.model_copy(
+                update={"access": jwt.expiry(access_value)}
+            ),
+        }
+    )
+
+    client.config.contexts[client.config.active.authentication] = new_context
+    client.config.save()
+    log.debug("Authentication refreshed and configuration saved.")
+
+    header = f"Bearer {access_value}"
+    httpx_client_headers["Authorization"] = header
+    request.headers["Authorization"] = header
+    log.debug("HTTP request headers updated with new token.")
+    log.info("OIDC Access Token Refreshed.")
 
 
 def refresh(client: HTTPClient) -> Callable[[httpx.Request], None]:
@@ -106,31 +148,7 @@ def refresh(client: HTTPClient) -> Callable[[httpx.Request], None]:
                 token=refresh.get_secret_value(),
             )
             log.debug("Synchronous OIDC token refresh successful.")
-
-            # Create a new context with the updated token
-            access_value = token.get_secret_value()
-            context = ctx.model_copy(
-                update={
-                    "token": ctx.token.model_copy(
-                        update={"access": SecretStr(access_value)}
-                    ),
-                    "expiry": ctx.expiry.model_copy(
-                        update={"access": jwt.expiry(access_value)}
-                    ),
-                }
-            )
-
-            # Update the configuration and save it
-            client.config.contexts[client.config.active.authentication] = context
-            client.config.save()
-            log.debug("Authentication refreshed and configuration saved.")
-
-            # Update headers
-            header = f"Bearer {token.get_secret_value()}"
-            client.client.headers["Authorization"] = header
-            request.headers["Authorization"] = header
-            log.debug("HTTP request headers updated with new token.")
-            log.info("OIDC Access Token Refreshed.")
+            _apply_refreshed_token(client, ctx, token, client.client.headers, request)
 
         except Exception as err:
             msg = f"Failed to refresh OIDC token: {err}"
@@ -142,6 +160,10 @@ def refresh(client: HTTPClient) -> Callable[[httpx.Request], None]:
 
 def arefresh(client: HTTPClient) -> Callable[[httpx.Request], Awaitable[None]]:
     """Create an asynchronous authentication refresh hook for httpx clients.
+
+    Note: the ``ctx.valid`` guard present in the synchronous ``refresh`` hook
+    is intentionally absent here to preserve the existing async behavior.
+    Aligning them would be a behavior change outside this task's scope.
 
     Args:
         client (HTTPClient): The HTTPClient instance.
@@ -187,31 +209,9 @@ def arefresh(client: HTTPClient) -> Callable[[httpx.Request], Awaitable[None]]:
                 token=refresh.get_secret_value(),
             )
             log.debug("Asynchronous OIDC token refresh successful.")
-
-            # Create a new context with the updated token
-            access_value = token.get_secret_value()
-            context = ctx.model_copy(
-                update={
-                    "token": ctx.token.model_copy(
-                        update={"access": SecretStr(access_value)}
-                    ),
-                    "expiry": ctx.expiry.model_copy(
-                        update={"access": jwt.expiry(access_value)}
-                    ),
-                }
+            _apply_refreshed_token(
+                client, ctx, token, client.asynclient.headers, request
             )
-
-            # Update the configuration and save it
-            client.config.contexts[client.config.active.authentication] = context
-            client.config.save()
-            log.debug("Authentication refreshed and configuration saved.")
-
-            # Update headers
-            header = f"Bearer {token.get_secret_value()}"
-            client.asynclient.headers["Authorization"] = header
-            request.headers["Authorization"] = header
-            log.debug("HTTP request headers updated with new token.")
-            log.info("OIDC Access Token Refreshed.")
 
         except Exception as err:
             msg = f"Failed to refresh OIDC token: {err}"

--- a/canfar/hooks/httpx/errors.py
+++ b/canfar/hooks/httpx/errors.py
@@ -69,6 +69,12 @@ def _handle_error(response: httpx.Response) -> None:
     read the body (``response.read()`` vs ``await response.aread()``); every
     except branch here is identical for sync and async paths.
 
+    Note: errors that arise during body download (``response.read()`` /
+    ``await response.aread()``) propagate without being warning-logged here,
+    because the read call happens outside this function.  This is a known
+    minor behavior difference vs the pre-refactor code where both the read
+    and ``raise_for_status()`` shared a single try block.
+
     Raises:
         httpx.ConnectTimeout: on connect timeout.
         httpx.ReadTimeout: on read timeout.

--- a/canfar/hooks/httpx/errors.py
+++ b/canfar/hooks/httpx/errors.py
@@ -61,25 +61,23 @@ def _response_text(response: httpx.Response) -> str:
     return _BEARER_TOKEN.sub(r"\g<prefix><redacted>", text)
 
 
-def catch(response: httpx.Response) -> None:
-    """Reads the response body and raises HTTPStatusError for error responses.
+def _handle_error(response: httpx.Response) -> None:
+    """Log and re-raise any error from response.raise_for_status().
 
-    Handles various httpx exceptions with informative error messages:
-    - Timeout exceptions (ConnectTimeout, ReadTimeout, WriteTimeout, PoolTimeout)
-      are caught and logged with specific timeout information
-    - HTTP status errors (4xx, 5xx) are logged with response details
-    - Other request errors are caught and logged generally
-
-    Args:
-        response: An httpx.Response object.
+    Shared error-handling core called by both ``catch`` and ``acatch`` after
+    the body has already been read.  The two callers differ only in how they
+    read the body (``response.read()`` vs ``await response.aread()``); every
+    except branch here is identical for sync and async paths.
 
     Raises:
-        httpx.TimeoutException: When a timeout occurs during the request
-        httpx.HTTPStatusError: When the response has an error status code
-        httpx.RequestError: For other request-related errors
+        httpx.ConnectTimeout: on connect timeout.
+        httpx.ReadTimeout: on read timeout.
+        httpx.WriteTimeout: on write timeout.
+        httpx.PoolTimeout: on pool timeout.
+        httpx.HTTPStatusError: on 4xx/5xx status.
+        httpx.RequestError: for other request errors.
     """
     try:
-        response.read()
         response.raise_for_status()
     except httpx.ConnectTimeout as err:
         log.warning(
@@ -137,6 +135,27 @@ def catch(response: httpx.Response) -> None:
         )
         log.debug("Request error details", exc_info=True)
         raise
+
+
+def catch(response: httpx.Response) -> None:
+    """Reads the response body and raises HTTPStatusError for error responses.
+
+    Handles various httpx exceptions with informative error messages:
+    - Timeout exceptions (ConnectTimeout, ReadTimeout, WriteTimeout, PoolTimeout)
+      are caught and logged with specific timeout information
+    - HTTP status errors (4xx, 5xx) are logged with response details
+    - Other request errors are caught and logged generally
+
+    Args:
+        response: An httpx.Response object.
+
+    Raises:
+        httpx.TimeoutException: When a timeout occurs during the request
+        httpx.HTTPStatusError: When the response has an error status code
+        httpx.RequestError: For other request-related errors
+    """
+    response.read()
+    _handle_error(response)
 
 
 async def acatch(response: httpx.Response) -> None:
@@ -156,62 +175,5 @@ async def acatch(response: httpx.Response) -> None:
         httpx.HTTPStatusError: When the response has an error status code
         httpx.RequestError: For other request-related errors
     """
-    try:
-        await response.aread()
-        response.raise_for_status()
-    except httpx.ConnectTimeout as err:
-        log.warning(
-            "%s URL: %s",
-            CONN_ERR_MSG,
-            _request_url(err),
-            exc_info=False,
-        )
-        log.debug("Connect timeout details", exc_info=True)
-        raise
-    except httpx.ReadTimeout as err:
-        log.warning(
-            "%s URL: %s",
-            READ_ERR_MSG,
-            _request_url(err),
-            exc_info=False,
-        )
-        log.debug("Read timeout details", exc_info=True)
-        raise
-    except httpx.WriteTimeout as err:
-        log.warning(
-            "%s URL: %s",
-            WRITE_ERR_MSG,
-            _request_url(err),
-            exc_info=False,
-        )
-        log.debug("Write timeout details", exc_info=True)
-        raise
-    except httpx.PoolTimeout as err:
-        log.warning(
-            "%s URL: %s",
-            POOL_ERR_MSG,
-            _request_url(err),
-            exc_info=False,
-        )
-        log.debug("Pool timeout details", exc_info=True)
-        raise
-    except httpx.HTTPStatusError as err:
-        log.warning(
-            "HTTP %d error for %s %s: %s",
-            err.response.status_code,
-            err.request.method,
-            err.request.url,
-            _response_text(err.response),
-            exc_info=False,
-        )
-        log.debug("HTTP status error details", exc_info=True)
-        raise
-    except httpx.RequestError as err:
-        log.warning(
-            "Request error for %s: %s",
-            _request_url(err),
-            err,
-            exc_info=False,
-        )
-        log.debug("Request error details", exc_info=True)
-        raise
+    await response.aread()
+    _handle_error(response)

--- a/canfar/hooks/httpx/errors.py
+++ b/canfar/hooks/httpx/errors.py
@@ -1,23 +1,13 @@
 """Module for providing httpx event hooks to log error responses.
 
-When using httpx event hooks, especially for 'response' events, it's crucial
-to explicitly read the response body using `response.read()` (for synchronous
-clients) or `await response.aread()` (for asynchronous clients) *before*
-attempting to access `response.text` or calling `response.raise_for_status()`.
-
-This is because:
-1. `response.text`, `response.content`, `response.json()`, etc., are typically
-   populated only after the response body has been read.
-2. Event hooks are often called before httpx automatically reads the response
-   body for these attributes or methods.
-3. Therefore, to ensure that `response.text` (or other content attributes)
-   is available for logging in the event hook, especially when an error
-   occurs and `response.raise_for_status()` is called, the body must be
-   read first within the hook itself. Failing to do so might result in
-   empty or incomplete information being logged.
+When using httpx event hooks for 'response' events, the response body is read
+inside the error-handling context so that body-download errors (e.g.
+ReadTimeout during streaming) are warning-logged alongside status errors.
 """
 
+import contextlib
 import re
+from collections.abc import Generator
 
 import httpx
 
@@ -61,19 +51,16 @@ def _response_text(response: httpx.Response) -> str:
     return _BEARER_TOKEN.sub(r"\g<prefix><redacted>", text)
 
 
-def _handle_error(response: httpx.Response) -> None:
-    """Log and re-raise any error from response.raise_for_status().
+@contextlib.contextmanager
+def _error_handling() -> Generator[None, None, None]:
+    """Context manager that logs and re-raises httpx errors.
 
-    Shared error-handling core called by both ``catch`` and ``acatch`` after
-    the body has already been read.  The two callers differ only in how they
-    read the body (``response.read()`` vs ``await response.aread()``); every
-    except branch here is identical for sync and async paths.
+    Wraps both the body-read and ``raise_for_status()`` calls so that errors
+    from either step are warning-logged.  Use as::
 
-    Note: errors that arise during body download (``response.read()`` /
-    ``await response.aread()``) propagate without being warning-logged here,
-    because the read call happens outside this function.  This is a known
-    minor behavior difference vs the pre-refactor code where both the read
-    and ``raise_for_status()`` shared a single try block.
+        with _error_handling():
+            response.read()  # or await response.aread()
+            response.raise_for_status()
 
     Raises:
         httpx.ConnectTimeout: on connect timeout.
@@ -84,7 +71,7 @@ def _handle_error(response: httpx.Response) -> None:
         httpx.RequestError: for other request errors.
     """
     try:
-        response.raise_for_status()
+        yield
     except httpx.ConnectTimeout as err:
         log.warning(
             "%s URL: %s",
@@ -144,42 +131,38 @@ def _handle_error(response: httpx.Response) -> None:
 
 
 def catch(response: httpx.Response) -> None:
-    """Reads the response body and raises HTTPStatusError for error responses.
-
-    Handles various httpx exceptions with informative error messages:
-    - Timeout exceptions (ConnectTimeout, ReadTimeout, WriteTimeout, PoolTimeout)
-      are caught and logged with specific timeout information
-    - HTTP status errors (4xx, 5xx) are logged with response details
-    - Other request errors are caught and logged generally
+    """Read the response body and raise HTTPStatusError for error responses.
 
     Args:
         response: An httpx.Response object.
 
     Raises:
-        httpx.TimeoutException: When a timeout occurs during the request
-        httpx.HTTPStatusError: When the response has an error status code
-        httpx.RequestError: For other request-related errors
+        httpx.ConnectTimeout: on connect timeout.
+        httpx.ReadTimeout: on read timeout (body download or raise_for_status).
+        httpx.WriteTimeout: on write timeout.
+        httpx.PoolTimeout: on pool timeout.
+        httpx.HTTPStatusError: on 4xx/5xx status.
+        httpx.RequestError: for other request errors.
     """
-    response.read()
-    _handle_error(response)
+    with _error_handling():
+        response.read()
+        response.raise_for_status()
 
 
 async def acatch(response: httpx.Response) -> None:
-    """Reads the response body and raises HTTPStatusError for error responses (async).
-
-    Handles various httpx exceptions with informative error messages:
-    - Timeout exceptions (ConnectTimeout, ReadTimeout, WriteTimeout, PoolTimeout)
-      are caught and logged with specific timeout information
-    - HTTP status errors (4xx, 5xx) are logged with response details
-    - Other request errors are caught and logged generally
+    """Read the response body and raise HTTPStatusError for error responses (async).
 
     Args:
         response: An httpx.Response object.
 
     Raises:
-        httpx.TimeoutException: When a timeout occurs during the request
-        httpx.HTTPStatusError: When the response has an error status code
-        httpx.RequestError: For other request-related errors
+        httpx.ConnectTimeout: on connect timeout.
+        httpx.ReadTimeout: on read timeout (body download or raise_for_status).
+        httpx.WriteTimeout: on write timeout.
+        httpx.PoolTimeout: on pool timeout.
+        httpx.HTTPStatusError: on 4xx/5xx status.
+        httpx.RequestError: for other request errors.
     """
-    await response.aread()
-    _handle_error(response)
+    with _error_handling():
+        await response.aread()
+        response.raise_for_status()

--- a/canfar/hooks/httpx/expiry.py
+++ b/canfar/hooks/httpx/expiry.py
@@ -18,6 +18,33 @@ if TYPE_CHECKING:
     from canfar.client import HTTPClient
 
 
+def _check_expiry(client: HTTPClient) -> None:
+    """Shared expiry-check core for both sync and async hooks.
+
+    Raises:
+        AuthExpiredError: if the saved Authentication Record is expired or its
+            X.509 certificate cannot be loaded.
+    """
+    if client.uses_runtime_credentials:
+        log.debug(
+            "Skipping saved Authentication Record expiry check; "
+            "runtime credentials are active."
+        )
+        return
+
+    try:
+        expired = client.config.context.expired
+    except x509.CertificateError as err:
+        raise AuthExpiredError(
+            context=client.config.context.mode, reason=str(err)
+        ) from err
+
+    if expired:
+        raise AuthExpiredError(
+            context=client.config.context.mode, reason="auth expired"
+        )
+
+
 def check(client: HTTPClient) -> Callable[[httpx.Request], None]:
     """Create a hook to check for authentication expiry.
 
@@ -36,24 +63,7 @@ def check(client: HTTPClient) -> Callable[[httpx.Request], None]:
             AuthExpiredError: If the active Authentication credential is expired.
 
         """
-        if client.uses_runtime_credentials:
-            log.debug(
-                "Skipping saved Authentication Record expiry check; "
-                "runtime credentials are active."
-            )
-            return
-
-        try:
-            expired = client.config.context.expired
-        except x509.CertificateError as err:
-            raise AuthExpiredError(
-                context=client.config.context.mode, reason=str(err)
-            ) from err
-
-        if expired:
-            raise AuthExpiredError(
-                context=client.config.context.mode, reason="auth expired"
-            )
+        _check_expiry(client)
 
     return hook
 
@@ -76,23 +86,8 @@ def acheck(client: HTTPClient) -> Callable[[httpx.Request], Awaitable[None]]:
         Raises:
             AuthExpiredError: If the active Authentication credential is expired.
         """
-        if client.uses_runtime_credentials:
-            log.debug(
-                "Skipping saved Authentication Record expiry check; "
-                "runtime credentials are active."
-            )
-            return
-
-        try:
-            expired = client.config.context.expired
-        except x509.CertificateError as err:
-            raise AuthExpiredError(
-                context=client.config.context.mode, reason=str(err)
-            ) from err
-
-        if expired:
-            raise AuthExpiredError(
-                context=client.config.context.mode, reason="auth expired"
-            )
+        # No await needed: _check_expiry is synchronous; async is only required
+        # by the httpx async event-hook signature.
+        _check_expiry(client)
 
     return hook

--- a/tests/test_hooks_httpx_auth.py
+++ b/tests/test_hooks_httpx_auth.py
@@ -191,3 +191,47 @@ class TestAsyncHook:
 
         with pytest.raises(AuthenticationError, match="Failed to refresh OIDC token"):
             await hook_func(request)
+
+
+class TestSyncAsyncParity:
+    """Characterization tests: sync and async auth hooks share guard behavior."""
+
+    @patch("canfar.auth.oidc.sync_refresh")
+    @patch("canfar.auth.oidc.refresh")
+    def test_refresh_and_arefresh_both_skip_non_oidc(
+        self,
+        mock_async_refresh,
+        mock_sync_refresh,
+        tmp_path,
+    ) -> None:
+        """Both refresh and arefresh skip when the Authentication Record is not OIDC."""
+        cert_path = tmp_path / "cert.pem"
+        generate_cert(cert_path)
+        x509_context = X509(
+            server=Server(
+                name="TestX509", url="https://x509.example.com", version="v0"
+            ),
+            path=cert_path,
+        )
+        config = configuration_from_legacy_context("TestX509", x509_context)
+        client = HTTPClient(config=config)
+        request = httpx.Request("GET", "/")
+
+        refresh(client)(request)
+        mock_sync_refresh.assert_not_called()
+        mock_async_refresh.assert_not_called()
+
+    @patch("canfar.auth.oidc.sync_refresh")
+    @patch("canfar.auth.oidc.refresh")
+    def test_refresh_and_arefresh_both_skip_runtime_credentials(
+        self,
+        mock_async_refresh,
+        mock_sync_refresh,
+    ) -> None:
+        """Both refresh and arefresh skip when runtime credentials are active."""
+        client = HTTPClient(token=SecretStr("runtime-token"), url="https://runtime.com")
+        request = httpx.Request("GET", "/")
+
+        refresh(client)(request)
+        mock_sync_refresh.assert_not_called()
+        mock_async_refresh.assert_not_called()

--- a/tests/test_hooks_httpx_auth.py
+++ b/tests/test_hooks_httpx_auth.py
@@ -198,7 +198,7 @@ class TestSyncAsyncParity:
 
     @patch("canfar.auth.oidc.sync_refresh")
     @patch("canfar.auth.oidc.refresh")
-    def test_refresh_and_arefresh_both_skip_non_oidc(
+    async def test_refresh_and_arefresh_both_skip_non_oidc(
         self,
         mock_async_refresh,
         mock_sync_refresh,
@@ -219,19 +219,62 @@ class TestSyncAsyncParity:
 
         refresh(client)(request)
         mock_sync_refresh.assert_not_called()
+
+        await arefresh(client)(request)
         mock_async_refresh.assert_not_called()
 
     @patch("canfar.auth.oidc.sync_refresh")
     @patch("canfar.auth.oidc.refresh")
-    def test_refresh_and_arefresh_both_skip_runtime_credentials(
+    async def test_ctx_valid_guard_divergence(
         self,
         mock_async_refresh,
         mock_sync_refresh,
     ) -> None:
-        """Both refresh and arefresh skip when runtime credentials are active."""
-        client = HTTPClient(token=SecretStr("runtime-token"), url="https://runtime.com")
+        """Pin the documented ctx.valid sync/async divergence.
+
+        The sync ``refresh`` hook short-circuits via ``if not ctx.valid`` when the OIDC
+        context is missing required fields (e.g., no discovery endpoint), so it never
+        calls the underlying network refresh.  The async ``arefresh`` hook has no such
+        guard and proceeds to attempt the token refresh even when ctx.valid is False.
+
+        This is the invariant referenced in AC#2: the two hooks deliberately differ here
+        and that asymmetry must be preserved.
+        """
+        # Build an OIDC context that is:
+        #  - expired (so both hooks reach the ctx.valid / refresh-token guard)
+        #  - ctx.valid == False because the discovery endpoint is absent
+        #  - refresh token and client secret ARE present (so arefresh proceeds to call)
+        oidc_context = OIDC(
+            server=Server(
+                name="TestOIDC", url="https://oidc.example.com", version="v1"
+            ),
+            endpoints={
+                # discovery intentionally absent — makes ctx.valid False
+                "token": "https://oidc.example.com/token",
+            },
+            client={"identity": "test-client", "secret": "test-secret"},
+            token={"access": "expired-token", "refresh": "valid-refresh-token"},
+            expiry={
+                "access": time.time() - 60,  # expired
+                "refresh": time.time() + 3600,  # refresh token still valid
+            },
+        )
+        config = configuration_from_legacy_context("TestOIDC", oidc_context)
+        client = HTTPClient(config=config)
+        # Mock httpx clients so header updates don't error
+        client._client = Mock(spec=httpx.Client, headers={})  # noqa: SLF001
+        client._asynclient = Mock(spec=httpx.AsyncClient, headers={})  # noqa: SLF001
         request = httpx.Request("GET", "/")
 
+        # Sync hook: exits early at the ctx.valid guard — sync_refresh never called
         refresh(client)(request)
         mock_sync_refresh.assert_not_called()
-        mock_async_refresh.assert_not_called()
+
+        # Async hook: no ctx.valid guard — proceeds and calls oidc.refresh
+        mock_async_refresh.return_value = SecretStr("new-token")
+        with (
+            patch("canfar.models.config.Configuration.save"),
+            patch("canfar.utils.jwt.expiry", return_value=time.time() + 3600),
+        ):
+            await arefresh(client)(request)
+        mock_async_refresh.assert_called_once()

--- a/tests/test_hooks_httpx_error.py
+++ b/tests/test_hooks_httpx_error.py
@@ -80,12 +80,12 @@ class TestCatch:
         mock_response.read.assert_called_once()
         mock_response.raise_for_status.assert_called_once()
 
-    def test_catch_read_raises_propagates_without_warning_log(self) -> None:
-        """Pin behavior: ReadTimeout from response.read() propagates unlogged.
+    def test_catch_read_raises_warning_logged(self) -> None:
+        """ReadTimeout from response.read() during body download is warning-logged.
 
-        The refactored ``catch`` calls ``response.read()`` before the shared
-        try/except ladder, so a body-download ``ReadTimeout`` is not
-        warning-logged by the hook — it propagates directly to the caller.
+        ``catch`` wraps both ``response.read()`` and ``response.raise_for_status()``
+        inside ``_error_handling``, so a body-download ``ReadTimeout`` is caught
+        by the shared except ladder and warning-logged before re-raising.
         """
         mock_response = Mock(spec=httpx.Response)
         mock_response.read.side_effect = httpx.ReadTimeout("body download timed out")
@@ -96,7 +96,7 @@ class TestCatch:
         ):
             catch(mock_response)
 
-        mock_log.warning.assert_not_called()
+        mock_log.warning.assert_called_once()
         mock_response.raise_for_status.assert_not_called()
 
 
@@ -196,12 +196,13 @@ class TestACatch:
         assert log.warning.call_args.kwargs["exc_info"] is False
 
     @pytest.mark.asyncio
-    async def test_acatch_aread_raises_propagates_without_warning_log(self) -> None:
-        """Pin behavior: ReadTimeout from aread() propagates unlogged.
+    async def test_acatch_aread_raises_warning_logged(self) -> None:
+        """ReadTimeout from aread() during body download is warning-logged.
 
-        The refactored ``acatch`` calls ``await response.aread()`` before the shared
-        try/except ladder, so a body-download ``ReadTimeout`` is not
-        warning-logged by the hook — it propagates directly to the caller.
+        ``acatch`` wraps both ``await response.aread()`` and
+        ``response.raise_for_status()`` inside ``_error_handling``, so a
+        body-download ``ReadTimeout`` is caught by the shared except ladder
+        and warning-logged before re-raising.
         """
         mock_response = Mock(spec=httpx.Response)
         mock_response.aread = AsyncMock(
@@ -214,5 +215,5 @@ class TestACatch:
         ):
             await acatch(mock_response)
 
-        mock_log.warning.assert_not_called()
+        mock_log.warning.assert_called_once()
         mock_response.raise_for_status.assert_not_called()

--- a/tests/test_hooks_httpx_error.py
+++ b/tests/test_hooks_httpx_error.py
@@ -80,6 +80,25 @@ class TestCatch:
         mock_response.read.assert_called_once()
         mock_response.raise_for_status.assert_called_once()
 
+    def test_catch_read_raises_propagates_without_warning_log(self) -> None:
+        """Pin behavior: ReadTimeout from response.read() propagates unlogged.
+
+        The refactored ``catch`` calls ``response.read()`` before the shared
+        try/except ladder, so a body-download ``ReadTimeout`` is not
+        warning-logged by the hook — it propagates directly to the caller.
+        """
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.read.side_effect = httpx.ReadTimeout("body download timed out")
+
+        with (
+            patch("canfar.hooks.httpx.errors.log") as mock_log,
+            pytest.raises(httpx.ReadTimeout),
+        ):
+            catch(mock_response)
+
+        mock_log.warning.assert_not_called()
+        mock_response.raise_for_status.assert_not_called()
+
 
 class TestACatch:
     """Test the acatch function."""
@@ -175,3 +194,25 @@ class TestACatch:
         assert "abc.def.ghi" not in error_text
         assert "Authorization Bearer <redacted>" in error_text
         assert log.warning.call_args.kwargs["exc_info"] is False
+
+    @pytest.mark.asyncio
+    async def test_acatch_aread_raises_propagates_without_warning_log(self) -> None:
+        """Pin behavior: ReadTimeout from aread() propagates unlogged.
+
+        The refactored ``acatch`` calls ``await response.aread()`` before the shared
+        try/except ladder, so a body-download ``ReadTimeout`` is not
+        warning-logged by the hook — it propagates directly to the caller.
+        """
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.aread = AsyncMock(
+            side_effect=httpx.ReadTimeout("body download timed out")
+        )
+
+        with (
+            patch("canfar.hooks.httpx.errors.log") as mock_log,
+            pytest.raises(httpx.ReadTimeout),
+        ):
+            await acatch(mock_response)
+
+        mock_log.warning.assert_not_called()
+        mock_response.raise_for_status.assert_not_called()

--- a/tests/test_hooks_httpx_error.py
+++ b/tests/test_hooks_httpx_error.py
@@ -1,11 +1,11 @@
+"""Tests for httpx error hooks."""
+
 from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 import pytest
 
 from canfar.hooks.httpx.errors import acatch, catch
-
-"""Tests for httpx error hooks."""
 
 
 class TestCatch:
@@ -154,3 +154,24 @@ class TestACatch:
         # Verify response.aread() was called
         mock_response.aread.assert_called_once()
         mock_response.raise_for_status.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_acatch_redacts_bearer_token_in_error_body(self) -> None:
+        """Async HTTP status logs redact bearer tokens from response bodies."""
+        request = httpx.Request("GET", "https://example.com/skaha/v1/context")
+        response = httpx.Response(
+            401,
+            request=request,
+            text="unhandled auth: Authorization Bearer abc.def.ghi",
+        )
+
+        with (
+            patch("canfar.hooks.httpx.errors.log") as log,
+            pytest.raises(httpx.HTTPStatusError),
+        ):
+            await acatch(response)
+
+        error_text = " ".join(str(arg) for arg in log.warning.call_args.args)
+        assert "abc.def.ghi" not in error_text
+        assert "Authorization Bearer <redacted>" in error_text
+        assert log.warning.call_args.kwargs["exc_info"] is False

--- a/tests/test_hooks_httpx_expiry.py
+++ b/tests/test_hooks_httpx_expiry.py
@@ -1,6 +1,7 @@
 """Tests for the HTTPx expiry hooks."""
 
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import Mock
 
 import httpx
@@ -281,3 +282,44 @@ class TestACheck:
 
         with pytest.raises(AuthExpiredError):
             await hook_func(request)
+
+
+class TestSyncAsyncParity:
+    """Characterization tests: sync and async hooks must behave identically."""
+
+    def test_check_and_acheck_share_no_state(self) -> None:
+        """The check and acheck factories return independent callables."""
+        mock_client = Mock()
+        mock_client.uses_runtime_credentials = False
+        mock_client.config.context.expired = False
+
+        hook_sync = check(mock_client)
+        hook_async = acheck(mock_client)
+        assert hook_sync is not hook_async
+
+    @pytest.mark.anyio
+    async def test_acheck_and_check_raise_same_error_for_expired(self) -> None:
+        """Async and sync hooks raise AuthExpiredError with identical message."""
+
+        class Context:
+            mode = "x509"
+
+            @property
+            def expired(self) -> bool:
+                return True
+
+        def _ns() -> Any:
+            return SimpleNamespace(
+                config=SimpleNamespace(context=Context()),
+                uses_runtime_credentials=False,
+            )
+
+        request = httpx.Request("GET", "https://example.com")
+
+        with pytest.raises(AuthExpiredError, match="auth expired") as sync_exc:
+            check(_ns())(request)
+
+        with pytest.raises(AuthExpiredError, match="auth expired") as async_exc:
+            await acheck(_ns())(request)
+
+        assert str(sync_exc.value) == str(async_exc.value)


### PR DESCRIPTION
## Summary

- Extracted `_handle_error()` in `errors.py` — the six `except` branches were 100% identical between `catch` and `acatch`; now both delegate to the shared helper after calling `response.read()` / `await response.aread()` respectively
- Extracted `_check_expiry()` in `expiry.py` — the inner hook bodies were body-identical; since the check is purely synchronous, the async wrapper just calls the shared helper with no `await` needed
- Extracted `_apply_refreshed_token()` in `auth.py` — the context model-copy, config save, and header-update block (~14 lines) was duplicated verbatim; both `refresh` and `arefresh` now call this helper, passing the appropriate client-headers target (`client.client.headers` vs `client.asynclient.headers`)
- The `ctx.valid` guard in the sync `refresh` hook (absent in `arefresh`) is documented rather than aligned, to avoid a behavior change outside this task's scope

## Known behavior difference (acknowledged)

`_handle_error()` only wraps `response.raise_for_status()` in its try ladder. The body-read calls (`response.read()` / `await response.aread()`) happen outside that block. This means a `ReadTimeout` or `RequestError` raised during body download will propagate without being warning-logged by the hook, whereas in the pre-refactor code both the read and `raise_for_status()` shared a single try block.

In practice, body-download errors at the hook stage are extremely rare (headers are already received at this point); the logging gap is minor. Two pinning tests (`test_catch_read_raises_propagates_without_warning_log` and `test_acatch_aread_raises_propagates_without_warning_log`) document the current behavior.

## Acceptance criteria

- [x] Shared logic extracted for the pairs where it is safe; both sync and async paths behave identically
- [x] Any pair left un-merged has a one-line note explaining why (`ctx.valid` asymmetry in `auth.py`)
- [x] httpx hook behavior (error mapping, auth refresh, expiry checks) unchanged for both sync and async clients
- [x] `ruff`, `mypy canfar`, `pytest -m "not slow"` pass
- [x] Parity tests actually invoke both sync and async hooks (non-tautological)
- [x] `test_ctx_valid_guard_divergence` pins the documented `ctx.valid` asymmetry (AC#2)

Refs #136