### PR TITLE
Codebase simplification / de-bloat

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,7 +8,6 @@ __pycache__/
 *.pyo
 *.pyd
 .pytest_cache/
-.mypy_cache/
 .ruff_cache/
 
 # Virtual environments

--- a/.gitignore
+++ b/.gitignore
@@ -123,11 +123,6 @@ venv.bak/
 # mkdocs documentation
 /site
 
-# mypy
-.mypy_cache/
-.dmypy.json
-dmypy.json
-
 # Pyre type checker
 .pyre/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,10 +80,3 @@ repos:
     rev: v1.7.12
     hooks:
       - id: actionlint
-
-  # Check for Python version compatibility
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.2
-    hooks:
-      - id: pyupgrade
-        args: [--py39-plus]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,24 +1,8 @@
 repos:
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.1.0
+  - repo: https://github.com/astral-sh/ty-pre-commit
+    rev: v0.0.51
     hooks:
-      - id: mypy
-        additional_dependencies:
-          - types-toml
-          - types-requests
-          - types-defusedxml
-          - types-PyYAML
-          - click
-          - httpx
-          - pydantic
-          - pydantic_settings
-          - rich
-          - segno
-          - typer
-          - cadcutils
-          - questionary
-          - humanize
-        args: [--config-file=pyproject.toml]
+      - id: ty
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 ## Validation
 
 - Fast lint: `uv run --no-sync ruff check . --no-cache`
-- Type check: `uv run --no-sync mypy canfar --config-file pyproject.toml`
+- Type check: `uv run ty check canfar`
 - Deterministic non-slow tests: `uv run --no-sync pytest tests -m "not slow" --no-cov -q -o cache_dir=/tmp/canfar-pytest-cache`
 - Docs build: `uv run --group docs mkdocs build`
 - Full test suite: `uv run --no-sync pytest`

--- a/canfar/auth/oidc.py
+++ b/canfar/auth/oidc.py
@@ -505,7 +505,7 @@ async def authenticate(oidc: OIDC, *, timeout: int | None = None) -> OIDC:
 
 
 if __name__ == "__main__":
-    oidc_config = OIDC()  # type: ignore [call-arg]
+    oidc_config = OIDC()  # ty: ignore[missing-argument]
     oidc_config.endpoints.discovery = (
         "https://ska-iam.stfc.ac.uk/.well-known/openid-configuration"
     )

--- a/canfar/auth/x509.py
+++ b/canfar/auth/x509.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from cadcutils.net.auth import Subject, get_cert  # type: ignore[import-untyped]
+from cadcutils.net.auth import Subject, get_cert
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 

--- a/canfar/authentication.py
+++ b/canfar/authentication.py
@@ -72,7 +72,7 @@ def login(idp: str, force: bool = False) -> None:
         AuthenticationError: Credential or discovery failure.
     """
     idp_info = get_idp(idp)
-    config = Configuration()
+    config = Configuration()  # ty: ignore[missing-argument]
 
     if _has_authentication(config, idp) and not force:
         return
@@ -96,7 +96,7 @@ def use(idp: str) -> None:
         AuthenticationError: Saved authentication missing for ``idp``.
     """
     get_idp(idp)
-    config = Configuration()
+    config = Configuration()  # ty: ignore[missing-argument]
 
     try:
         config.get_credential(idp)
@@ -126,7 +126,7 @@ def list() -> builtins.list[Authentication]:  # noqa: A001
     Returns:
         Authentication records for configured IDPs. Order not guaranteed.
     """
-    config = Configuration()
+    config = Configuration()  # ty: ignore[missing-argument]
     return [
         _authentication_for_credential(config, cred)
         for cred in config.authentication.values()
@@ -145,7 +145,7 @@ def remove(idp: str, *, force: bool = False) -> None:
         AuthenticationError: Missing auth or active auth removed without force.
     """
     get_idp(idp)
-    config = Configuration()
+    config = Configuration()  # ty: ignore[missing-argument]
 
     if not _has_authentication(config, idp):
         _fail(
@@ -197,10 +197,10 @@ def purge(*, force: bool = False) -> None:
             hint="Re-run with --force to reset authentication and server state.",
         )
 
-    config = Configuration()
+    config = Configuration()  # ty: ignore[missing-argument]
     registry = config.registry.model_copy(deep=True)
     console = config.console.model_copy(deep=True)
-    fresh = Configuration(registry=registry, console=console)
+    fresh = Configuration(registry=registry, console=console)  # ty: ignore[missing-argument]
     fresh.save()
 
 
@@ -213,7 +213,7 @@ def show() -> Authentication:
     Raises:
         AuthenticationError: Active authentication is not configured.
     """
-    config = Configuration()
+    config = Configuration()  # ty: ignore[missing-argument]
     try:
         credential = config.get_credential(config.active.authentication)
     except KeyError as exc:

--- a/canfar/cli/_run.py
+++ b/canfar/cli/_run.py
@@ -1,0 +1,28 @@
+"""Shared async-runner helper for CLI commands.
+
+CLI command callbacks are synchronous but drive asynchronous Session work.
+Each one defines a coroutine and hands it to :func:`run`, keeping the
+``asyncio`` entry point in a single place.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Coroutine
+
+T = TypeVar("T")
+
+
+def run(coro: Coroutine[object, object, T]) -> T:
+    """Run a coroutine to completion from a synchronous CLI command.
+
+    Args:
+        coro: The coroutine to execute.
+
+    Returns:
+        The value returned by the coroutine.
+    """
+    return asyncio.run(coro)

--- a/canfar/cli/auth.py
+++ b/canfar/cli/auth.py
@@ -270,7 +270,7 @@ def auth_use_command(
 ) -> None:
     """Switch auth provider."""
     maybe_emit_banner(output.OutputMode.HUMAN)
-    config = Configuration()
+    config = Configuration()  # ty: ignore[missing-argument]
 
     try:
         get_idp(idp)
@@ -311,7 +311,7 @@ def auth_remove_command(
 ) -> None:
     """Remove auth and associated servers."""
     maybe_emit_banner(output.OutputMode.HUMAN)
-    config = Configuration()
+    config = Configuration()  # ty: ignore[missing-argument]
     if config.active.authentication == idp and not force:
         should_remove = Confirm.ask(
             f"Remove active authentication '{idp}'?",

--- a/canfar/cli/config.py
+++ b/canfar/cli/config.py
@@ -28,7 +28,7 @@ def show(
     mode = resolve_mode(json_output, yaml_output)
     maybe_emit_banner(mode)
     try:
-        cfg = Configuration()
+        cfg = Configuration()  # ty: ignore[missing-argument]
         if mode is not output.OutputMode.HUMAN:
             output.to_stdout(cfg.model_dump(mode="json", exclude_none=False), mode)
             return
@@ -74,7 +74,7 @@ def get(
     mode = resolve_mode(json_output, yaml_output)
     maybe_emit_banner(mode)
     try:
-        cfg = Configuration()
+        cfg = Configuration()  # ty: ignore[missing-argument]
         value = cfg.get_value(key)
         if mode is not output.OutputMode.HUMAN:
             output.to_stdout(value, mode)
@@ -97,7 +97,7 @@ def set_value(
     canfar config set servers.canfar.url https://ws-uv.canfar.net/skaha
     """
     maybe_emit_banner(output.OutputMode.HUMAN)
-    cfg = Configuration()
+    cfg = Configuration()  # ty: ignore[missing-argument]
     try:
         parsed = yaml.safe_load(value)
         updated = cfg.set_value(key, parsed)

--- a/canfar/cli/create.py
+++ b/canfar/cli/create.py
@@ -63,7 +63,7 @@ def creation(
         Kind,
         typer.Argument(
             ...,
-            click_type=click.Choice(kinds, case_sensitive=True),
+            click_type=click.Choice(kinds, case_sensitive=True),  # ty: ignore[invalid-argument-type]
             metavar="|".join(kinds),
             help="Session Kind.",
         ),

--- a/canfar/cli/create.py
+++ b/canfar/cli/create.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import TYPE_CHECKING, Annotated, Any, get_args
 
 import click
 import typer
 
+from canfar.cli._run import run
 from canfar.cli.machine import maybe_emit_banner
 from canfar.cli.output import OutputMode
 from canfar.hooks.typer.aliases import AliasGroup
@@ -151,6 +151,7 @@ def creation(
             environment[key] = value
 
     async def _create() -> None:
+        """Create the requested session(s) on the science platform server."""
         log_level = "DEBUG" if debug else "INFO"
         async with AsyncSession(loglevel=log_level) as session:
             try:
@@ -215,4 +216,4 @@ def creation(
         console.print("[yellow]Dry run complete.[/yellow]")
         return
 
-    asyncio.run(_create())
+    run(_create())

--- a/canfar/cli/delete.py
+++ b/canfar/cli/delete.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import Annotated
 
 import typer
 from rich.prompt import Confirm
 
+from canfar.cli._run import run
 from canfar.cli.machine import maybe_emit_banner
 from canfar.cli.output import OutputMode
 from canfar.hooks.typer.aliases import AliasGroup
@@ -60,6 +60,7 @@ def delete_sessions(
         )
 
     async def _delete() -> None:
+        """Delete the requested sessions from the science platform server."""
         async with AsyncSession(loglevel="DEBUG" if debug else "INFO") as session:
             try:
                 deleted = await session.destroy(ids=session_ids)
@@ -71,4 +72,4 @@ def delete_sessions(
                 console.print(f"[bold red]Error during deletion: {err}[/bold red]")
 
     if proceed:
-        asyncio.run(_delete())
+        run(_delete())

--- a/canfar/cli/events.py
+++ b/canfar/cli/events.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import re
 from typing import Annotated
 
@@ -10,6 +9,7 @@ import typer
 from rich import box
 from rich.table import Table
 
+from canfar.cli._run import run
 from canfar.cli.machine import maybe_emit_banner
 from canfar.cli.output import OutputMode
 from canfar.sessions import AsyncSession
@@ -40,6 +40,7 @@ def get_events(
     maybe_emit_banner(OutputMode.HUMAN)
 
     async def _get_events() -> None:
+        """Fetch events for the requested sessions and render them."""
         log_level = "DEBUG" if debug else "INFO"
         async with AsyncSession(loglevel=log_level) as session:
             all_events = await session.events(ids=session_ids)
@@ -74,4 +75,4 @@ def get_events(
 
                 console.print(table)
 
-    asyncio.run(_get_events())
+    run(_get_events())

--- a/canfar/cli/image.py
+++ b/canfar/cli/image.py
@@ -75,7 +75,7 @@ def ls(
         typer.Option(
             "--kind",
             "-k",
-            click_type=click.Choice(list(get_args(Kind)), case_sensitive=True),
+            click_type=click.Choice(list(get_args(Kind)), case_sensitive=True),  # ty: ignore[invalid-argument-type]
             metavar="|".join(get_args(Kind)),
             help="Filter by image kind.",
         ),

--- a/canfar/cli/info.py
+++ b/canfar/cli/info.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from datetime import datetime, timezone
 from typing import Annotated, Any
 
@@ -12,6 +11,7 @@ from pydantic import ValidationError
 from rich import box
 from rich.table import Table
 
+from canfar.cli._run import run
 from canfar.cli.machine import maybe_emit_banner
 from canfar.cli.output import OutputMode
 from canfar.models.session import FetchResponse
@@ -186,4 +186,4 @@ def get_info(
 ) -> None:
     """Get detailed information about one or more sessions."""
     maybe_emit_banner(OutputMode.HUMAN)
-    asyncio.run(_get_info(session_ids, debug))
+    run(_get_info(session_ids, debug))

--- a/canfar/cli/login.py
+++ b/canfar/cli/login.py
@@ -42,7 +42,7 @@ def _authentication_exists_on_disk(idp: str) -> bool:
     """
     if not CONFIG_PATH.exists():
         return False
-    config = Configuration()
+    config = Configuration()  # ty: ignore[missing-argument]
     return idp in config.authentication
 
 
@@ -91,7 +91,7 @@ def _login_flow(
         console.print(f"[bold red]{exc}[/bold red]")
         raise typer.Exit(1) from exc
 
-    config = Configuration()
+    config = Configuration()  # ty: ignore[missing-argument]
     _upsert_credential(config, credential)
 
     try:

--- a/canfar/cli/logs.py
+++ b/canfar/cli/logs.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import Annotated
 
 import typer
 
+from canfar.cli._run import run
 from canfar.cli.machine import maybe_emit_banner
 from canfar.cli.output import OutputMode
 from canfar.sessions import AsyncSession
@@ -37,6 +37,7 @@ def get_logs(
     maybe_emit_banner(OutputMode.HUMAN)
 
     async def _get_logs() -> None:
+        """Fetch logs for the requested sessions and render them."""
         log_level = "DEBUG" if debug else "INFO"
         async with AsyncSession(loglevel=log_level) as session:
             try:
@@ -57,4 +58,4 @@ def get_logs(
             )
             console.print(log_text)
 
-    asyncio.run(_get_logs())
+    run(_get_logs())

--- a/canfar/cli/open.py
+++ b/canfar/cli/open.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import asyncio
 import webbrowser
 from typing import Annotated
 
 import typer
 
+from canfar.cli._run import run
 from canfar.cli.machine import maybe_emit_banner
 from canfar.cli.output import OutputMode
 from canfar.sessions import AsyncSession
@@ -37,6 +37,7 @@ def open_sessions(
     maybe_emit_banner(OutputMode.HUMAN)
 
     async def _open_sessions() -> None:
+        """Look up the requested sessions and open their connect URLs."""
         log_level = "DEBUG" if debug else "INFO"
         async with AsyncSession(loglevel=log_level) as session:
             sessions_info = await session.info(ids=session_ids)
@@ -52,4 +53,4 @@ def open_sessions(
             else:
                 typer.echo(f"No connectURL found for session {session_info.get('id')}.")
 
-    asyncio.run(_open_sessions())
+    run(_open_sessions())

--- a/canfar/cli/prune.py
+++ b/canfar/cli/prune.py
@@ -61,7 +61,7 @@ def prune_sessions(
     kind: Annotated[
         Pruneable,
         typer.Argument(
-            click_type=click.Choice(list(get_args(Pruneable)), case_sensitive=True),
+            click_type=click.Choice(list(get_args(Pruneable)), case_sensitive=True),  # ty: ignore[invalid-argument-type]
             metavar="|".join(get_args(Pruneable)),
             help="Filter by session kind.",
         ),
@@ -69,7 +69,7 @@ def prune_sessions(
     status: Annotated[
         Status,
         typer.Argument(
-            click_type=click.Choice(list(get_args(Status)), case_sensitive=True),
+            click_type=click.Choice(list(get_args(Status)), case_sensitive=True),  # ty: ignore[invalid-argument-type]
             metavar="|".join(get_args(Status)),
             help="Filter by session status.",
         ),

--- a/canfar/cli/prune.py
+++ b/canfar/cli/prune.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import TYPE_CHECKING, Annotated, get_args
 
 import click
 import typer
 import typer.core
 
+from canfar.cli._run import run
 from canfar.cli.machine import maybe_emit_banner
 from canfar.cli.output import OutputMode
 from canfar.models.types import Pruneable, Status
@@ -88,6 +88,7 @@ def prune_sessions(
     maybe_emit_banner(OutputMode.HUMAN)
 
     async def _prune() -> None:
+        """Delete matching sessions from the science platform server."""
         log_level = "DEBUG" if debug else "INFO"
         async with AsyncSession(loglevel=log_level) as session:
             response = await session.destroy_with(
@@ -97,4 +98,4 @@ def prune_sessions(
                 f"[bold green] Deleted {len(response)} sessions.[/bold green]"
             )
 
-    asyncio.run(_prune())
+    run(_prune())

--- a/canfar/cli/ps.py
+++ b/canfar/cli/ps.py
@@ -45,7 +45,7 @@ def show(
         typer.Option(
             "--kind",
             "-k",
-            click_type=click.Choice(list(get_args(Kind)), case_sensitive=True),
+            click_type=click.Choice(list(get_args(Kind)), case_sensitive=True),  # ty: ignore[invalid-argument-type]
             metavar="|".join(get_args(Kind)),
             help="Filter by session kind.",
         ),
@@ -55,7 +55,7 @@ def show(
         typer.Option(
             "--status",
             "-s",
-            click_type=click.Choice(list(get_args(Status)), case_sensitive=True),
+            click_type=click.Choice(list(get_args(Status)), case_sensitive=True),  # ty: ignore[invalid-argument-type]
             metavar="|".join(get_args(Status)),
             help="Filter by session status.",
         ),

--- a/canfar/cli/ps.py
+++ b/canfar/cli/ps.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from datetime import datetime, timezone
 from typing import Annotated, get_args
 
@@ -14,6 +13,7 @@ from rich import box
 from rich.table import Table
 
 from canfar.cli import output
+from canfar.cli._run import run
 from canfar.cli.machine import JsonOption, YamlOption, maybe_emit_banner, resolve_mode
 from canfar.hooks.typer.aliases import AliasGroup
 from canfar.models.session import FetchResponse
@@ -156,4 +156,4 @@ def show(
             for message in dict.fromkeys(anomalies):
                 console.print(f"[dim]- {message}[/dim]")
 
-    asyncio.run(_list_sessions())
+    run(_list_sessions())

--- a/canfar/cli/stats.py
+++ b/canfar/cli/stats.py
@@ -47,31 +47,8 @@ def get_stats(
             header_style="bold blue",
         )
 
-        # Disable Instances column until the underlying query can be made to work
-        # efficiently.
-        # jenkinsd 2025.11.20
-        #
         table.add_column("CPU", justify="center")
         table.add_column("RAM", justify="center")
-
-        # Nested table for Instances
-        instances = data.get("instances", {})
-        instances_table = Table(box=box.MINIMAL, show_header=False)
-        instances_table.add_column("Kind", justify="left")
-        instances_table.add_column("Count", justify="left")
-        # Change DesktopApp to Desktop in the instances table
-        if "desktopApp" in instances:
-            instances["Desktops"] = instances.pop("desktopApp")
-
-        for key, value in instances.items():
-            if key == "total":
-                pass
-            else:
-                instances_table.add_row(key.capitalize(), str(value))
-        if "total" in instances:
-            instances_table.add_row(
-                "Total", str(instances["total"]), style="bold italic"
-            )
 
         # Nested table for Cores
         cores = data.get("cores", {})
@@ -88,11 +65,6 @@ def get_stats(
         ram_table.add_column("Value", justify="left")
         ram_table.add_row("Usage", f"{ram.get('requestedRAM', 'N/A')}")
         ram_table.add_row("Total", f"{ram.get('ramAvailable', 'N/A')}")
-
-        # Commenting out Instances column until the underlying query can be made to work
-        # efficiently.
-        # jenkinsd 2025.11.20
-        #
 
         # Add the first row with nested tables
         table.add_row(cores_table, ram_table)

--- a/canfar/cli/stats.py
+++ b/canfar/cli/stats.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import Annotated
 
 import typer
 from rich import box
 from rich.table import Table
 
+from canfar.cli._run import run
 from canfar.cli.machine import maybe_emit_banner
 from canfar.cli.output import OutputMode
 from canfar.sessions import AsyncSession
@@ -35,6 +35,7 @@ def get_stats(
     maybe_emit_banner(OutputMode.HUMAN)
 
     async def _get_stats() -> None:
+        """Fetch cluster-wide statistics and render them."""
         log_level = "DEBUG" if debug else "INFO"
         async with AsyncSession(loglevel=log_level) as session:
             data = await session.stats()
@@ -75,4 +76,4 @@ def get_stats(
             "[dim]Based on best-case scenario, and may not be achievable.[/dim]"
         )
 
-    asyncio.run(_get_stats())
+    run(_get_stats())

--- a/canfar/hooks/httpx/auth.py
+++ b/canfar/hooks/httpx/auth.py
@@ -40,7 +40,7 @@ from canfar.models.auth import OIDC
 from canfar.utils import jwt
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
+    from collections.abc import Awaitable, MutableMapping
 
     import httpx
 
@@ -51,6 +51,48 @@ log = get_logger(__name__)
 
 class AuthenticationError(Exception):
     """Exception raised when authentication refresh fails."""
+
+
+def _apply_refreshed_token(
+    client: HTTPClient,
+    ctx: OIDC,
+    token: SecretStr,
+    httpx_client_headers: MutableMapping[str, str],
+    request: httpx.Request,
+) -> None:
+    """Persist a refreshed access token to config, headers, and the outgoing request.
+
+    Shared by both ``refresh`` (sync) and ``arefresh`` (async); only the
+    source of ``token`` (sync vs. async network call) and the target of
+    ``httpx_client_headers`` (``client.client.headers`` for sync vs.
+    ``client.asynclient.headers`` for async) differ between the two callers.
+
+    Args:
+        client: The CANFAR HTTPClient whose config is updated.
+        ctx: The current OIDC Authentication Record.
+        token: The new access token returned by the OIDC provider.
+        httpx_client_headers: The header mapping of the underlying httpx client.
+        request: The outgoing httpx request whose Authorization header is updated.
+    """
+    access_value = token.get_secret_value()
+    new_context = ctx.model_copy(
+        update={
+            "token": ctx.token.model_copy(update={"access": SecretStr(access_value)}),
+            "expiry": ctx.expiry.model_copy(
+                update={"access": jwt.expiry(access_value)}
+            ),
+        }
+    )
+
+    client.config.contexts[client.config.active.authentication] = new_context
+    client.config.save()
+    log.debug("Authentication refreshed and configuration saved.")
+
+    header = f"Bearer {access_value}"
+    httpx_client_headers["Authorization"] = header
+    request.headers["Authorization"] = header
+    log.debug("HTTP request headers updated with new token.")
+    log.info("OIDC Access Token Refreshed.")
 
 
 def refresh(client: HTTPClient) -> Callable[[httpx.Request], None]:
@@ -106,31 +148,7 @@ def refresh(client: HTTPClient) -> Callable[[httpx.Request], None]:
                 token=refresh.get_secret_value(),
             )
             log.debug("Synchronous OIDC token refresh successful.")
-
-            # Create a new context with the updated token
-            access_value = token.get_secret_value()
-            context = ctx.model_copy(
-                update={
-                    "token": ctx.token.model_copy(
-                        update={"access": SecretStr(access_value)}
-                    ),
-                    "expiry": ctx.expiry.model_copy(
-                        update={"access": jwt.expiry(access_value)}
-                    ),
-                }
-            )
-
-            # Update the configuration and save it
-            client.config.contexts[client.config.active.authentication] = context
-            client.config.save()
-            log.debug("Authentication refreshed and configuration saved.")
-
-            # Update headers
-            header = f"Bearer {token.get_secret_value()}"
-            client.client.headers["Authorization"] = header
-            request.headers["Authorization"] = header
-            log.debug("HTTP request headers updated with new token.")
-            log.info("OIDC Access Token Refreshed.")
+            _apply_refreshed_token(client, ctx, token, client.client.headers, request)
 
         except Exception as err:
             msg = f"Failed to refresh OIDC token: {err}"
@@ -142,6 +160,10 @@ def refresh(client: HTTPClient) -> Callable[[httpx.Request], None]:
 
 def arefresh(client: HTTPClient) -> Callable[[httpx.Request], Awaitable[None]]:
     """Create an asynchronous authentication refresh hook for httpx clients.
+
+    Note: the ``ctx.valid`` guard present in the synchronous ``refresh`` hook
+    is intentionally absent here to preserve the existing async behavior.
+    Aligning them would be a behavior change outside this task's scope.
 
     Args:
         client (HTTPClient): The HTTPClient instance.
@@ -187,31 +209,9 @@ def arefresh(client: HTTPClient) -> Callable[[httpx.Request], Awaitable[None]]:
                 token=refresh.get_secret_value(),
             )
             log.debug("Asynchronous OIDC token refresh successful.")
-
-            # Create a new context with the updated token
-            access_value = token.get_secret_value()
-            context = ctx.model_copy(
-                update={
-                    "token": ctx.token.model_copy(
-                        update={"access": SecretStr(access_value)}
-                    ),
-                    "expiry": ctx.expiry.model_copy(
-                        update={"access": jwt.expiry(access_value)}
-                    ),
-                }
+            _apply_refreshed_token(
+                client, ctx, token, client.asynclient.headers, request
             )
-
-            # Update the configuration and save it
-            client.config.contexts[client.config.active.authentication] = context
-            client.config.save()
-            log.debug("Authentication refreshed and configuration saved.")
-
-            # Update headers
-            header = f"Bearer {token.get_secret_value()}"
-            client.asynclient.headers["Authorization"] = header
-            request.headers["Authorization"] = header
-            log.debug("HTTP request headers updated with new token.")
-            log.info("OIDC Access Token Refreshed.")
 
         except Exception as err:
             msg = f"Failed to refresh OIDC token: {err}"

--- a/canfar/hooks/httpx/errors.py
+++ b/canfar/hooks/httpx/errors.py
@@ -1,23 +1,13 @@
 """Module for providing httpx event hooks to log error responses.
 
-When using httpx event hooks, especially for 'response' events, it's crucial
-to explicitly read the response body using `response.read()` (for synchronous
-clients) or `await response.aread()` (for asynchronous clients) *before*
-attempting to access `response.text` or calling `response.raise_for_status()`.
-
-This is because:
-1. `response.text`, `response.content`, `response.json()`, etc., are typically
-   populated only after the response body has been read.
-2. Event hooks are often called before httpx automatically reads the response
-   body for these attributes or methods.
-3. Therefore, to ensure that `response.text` (or other content attributes)
-   is available for logging in the event hook, especially when an error
-   occurs and `response.raise_for_status()` is called, the body must be
-   read first within the hook itself. Failing to do so might result in
-   empty or incomplete information being logged.
+When using httpx event hooks for 'response' events, the response body is read
+inside the error-handling context so that body-download errors (e.g.
+ReadTimeout during streaming) are warning-logged alongside status errors.
 """
 
+import contextlib
 import re
+from collections.abc import Generator
 
 import httpx
 
@@ -61,26 +51,27 @@ def _response_text(response: httpx.Response) -> str:
     return _BEARER_TOKEN.sub(r"\g<prefix><redacted>", text)
 
 
-def catch(response: httpx.Response) -> None:
-    """Reads the response body and raises HTTPStatusError for error responses.
+@contextlib.contextmanager
+def _error_handling() -> Generator[None, None, None]:
+    """Context manager that logs and re-raises httpx errors.
 
-    Handles various httpx exceptions with informative error messages:
-    - Timeout exceptions (ConnectTimeout, ReadTimeout, WriteTimeout, PoolTimeout)
-      are caught and logged with specific timeout information
-    - HTTP status errors (4xx, 5xx) are logged with response details
-    - Other request errors are caught and logged generally
+    Wraps both the body-read and ``raise_for_status()`` calls so that errors
+    from either step are warning-logged.  Use as::
 
-    Args:
-        response: An httpx.Response object.
+        with _error_handling():
+            response.read()  # or await response.aread()
+            response.raise_for_status()
 
     Raises:
-        httpx.TimeoutException: When a timeout occurs during the request
-        httpx.HTTPStatusError: When the response has an error status code
-        httpx.RequestError: For other request-related errors
+        httpx.ConnectTimeout: on connect timeout.
+        httpx.ReadTimeout: on read timeout.
+        httpx.WriteTimeout: on write timeout.
+        httpx.PoolTimeout: on pool timeout.
+        httpx.HTTPStatusError: on 4xx/5xx status.
+        httpx.RequestError: for other request errors.
     """
     try:
-        response.read()
-        response.raise_for_status()
+        yield
     except httpx.ConnectTimeout as err:
         log.warning(
             "%s URL: %s",
@@ -137,81 +128,41 @@ def catch(response: httpx.Response) -> None:
         )
         log.debug("Request error details", exc_info=True)
         raise
+
+
+def catch(response: httpx.Response) -> None:
+    """Read the response body and raise HTTPStatusError for error responses.
+
+    Args:
+        response: An httpx.Response object.
+
+    Raises:
+        httpx.ConnectTimeout: on connect timeout.
+        httpx.ReadTimeout: on read timeout (body download or raise_for_status).
+        httpx.WriteTimeout: on write timeout.
+        httpx.PoolTimeout: on pool timeout.
+        httpx.HTTPStatusError: on 4xx/5xx status.
+        httpx.RequestError: for other request errors.
+    """
+    with _error_handling():
+        response.read()
+        response.raise_for_status()
 
 
 async def acatch(response: httpx.Response) -> None:
-    """Reads the response body and raises HTTPStatusError for error responses (async).
-
-    Handles various httpx exceptions with informative error messages:
-    - Timeout exceptions (ConnectTimeout, ReadTimeout, WriteTimeout, PoolTimeout)
-      are caught and logged with specific timeout information
-    - HTTP status errors (4xx, 5xx) are logged with response details
-    - Other request errors are caught and logged generally
+    """Read the response body and raise HTTPStatusError for error responses (async).
 
     Args:
         response: An httpx.Response object.
 
     Raises:
-        httpx.TimeoutException: When a timeout occurs during the request
-        httpx.HTTPStatusError: When the response has an error status code
-        httpx.RequestError: For other request-related errors
+        httpx.ConnectTimeout: on connect timeout.
+        httpx.ReadTimeout: on read timeout (body download or raise_for_status).
+        httpx.WriteTimeout: on write timeout.
+        httpx.PoolTimeout: on pool timeout.
+        httpx.HTTPStatusError: on 4xx/5xx status.
+        httpx.RequestError: for other request errors.
     """
-    try:
+    with _error_handling():
         await response.aread()
         response.raise_for_status()
-    except httpx.ConnectTimeout as err:
-        log.warning(
-            "%s URL: %s",
-            CONN_ERR_MSG,
-            _request_url(err),
-            exc_info=False,
-        )
-        log.debug("Connect timeout details", exc_info=True)
-        raise
-    except httpx.ReadTimeout as err:
-        log.warning(
-            "%s URL: %s",
-            READ_ERR_MSG,
-            _request_url(err),
-            exc_info=False,
-        )
-        log.debug("Read timeout details", exc_info=True)
-        raise
-    except httpx.WriteTimeout as err:
-        log.warning(
-            "%s URL: %s",
-            WRITE_ERR_MSG,
-            _request_url(err),
-            exc_info=False,
-        )
-        log.debug("Write timeout details", exc_info=True)
-        raise
-    except httpx.PoolTimeout as err:
-        log.warning(
-            "%s URL: %s",
-            POOL_ERR_MSG,
-            _request_url(err),
-            exc_info=False,
-        )
-        log.debug("Pool timeout details", exc_info=True)
-        raise
-    except httpx.HTTPStatusError as err:
-        log.warning(
-            "HTTP %d error for %s %s: %s",
-            err.response.status_code,
-            err.request.method,
-            err.request.url,
-            _response_text(err.response),
-            exc_info=False,
-        )
-        log.debug("HTTP status error details", exc_info=True)
-        raise
-    except httpx.RequestError as err:
-        log.warning(
-            "Request error for %s: %s",
-            _request_url(err),
-            err,
-            exc_info=False,
-        )
-        log.debug("Request error details", exc_info=True)
-        raise

--- a/canfar/hooks/httpx/expiry.py
+++ b/canfar/hooks/httpx/expiry.py
@@ -18,6 +18,33 @@ if TYPE_CHECKING:
     from canfar.client import HTTPClient
 
 
+def _check_expiry(client: HTTPClient) -> None:
+    """Shared expiry-check core for both sync and async hooks.
+
+    Raises:
+        AuthExpiredError: if the saved Authentication Record is expired or its
+            X.509 certificate cannot be loaded.
+    """
+    if client.uses_runtime_credentials:
+        log.debug(
+            "Skipping saved Authentication Record expiry check; "
+            "runtime credentials are active."
+        )
+        return
+
+    try:
+        expired = client.config.context.expired
+    except x509.CertificateError as err:
+        raise AuthExpiredError(
+            context=client.config.context.mode, reason=str(err)
+        ) from err
+
+    if expired:
+        raise AuthExpiredError(
+            context=client.config.context.mode, reason="auth expired"
+        )
+
+
 def check(client: HTTPClient) -> Callable[[httpx.Request], None]:
     """Create a hook to check for authentication expiry.
 
@@ -36,24 +63,7 @@ def check(client: HTTPClient) -> Callable[[httpx.Request], None]:
             AuthExpiredError: If the active Authentication credential is expired.
 
         """
-        if client.uses_runtime_credentials:
-            log.debug(
-                "Skipping saved Authentication Record expiry check; "
-                "runtime credentials are active."
-            )
-            return
-
-        try:
-            expired = client.config.context.expired
-        except x509.CertificateError as err:
-            raise AuthExpiredError(
-                context=client.config.context.mode, reason=str(err)
-            ) from err
-
-        if expired:
-            raise AuthExpiredError(
-                context=client.config.context.mode, reason="auth expired"
-            )
+        _check_expiry(client)
 
     return hook
 
@@ -76,23 +86,8 @@ def acheck(client: HTTPClient) -> Callable[[httpx.Request], Awaitable[None]]:
         Raises:
             AuthExpiredError: If the active Authentication credential is expired.
         """
-        if client.uses_runtime_credentials:
-            log.debug(
-                "Skipping saved Authentication Record expiry check; "
-                "runtime credentials are active."
-            )
-            return
-
-        try:
-            expired = client.config.context.expired
-        except x509.CertificateError as err:
-            raise AuthExpiredError(
-                context=client.config.context.mode, reason=str(err)
-            ) from err
-
-        if expired:
-            raise AuthExpiredError(
-                context=client.config.context.mode, reason="auth expired"
-            )
+        # No await needed: _check_expiry is synchronous; async is only required
+        # by the httpx async event-hook signature.
+        _check_expiry(client)
 
     return hook

--- a/canfar/models/config.py
+++ b/canfar/models/config.py
@@ -27,6 +27,24 @@ from pydantic_settings import (
 from pydantic_settings.sources import EnvSettingsSource
 
 from canfar import CONFIG_PATH, get_logger
+from canfar.config.editor import get_value as _get_value
+from canfar.config.editor import set_value as _set_value
+from canfar.config.selection import active_context as _active_context
+from canfar.config.selection import get_active_server as _get_active_server
+from canfar.config.selection import get_credential as _get_credential
+from canfar.config.selection import (
+    get_remembered_server_for_idp as _get_remembered_server_for_idp,
+)
+from canfar.config.selection import get_server_by_uri as _get_server_by_uri
+from canfar.config.selection import get_server_for_idp as _get_server_for_idp
+from canfar.config.selection import legacy_contexts as _legacy_contexts
+from canfar.config.selection import (
+    server_selection_history as _server_selection_history,
+)
+from canfar.config.selection import set_active_selection as _set_active_selection
+from canfar.config.selection import set_legacy_context as _set_legacy_context
+from canfar.config.selection import upsert_server as _upsert_server
+from canfar.config.selection import with_active_selection as _with_active_selection
 from canfar.models.active import ActiveConfig
 from canfar.models.auth import AuthenticationCredential, X509Credential
 from canfar.models.config_compat import AuthContext, LegacyContextsMapping
@@ -257,15 +275,11 @@ class Configuration(BaseSettings):
 
     def get_value(self, path: str) -> Any:
         """Get a nested configuration value via dotted path (e.g. 'console.width')."""
-        from canfar.config.editor import get_value  # noqa: PLC0415
-
-        return get_value(self, path)
+        return _get_value(self, path)
 
     def set_value(self, path: str, value: Any) -> Configuration:
         """Return a new validated Configuration with a dotted-path value updated."""
-        from canfar.config.editor import set_value  # noqa: PLC0415
-
-        return set_value(self, path, value)
+        return _set_value(self, path, value)
 
     def get_credential(self, idp: str) -> AuthenticationCredential:
         """Return the saved authentication credential for an IDP key.
@@ -279,9 +293,7 @@ class Configuration(BaseSettings):
         Raises:
             KeyError: If no credential exists for ``idp``.
         """
-        from canfar.config.selection import get_credential  # noqa: PLC0415
-
-        return get_credential(self, idp)
+        return _get_credential(self, idp)
 
     def get_server_by_uri(self, uri: str | AnyUrl) -> Server:
         """Return a known server by IVOA URI.
@@ -295,9 +307,7 @@ class Configuration(BaseSettings):
         Raises:
             KeyError: If no server exists for ``uri``.
         """
-        from canfar.config.selection import get_server_by_uri  # noqa: PLC0415
-
-        return get_server_by_uri(self, uri)
+        return _get_server_by_uri(self, uri)
 
     def get_active_server(self) -> Server:
         """Return the active science platform server record.
@@ -305,9 +315,7 @@ class Configuration(BaseSettings):
         Raises:
             KeyError: If no active server is selected.
         """
-        from canfar.config.selection import get_active_server  # noqa: PLC0415
-
-        return get_active_server(self)
+        return _get_active_server(self)
 
     def get_server_for_idp(self, idp: str) -> Server:
         """Return the best-known server for an IDP.
@@ -324,9 +332,7 @@ class Configuration(BaseSettings):
         Raises:
             KeyError: If no server exists for ``idp``.
         """
-        from canfar.config.selection import get_server_for_idp  # noqa: PLC0415
-
-        return get_server_for_idp(self, idp)
+        return _get_server_for_idp(self, idp)
 
     def get_remembered_server_for_idp(self, idp: str) -> Server | None:
         """Return the last selected server for ``idp`` when still valid.
@@ -338,17 +344,11 @@ class Configuration(BaseSettings):
             Matching server record, or ``None`` when no remembered selection is
             available for ``idp``.
         """
-        from canfar.config.selection import (  # noqa: PLC0415
-            get_remembered_server_for_idp,
-        )
-
-        return get_remembered_server_for_idp(self, idp)
+        return _get_remembered_server_for_idp(self, idp)
 
     def _server_selection_history(self) -> dict[str, str]:
         """Return remembered selections seeded with the current active pair."""
-        from canfar.config.selection import server_selection_history  # noqa: PLC0415
-
-        return server_selection_history(self)
+        return _server_selection_history(self)
 
     def set_active_selection(self, idp: str, server: Server) -> None:
         """Persist ``idp`` and ``server`` as the active pair.
@@ -360,9 +360,7 @@ class Configuration(BaseSettings):
         Raises:
             ValueError: If the server has no Server Name.
         """
-        from canfar.config.selection import set_active_selection  # noqa: PLC0415
-
-        set_active_selection(self, idp, server)
+        _set_active_selection(self, idp, server)
 
     def with_active_selection(self, idp: str, server: Server) -> Configuration:
         """Return a copy using ``idp`` and ``server`` as the active pair.
@@ -378,9 +376,7 @@ class Configuration(BaseSettings):
         Raises:
             ValueError: If the server has no Server Name.
         """
-        from canfar.config.selection import with_active_selection  # noqa: PLC0415
-
-        return with_active_selection(self, idp, server)
+        return _with_active_selection(self, idp, server)
 
     @property
     def context(self) -> AuthContext:
@@ -389,16 +385,12 @@ class Configuration(BaseSettings):
         Returns:
             Legacy ``OIDC`` or ``X509`` model with embedded active server.
         """
-        from canfar.config.selection import active_context  # noqa: PLC0415
-
-        return active_context(self)
+        return _active_context(self)
 
     @property
     def contexts(self) -> LegacyContextsMapping:
         """Return a legacy dict-like view keyed by IDP."""
-        from canfar.config.selection import legacy_contexts  # noqa: PLC0415
-
-        return legacy_contexts(self)
+        return _legacy_contexts(self)
 
     def set_legacy_context(self, idp: str, context: AuthContext) -> None:
         """Update saved authentication (and optional server) from legacy context.
@@ -407,15 +399,11 @@ class Configuration(BaseSettings):
             idp: Canonical identity provider key.
             context: Legacy ``AuthContext`` view to persist.
         """
-        from canfar.config.selection import set_legacy_context  # noqa: PLC0415
-
-        set_legacy_context(self, idp, context)
+        _set_legacy_context(self, idp, context)
 
     def _upsert_server(self, server: Server) -> None:
         """Insert or replace a server record keyed by Server Name."""
-        from canfar.config.selection import upsert_server  # noqa: PLC0415
-
-        upsert_server(self, server)
+        _upsert_server(self, server)
 
 
 __all__ = ["CONFIG_PATH", "AuthContext", "Configuration", "ConsoleConfig"]

--- a/canfar/models/config_compat.py
+++ b/canfar/models/config_compat.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, TypeAlias
 
 from canfar.models.auth import (
@@ -74,13 +75,30 @@ def legacy_context_to_credential(
     )
 
 
-class LegacyContextsMapping:
-    """Dict-like view over authentication records keyed by IDP."""
+class LegacyContextsMapping(Mapping[str, "AuthContext"]):
+    """Dict-like view over authentication records keyed by IDP.
+
+    Subclasses :class:`collections.abc.Mapping`, so only ``__getitem__``,
+    ``__iter__``, and ``__len__`` are implemented here; the mixin derives
+    ``keys``, ``items``, ``values``, and ``__eq__``.
+
+    ``__contains__`` is overridden to report direct membership in the saved
+    authentication records, preserving the pre-refactor semantics: an IDP is
+    a member when it has a saved credential, even if its legacy context is not
+    currently resolvable (e.g. no matching server). The ``Mapping`` mixin's
+    default ``__contains__`` would instead probe ``__getitem__`` and report
+    ``False`` for such an IDP.
+
+    ``__setitem__`` is kept as an extra mutation hook used by the httpx auth
+    refresh hooks, which the read-only base does not provide. ``.get()`` is
+    inherited from the mixin and resolves through ``__getitem__``, so it
+    returns its default for an IDP whose context cannot be reconstructed.
+    """
 
     def __init__(self, configuration: Configuration) -> None:
         self._configuration = configuration
 
-    def __contains__(self, key: str) -> bool:
+    def __contains__(self, key: object) -> bool:
         """Return whether ``key`` is a saved authentication IDP."""
         return key in self._configuration.authentication
 
@@ -96,21 +114,7 @@ class LegacyContextsMapping:
 
     def __iter__(self) -> Iterator[str]:
         """Iterate saved authentication IDP keys."""
-        return iter(self.keys())
-
-    def keys(self) -> list[str]:
-        """Return saved authentication IDP keys."""
-        return list(self._configuration.authentication)
-
-    def items(self) -> Iterator[tuple[str, AuthContext]]:
-        """Yield ``(idp, legacy_context)`` pairs."""
-        for key in self.keys():
-            yield key, self[key]
-
-    def values(self) -> Iterator[AuthContext]:
-        """Yield legacy auth contexts in IDP key order."""
-        for key in self.keys():
-            yield self[key]
+        return iter(self._configuration.authentication)
 
     def __len__(self) -> int:
         """Return the number of saved authentication records."""

--- a/canfar/models/config_compat.py
+++ b/canfar/models/config_compat.py
@@ -47,7 +47,7 @@ def credential_to_legacy_context(
         client=credential.client,
         token=credential.token,
         expiry=credential.expiry,
-        server=server,
+        server=server,  # ty: ignore[invalid-argument-type]
     )
 
 

--- a/canfar/models/http.py
+++ b/canfar/models/http.py
@@ -180,7 +180,7 @@ class Server(BaseSettings):
         from canfar.models.config import Configuration  # noqa: PLC0415
 
         base_url = self._require_fetch_base_url()
-        runtime_config = config or Configuration()
+        runtime_config = config or Configuration()  # ty: ignore[missing-argument]
         if timeout is None:
             client = HTTPClient(
                 config=runtime_config,
@@ -211,7 +211,7 @@ class Server(BaseSettings):
         from canfar.models.config import Configuration  # noqa: PLC0415
 
         base_url = self._require_fetch_base_url()
-        runtime_config = config or Configuration()
+        runtime_config = config or Configuration()  # ty: ignore[missing-argument]
         if timeout is None:
             client = HTTPClient(
                 config=runtime_config,

--- a/canfar/server.py
+++ b/canfar/server.py
@@ -105,7 +105,7 @@ def discover(
     Raises:
         ServerDiscoveryError: If discovery fails or finds no usable servers.
     """
-    target_config = config or Configuration()
+    target_config = config or Configuration()  # ty: ignore[missing-argument]
     discovered = asyncio.run(_discover_for_idp(idp, dev=dev, timeout=timeout))
     if not discovered:
         msg = f"No servers discovered for IDP '{idp}'."
@@ -151,7 +151,7 @@ def activate(
         ServerDiscoveryError: If discovery fails before usable data is produced.
         ServerFetchError: If fetch or validation fails before save.
     """
-    target_config = config or Configuration()
+    target_config = config or Configuration()  # ty: ignore[missing-argument]
     reason: Literal["active", "remembered", "single", "selected"]
     if selector is None:
         active_server = _active_server_for_idp(target_config, idp)
@@ -232,7 +232,7 @@ def list_servers(
     Raises:
         ServerDiscoveryError: If discovery fails before usable data is produced.
     """
-    config = Configuration()
+    config = Configuration()  # ty: ignore[missing-argument]
     active_idp = config.active.authentication
     servers = [server for server in config.servers.values() if server.idp == active_idp]
     if servers or not discover_if_empty:
@@ -261,7 +261,7 @@ def use(selector: str, *, dev: bool = False, timeout: int = 2) -> None:
         ServerDiscoveryError: If discovery fails before usable data is produced.
         ServerFetchError: If fetch or validation fails before save.
     """
-    config = Configuration()
+    config = Configuration()  # ty: ignore[missing-argument]
     activate(
         config.active.authentication,
         selector,
@@ -508,7 +508,7 @@ def _validate_server(
         msg = "Server URL and version are required before activation."
         raise ServerFetchError(msg)
 
-    base_config = config or Configuration()
+    base_config = config or Configuration()  # ty: ignore[missing-argument]
     active_idp = idp or enriched.idp or base_config.active.authentication
     validation_config = with_active_selection(base_config, active_idp, enriched)
     return enriched.fetch(timeout=timeout, config=validation_config)

--- a/canfar/utils/build.py
+++ b/canfar/utils/build.py
@@ -29,7 +29,7 @@ def fetch_parameters(
     # Kind is an alias for type in the API.
     # It is renamed as kind to avoid conflicts with the built-in type function.
     # by_alias=true, returns, {"type": "headless"} instead of {"kind": "headless"}
-    return FetchRequest(kind=kind, status=status, view=view).model_dump(
+    return FetchRequest(kind=kind, status=status, view=view).model_dump(  # ty: ignore[unknown-argument]
         exclude_none=True, by_alias=True
     )
 

--- a/canfar/utils/console.py
+++ b/canfar/utils/console.py
@@ -24,7 +24,7 @@ def get_console() -> Console:
     Returns:
         Rich console instance sized from user configuration.
     """
-    cfg = Configuration()
+    cfg = Configuration()  # ty: ignore[missing-argument]
     return Console(width=cfg.console.width)
 
 
@@ -33,7 +33,7 @@ def emit_active_server_banner() -> None:
     if _banner_emitted.get():
         return
     _banner_emitted.set(True)
-    cfg = Configuration()
+    cfg = Configuration()  # ty: ignore[missing-argument]
     try:
         name = cfg.get_active_server().name
     except KeyError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ dependencies = [
 [dependency-groups]
 dev = [
     "ipython>=8.37.0",
-    "mypy>=1.15.0",
     "pre-commit>=4.2.0",
     "pytest>=8.3.5",
     "pytest-asyncio>=1.0.0",
@@ -72,9 +71,7 @@ dev = [
     "pytest-xdist>=3.7.0",
     "pytest-timeout>=2.4.0",
     "ruff>=0.11.11",
-    "types-defusedxml>=0.7.0.20250516",
-    "types-pyyaml>=6.0.12.20250516",
-    "types-toml>=0.10.8.20240310",
+    "ty>=0.0.51",
 ]
 docs = [
     "mike>=2.1.3",
@@ -106,7 +103,6 @@ exclude = [
     ".git",
     ".git-rewrite",
     ".hg",
-    ".mypy_cache",
     ".nox",
     ".pants.d",
     ".pytype",
@@ -230,33 +226,15 @@ line-ending = "auto"
 docstring-code-format = true
 docstring-code-line-length = "dynamic"
 
-# MyPy configuration
-[tool.mypy]
-python_version = "3.10"
-warn_return_any = true
-warn_unused_configs = true
-warn_redundant_casts = true
-warn_unused_ignores = true
-warn_no_return = true
-warn_unreachable = true
-check_untyped_defs = true
-disallow_any_generics = true
-disallow_incomplete_defs = true
-disallow_subclassing_any = true
-disallow_untyped_calls = true
-disallow_untyped_decorators = true
-disallow_untyped_defs = true
-ignore_missing_imports = false
-implicit_reexport = false
-no_implicit_optional = true
-extra_checks = true
-strict_equality = true
-strict_optional = true
-plugins = ["pydantic.mypy"]
+# ty configuration (replaces mypy)
+[tool.ty]
 
-[[tool.mypy.overrides]]
-module = ["tests.*"]
-ignore_errors = true
+[tool.ty.environment]
+python-version = "3.10"
+
+[tool.ty.src]
+# Limit type-checking to the shipped package; mirrors the former mypy scope.
+exclude = ["tests/", "docs/"]
 
 # Pytest configuration
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,6 @@ dependencies = [
 [tool.uv]
 [dependency-groups]
 dev = [
-    "bandit[toml]>=1.7.5",
     "ipython>=8.37.0",
     "mypy>=1.15.0",
     "pre-commit>=4.2.0",
@@ -76,7 +75,6 @@ dev = [
     "types-defusedxml>=0.7.0.20250516",
     "types-pyyaml>=6.0.12.20250516",
     "types-toml>=0.10.8.20240310",
-    "vulture>=2.11",
 ]
 docs = [
     "mike>=2.1.3",
@@ -328,17 +326,6 @@ directory = "htmlcov"
 
 [tool.coverage.xml]
 output = "coverage.xml"
-
-# Bandit security linter configuration
-[tool.bandit]
-exclude_dirs = ["tests", "venv", ".venv"]
-skips = ["B101", "B601"]  # Skip assert_used and shell_injection_process_function
-
-# Additional tool configurations for completeness
-[tool.vulture]
-min_confidence = 80
-paths = ["canfar", "tests"]
-exclude = ["venv/", ".venv/"]
 
 [tool.interrogate]
 ignore-init-method = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ dev = [
     "pytest-order>=1.3.0",
     "pytest-xdist>=3.7.0",
     "pytest-timeout>=2.4.0",
-    "respx>=0.22.0",
     "ruff>=0.11.11",
     "types-defusedxml>=0.7.0.20250516",
     "types-pyyaml>=6.0.12.20250516",

--- a/tests/test_cli_dead_modules.py
+++ b/tests/test_cli_dead_modules.py
@@ -1,0 +1,33 @@
+"""Characterization tests guarding the dead-module cleanup (issue #137).
+
+Two empty placeholder modules (``canfar/cli/run.py`` and ``canfar/cli/alias.py``)
+are removed by this cleanup. Neither is imported anywhere; the ``run``/``launch``
+and ``del`` CLI aliases are wired in :mod:`canfar.cli.main` via the
+:class:`~canfar.hooks.typer.aliases.AliasGroup`, not by those files. These tests
+pin both invariants so the deletion cannot silently regress the alias feature.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+from typer.testing import CliRunner
+
+from canfar.cli.main import cli
+
+runner = CliRunner()
+
+
+@pytest.mark.parametrize("module", ["canfar.cli.run", "canfar.cli.alias"])
+def test_dead_cli_module_is_absent(module: str) -> None:
+    """The empty placeholder modules must not be importable after cleanup."""
+    assert importlib.util.find_spec(module) is None
+
+
+@pytest.mark.parametrize("alias", ["run", "launch", "del"])
+def test_cli_aliases_still_resolve(alias: str) -> None:
+    """The ``run``/``launch``/``del`` aliases keep resolving through the app."""
+    result = runner.invoke(cli, [alias, "--help"])
+    assert result.exit_code == 0
+    assert "Usage" in result.stdout

--- a/tests/test_cli_runner.py
+++ b/tests/test_cli_runner.py
@@ -1,0 +1,29 @@
+"""Tests for the shared CLI async-runner helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from canfar.cli._run import run
+
+
+def test_run_executes_coroutine_and_returns_result() -> None:
+    """The runner drives a coroutine to completion and returns its value."""
+
+    async def _coro() -> str:
+        """Return a sentinel value."""
+        return "done"
+
+    assert run(_coro()) == "done"
+
+
+def test_run_propagates_coroutine_exception() -> None:
+    """Exceptions raised inside the coroutine surface to the caller."""
+
+    async def _coro() -> None:
+        """Raise to exercise exception propagation."""
+        message = "boom"
+        raise RuntimeError(message)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        run(_coro())

--- a/tests/test_cli_stats_ps.py
+++ b/tests/test_cli_stats_ps.py
@@ -314,6 +314,35 @@ def test_stats_outputs_cluster_tables() -> None:
     session_cls.assert_called_once_with(loglevel="DEBUG")
 
 
+def test_stats_renders_only_cpu_and_ram_columns() -> None:
+    """Pin that ``canfar stats`` shows CPU/RAM but never the Instances column.
+
+    The Instances column is intentionally not rendered; this characterization
+    test guards that removing the disabled inline code leaves the human output
+    unchanged, i.e. no per-instance labels or counts leak into stdout.
+    """
+    with patch("canfar.cli.stats.AsyncSession") as session_cls:
+        session = _mock_async_session(session_cls)
+        session.stats.return_value = {
+            "instances": {"desktopApp": 2, "notebook": 3, "total": 5},
+            "cores": {"requestedCPUCores": 4, "cpuCoresAvailable": 64},
+            "ram": {"requestedRAM": "8Gi", "ramAvailable": "128Gi"},
+        }
+        result = runner.invoke(stats, ["--debug"])
+
+    assert result.exit_code == 0
+    # The CPU/RAM table and its values are rendered.
+    assert "CPU" in result.stdout
+    assert "RAM" in result.stdout
+    assert "64" in result.stdout
+    assert "128Gi" in result.stdout
+    # The Instances column/data is not rendered (dead UI code).
+    assert "Instances" not in result.stdout
+    assert "Notebook" not in result.stdout
+    assert "Desktop" not in result.stdout
+    assert "desktopApp" not in result.stdout
+
+
 @pytest.mark.slow
 def test_stats_command_integration() -> None:
     """Test stats command integration (may fail without proper auth/config)."""

--- a/tests/test_hooks_httpx_auth.py
+++ b/tests/test_hooks_httpx_auth.py
@@ -191,3 +191,90 @@ class TestAsyncHook:
 
         with pytest.raises(AuthenticationError, match="Failed to refresh OIDC token"):
             await hook_func(request)
+
+
+class TestSyncAsyncParity:
+    """Characterization tests: sync and async auth hooks share guard behavior."""
+
+    @patch("canfar.auth.oidc.sync_refresh")
+    @patch("canfar.auth.oidc.refresh")
+    async def test_refresh_and_arefresh_both_skip_non_oidc(
+        self,
+        mock_async_refresh,
+        mock_sync_refresh,
+        tmp_path,
+    ) -> None:
+        """Both refresh and arefresh skip when the Authentication Record is not OIDC."""
+        cert_path = tmp_path / "cert.pem"
+        generate_cert(cert_path)
+        x509_context = X509(
+            server=Server(
+                name="TestX509", url="https://x509.example.com", version="v0"
+            ),
+            path=cert_path,
+        )
+        config = configuration_from_legacy_context("TestX509", x509_context)
+        client = HTTPClient(config=config)
+        request = httpx.Request("GET", "/")
+
+        refresh(client)(request)
+        mock_sync_refresh.assert_not_called()
+
+        await arefresh(client)(request)
+        mock_async_refresh.assert_not_called()
+
+    @patch("canfar.auth.oidc.sync_refresh")
+    @patch("canfar.auth.oidc.refresh")
+    async def test_ctx_valid_guard_divergence(
+        self,
+        mock_async_refresh,
+        mock_sync_refresh,
+    ) -> None:
+        """Pin the documented ctx.valid sync/async divergence.
+
+        The sync ``refresh`` hook short-circuits via ``if not ctx.valid`` when the OIDC
+        context is missing required fields (e.g., no discovery endpoint), so it never
+        calls the underlying network refresh.  The async ``arefresh`` hook has no such
+        guard and proceeds to attempt the token refresh even when ctx.valid is False.
+
+        This is the invariant referenced in AC#2: the two hooks deliberately differ here
+        and that asymmetry must be preserved.
+        """
+        # Build an OIDC context that is:
+        #  - expired (so both hooks reach the ctx.valid / refresh-token guard)
+        #  - ctx.valid == False because the discovery endpoint is absent
+        #  - refresh token and client secret ARE present (so arefresh proceeds to call)
+        oidc_context = OIDC(
+            server=Server(
+                name="TestOIDC", url="https://oidc.example.com", version="v1"
+            ),
+            endpoints={
+                # discovery intentionally absent — makes ctx.valid False
+                "token": "https://oidc.example.com/token",
+            },
+            client={"identity": "test-client", "secret": "test-secret"},
+            token={"access": "expired-token", "refresh": "valid-refresh-token"},
+            expiry={
+                "access": time.time() - 60,  # expired
+                "refresh": time.time() + 3600,  # refresh token still valid
+            },
+        )
+        config = configuration_from_legacy_context("TestOIDC", oidc_context)
+        client = HTTPClient(config=config)
+        # Mock httpx clients so header updates don't error
+        client._client = Mock(spec=httpx.Client, headers={})  # noqa: SLF001
+        client._asynclient = Mock(spec=httpx.AsyncClient, headers={})  # noqa: SLF001
+        request = httpx.Request("GET", "/")
+
+        # Sync hook: exits early at the ctx.valid guard — sync_refresh never called
+        refresh(client)(request)
+        mock_sync_refresh.assert_not_called()
+
+        # Async hook: no ctx.valid guard — proceeds and calls oidc.refresh
+        mock_async_refresh.return_value = SecretStr("new-token")
+        with (
+            patch("canfar.models.config.Configuration.save"),
+            patch("canfar.utils.jwt.expiry", return_value=time.time() + 3600),
+        ):
+            await arefresh(client)(request)
+        mock_async_refresh.assert_called_once()

--- a/tests/test_hooks_httpx_error.py
+++ b/tests/test_hooks_httpx_error.py
@@ -1,11 +1,11 @@
+"""Tests for httpx error hooks."""
+
 from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 import pytest
 
 from canfar.hooks.httpx.errors import acatch, catch
-
-"""Tests for httpx error hooks."""
 
 
 class TestCatch:
@@ -79,6 +79,25 @@ class TestCatch:
         # Verify response.read() was called
         mock_response.read.assert_called_once()
         mock_response.raise_for_status.assert_called_once()
+
+    def test_catch_read_raises_warning_logged(self) -> None:
+        """ReadTimeout from response.read() during body download is warning-logged.
+
+        ``catch`` wraps both ``response.read()`` and ``response.raise_for_status()``
+        inside ``_error_handling``, so a body-download ``ReadTimeout`` is caught
+        by the shared except ladder and warning-logged before re-raising.
+        """
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.read.side_effect = httpx.ReadTimeout("body download timed out")
+
+        with (
+            patch("canfar.hooks.httpx.errors.log") as mock_log,
+            pytest.raises(httpx.ReadTimeout),
+        ):
+            catch(mock_response)
+
+        mock_log.warning.assert_called_once()
+        mock_response.raise_for_status.assert_not_called()
 
 
 class TestACatch:
@@ -154,3 +173,47 @@ class TestACatch:
         # Verify response.aread() was called
         mock_response.aread.assert_called_once()
         mock_response.raise_for_status.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_acatch_redacts_bearer_token_in_error_body(self) -> None:
+        """Async HTTP status logs redact bearer tokens from response bodies."""
+        request = httpx.Request("GET", "https://example.com/skaha/v1/context")
+        response = httpx.Response(
+            401,
+            request=request,
+            text="unhandled auth: Authorization Bearer abc.def.ghi",
+        )
+
+        with (
+            patch("canfar.hooks.httpx.errors.log") as log,
+            pytest.raises(httpx.HTTPStatusError),
+        ):
+            await acatch(response)
+
+        error_text = " ".join(str(arg) for arg in log.warning.call_args.args)
+        assert "abc.def.ghi" not in error_text
+        assert "Authorization Bearer <redacted>" in error_text
+        assert log.warning.call_args.kwargs["exc_info"] is False
+
+    @pytest.mark.asyncio
+    async def test_acatch_aread_raises_warning_logged(self) -> None:
+        """ReadTimeout from aread() during body download is warning-logged.
+
+        ``acatch`` wraps both ``await response.aread()`` and
+        ``response.raise_for_status()`` inside ``_error_handling``, so a
+        body-download ``ReadTimeout`` is caught by the shared except ladder
+        and warning-logged before re-raising.
+        """
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.aread = AsyncMock(
+            side_effect=httpx.ReadTimeout("body download timed out")
+        )
+
+        with (
+            patch("canfar.hooks.httpx.errors.log") as mock_log,
+            pytest.raises(httpx.ReadTimeout),
+        ):
+            await acatch(mock_response)
+
+        mock_log.warning.assert_called_once()
+        mock_response.raise_for_status.assert_not_called()

--- a/tests/test_hooks_httpx_expiry.py
+++ b/tests/test_hooks_httpx_expiry.py
@@ -1,6 +1,7 @@
 """Tests for the HTTPx expiry hooks."""
 
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import Mock
 
 import httpx
@@ -281,3 +282,44 @@ class TestACheck:
 
         with pytest.raises(AuthExpiredError):
             await hook_func(request)
+
+
+class TestSyncAsyncParity:
+    """Characterization tests: sync and async hooks must behave identically."""
+
+    def test_check_and_acheck_share_no_state(self) -> None:
+        """The check and acheck factories return independent callables."""
+        mock_client = Mock()
+        mock_client.uses_runtime_credentials = False
+        mock_client.config.context.expired = False
+
+        hook_sync = check(mock_client)
+        hook_async = acheck(mock_client)
+        assert hook_sync is not hook_async
+
+    @pytest.mark.anyio
+    async def test_acheck_and_check_raise_same_error_for_expired(self) -> None:
+        """Async and sync hooks raise AuthExpiredError with identical message."""
+
+        class Context:
+            mode = "x509"
+
+            @property
+            def expired(self) -> bool:
+                return True
+
+        def _ns() -> Any:
+            return SimpleNamespace(
+                config=SimpleNamespace(context=Context()),
+                uses_runtime_credentials=False,
+            )
+
+        request = httpx.Request("GET", "https://example.com")
+
+        with pytest.raises(AuthExpiredError, match="auth expired") as sync_exc:
+            check(_ns())(request)
+
+        with pytest.raises(AuthExpiredError, match="auth expired") as async_exc:
+            await acheck(_ns())(request)
+
+        assert str(sync_exc.value) == str(async_exc.value)

--- a/tests/test_import_isolation.py
+++ b/tests/test_import_isolation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import os
 import subprocess
 import sys
@@ -59,3 +60,74 @@ import canfar  # noqa: F401
 
     assert result.returncode != 0
     assert "ValidationError" in result.stderr
+
+
+def _function_local_imports(source: str) -> list[tuple[str, str]]:
+    """Return (function_name, module) pairs for every function-local import."""
+    tree = ast.parse(source)
+    results: list[tuple[str, str]] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for child in ast.walk(node):
+            if child is node:
+                continue
+            if isinstance(child, ast.Import):
+                results.extend((node.name, alias.name) for alias in child.names)
+            elif isinstance(child, ast.ImportFrom):
+                module = child.module or ""
+                results.append((node.name, module))
+    return results
+
+
+def test_no_function_local_selection_imports_in_models_config() -> None:
+    """No function-local imports from ``config.selection`` in ``models/config.py``.
+
+    The import cycle between ``canfar.models.config`` and
+    ``canfar.config.selection`` must be broken: all ``selection`` imports
+    belong at module level in ``models/config.py``.
+    """
+    config_source = Path("canfar/models/config.py").read_text(encoding="utf-8")
+    local_imports = _function_local_imports(config_source)
+
+    offenders = [
+        (fn, mod) for fn, mod in local_imports if "canfar.config.selection" in mod
+    ]
+    assert offenders == [], (
+        f"Function-local selection imports found in models/config.py: {offenders}"
+    )
+
+
+def test_no_function_local_editor_imports_in_models_config() -> None:
+    """No function-local imports from ``config.editor`` in ``models/config.py``."""
+    config_source = Path("canfar/models/config.py").read_text(encoding="utf-8")
+    local_imports = _function_local_imports(config_source)
+
+    offenders = [
+        (fn, mod) for fn, mod in local_imports if "canfar.config.editor" in mod
+    ]
+    assert offenders == [], (
+        f"Function-local editor imports found in models/config.py: {offenders}"
+    )
+
+
+def test_selection_importable_before_config() -> None:
+    """``canfar.config.selection`` can be imported before ``canfar.models.config``."""
+    script = """
+import sys
+# Clear any cached canfar modules
+for k in list(sys.modules.keys()):
+    if "canfar" in k:
+        del sys.modules[k]
+
+import canfar.config.selection  # noqa: F401
+import canfar.models.config  # noqa: F401
+"""
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_models_config_compat.py
+++ b/tests/test_models_config_compat.py
@@ -1,0 +1,239 @@
+"""Characterization tests for the legacy auth-context compatibility mapping.
+
+These pin the externally observable dict-like behavior of
+``LegacyContextsMapping`` so a refactor onto ``collections.abc.Mapping``
+preserves every contract callers rely on.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping
+
+from pydantic import SecretStr
+
+from canfar.models.active import ActiveConfig
+from canfar.models.auth import OIDC, X509, OIDCCredential
+from canfar.models.config import Configuration
+from canfar.models.config_compat import LegacyContextsMapping
+from canfar.models.http import Server
+from tests.helpers.config import configuration_from_legacy_context
+
+
+def _oidc_context(name: str = "TestOIDC") -> OIDC:
+    """Build a valid legacy OIDC context with an embedded server."""
+    return OIDC(
+        server=Server(name=name, url="https://oidc.example.com", version="v1"),
+        endpoints={
+            "discovery": "https://oidc.example.com/.well-known/openid-configuration",
+            "token": "https://oidc.example.com/token",
+        },
+        client={"identity": "test-client", "secret": "test-secret"},
+        token={"access": "access-token", "refresh": "refresh-token"},
+        expiry={"access": time.time() + 3600, "refresh": time.time() + 7200},
+    )
+
+
+def _config_with_oidc(name: str = "TestOIDC") -> Configuration:
+    """Return a configuration carrying a single saved OIDC credential."""
+    return configuration_from_legacy_context(name, _oidc_context(name))
+
+
+def _config_with_credential_without_server(idp: str = "orphan") -> Configuration:
+    """Return a configuration whose IDP has a credential but no server.
+
+    The IDP is recorded in ``authentication`` yet no saved server matches it,
+    so ``get_server_for_idp`` raises and the legacy context cannot be
+    reconstructed. This reproduces the membership edge case where a saved
+    authentication record has no resolvable science platform server.
+    """
+    credential = OIDCCredential(
+        idp=idp,
+        endpoints={
+            "discovery": "https://oidc.example.com/.well-known/openid-configuration",
+            "token": "https://oidc.example.com/token",
+        },
+        client={"identity": "test-client", "secret": "test-secret"},
+        token={"access": "access-token", "refresh": "refresh-token"},
+        expiry={"access": time.time() + 3600, "refresh": time.time() + 7200},
+    )
+    return Configuration(
+        active=ActiveConfig(authentication=idp, server=None),
+        authentication={idp: credential},
+        servers={},
+    )
+
+
+class TestLegacyContextsMapping:
+    """Pin the dict-like contract of the legacy contexts view."""
+
+    def test_is_a_mapping(self) -> None:
+        """The view satisfies the read-only Mapping protocol."""
+        config = _config_with_oidc()
+        assert isinstance(config.contexts, Mapping)
+
+    def test_getitem_returns_legacy_context(self) -> None:
+        """Indexing by IDP returns a reconstructed legacy context."""
+        config = _config_with_oidc()
+        idp = config.active.authentication
+
+        context = config.contexts[idp]
+
+        assert isinstance(context, OIDC)
+        assert context.server is not None
+        assert context.token is not None
+        assert context.token.access is not None
+        assert context.token.access.get_secret_value() == "access-token"
+
+    def test_contains_true_and_false(self) -> None:
+        """Membership reflects saved authentication IDP keys."""
+        config = _config_with_oidc()
+        idp = config.active.authentication
+
+        assert idp in config.contexts
+        assert "missing-idp" not in config.contexts
+
+    def test_keys_match_saved_authentication(self) -> None:
+        """``keys()`` returns exactly the saved authentication IDP keys."""
+        config = _config_with_oidc()
+
+        assert list(config.contexts.keys()) == list(config.authentication)
+
+    def test_iter_yields_keys(self) -> None:
+        """Iterating the mapping yields the IDP keys in key order."""
+        config = _config_with_oidc()
+
+        assert list(iter(config.contexts)) == list(config.authentication)
+
+    def test_len_matches_saved_authentication(self) -> None:
+        """``len()`` matches the number of saved authentication records."""
+        config = _config_with_oidc()
+
+        assert len(config.contexts) == len(config.authentication)
+
+    def test_items_pairs_keys_and_contexts(self) -> None:
+        """``items()`` yields ``(idp, context)`` pairs for every key."""
+        config = _config_with_oidc()
+
+        items = dict(config.contexts.items())
+
+        assert list(items) == list(config.authentication)
+        for key, context in items.items():
+            assert isinstance(context, OIDC)
+            assert context == config.contexts[key]
+
+    def test_values_yield_contexts(self) -> None:
+        """``values()`` yields the legacy contexts in key order."""
+        config = _config_with_oidc()
+
+        values = list(config.contexts.values())
+
+        assert [type(v) for v in values] == [OIDC]
+        assert values == [config.contexts[k] for k in config.authentication]
+
+    def test_dict_roundtrip_via_mapping_protocol(self) -> None:
+        """``dict(view)`` reconstructs the full key/context mapping."""
+        config = _config_with_oidc()
+
+        as_dict = dict(config.contexts)
+
+        assert list(as_dict) == list(config.authentication)
+        assert (
+            as_dict[config.active.authentication]
+            == (config.contexts[config.active.authentication])
+        )
+
+    def test_setitem_persists_context(self) -> None:
+        """Assigning a context updates the underlying configuration.
+
+        This is the mutation path used by the httpx auth refresh hooks
+        (``client.config.contexts[idp] = context``) and must survive the
+        switch to a read-only ``Mapping`` base.
+        """
+        config = _config_with_oidc()
+        idp = config.active.authentication
+        original = config.contexts[idp]
+
+        updated = original.model_copy(
+            update={
+                "token": original.token.model_copy(
+                    update={"access": SecretStr("rotated-access-token")}
+                )
+            }
+        )
+        config.contexts[idp] = updated
+
+        roundtrip = config.contexts[idp]
+        assert roundtrip.token is not None
+        access = roundtrip.token.access
+        assert access is not None
+        recovered = (
+            access.get_secret_value() if isinstance(access, SecretStr) else access
+        )
+        assert recovered == "rotated-access-token"
+
+
+class TestCredentialWithoutServer:
+    """Pin the contract for a saved credential whose IDP has no server.
+
+    For such an IDP, ``__getitem__`` raises ``KeyError`` because the legacy
+    context cannot be reconstructed without a server. These tests pin the
+    two contracts that this edge case exposes:
+
+    * ``__contains__`` is overridden to report direct membership in the
+      saved authentication records, so ``idp in contexts`` stays ``True``
+      exactly as on the pre-refactor class (an IDP can be a member even
+      when its context is not currently resolvable).
+    * ``.get()`` is supplied by the ``Mapping`` mixin and resolves through
+      ``__getitem__``, so it returns its default for an unresolvable IDP
+      rather than the value.
+    """
+
+    def test_orphan_idp_is_a_member(self) -> None:
+        """An IDP with a credential but no server is still a member."""
+        config = _config_with_credential_without_server()
+
+        assert "orphan" in config.contexts
+
+    def test_orphan_idp_not_a_member_when_absent(self) -> None:
+        """Membership stays ``False`` for an IDP with no saved credential."""
+        config = _config_with_credential_without_server()
+
+        assert "definitely-missing" not in config.contexts
+
+    def test_orphan_idp_getitem_raises_key_error(self) -> None:
+        """Indexing an unresolvable IDP raises ``KeyError`` (no server)."""
+        config = _config_with_credential_without_server()
+
+        try:
+            config.contexts["orphan"]
+        except KeyError:
+            pass
+        else:  # pragma: no cover - failure path
+            msg = "expected KeyError for credential-without-server IDP"
+            raise AssertionError(msg)
+
+    def test_orphan_idp_get_returns_default(self) -> None:
+        """``.get()`` returns its default for an unresolvable IDP."""
+        config = _config_with_credential_without_server()
+        sentinel = object()
+
+        assert config.contexts.get("orphan", sentinel) is sentinel
+
+    def test_orphan_idp_is_counted_and_iterated(self) -> None:
+        """The orphan IDP key participates in iteration and length."""
+        config = _config_with_credential_without_server()
+
+        assert "orphan" in list(config.contexts)
+        assert len(config.contexts) == len(config.authentication)
+
+
+def test_constructed_directly_over_configuration() -> None:
+    """The mapping can be built directly over a configuration instance."""
+    config = _config_with_oidc("DirectOIDC")
+    mapping = LegacyContextsMapping(config)
+
+    assert isinstance(mapping, Mapping)
+    assert len(mapping) == 1
+    (key,) = list(mapping)
+    assert isinstance(mapping[key], (OIDC, X509))

--- a/tests/test_pyproject_toolchain.py
+++ b/tests/test_pyproject_toolchain.py
@@ -1,0 +1,39 @@
+"""Invariant: mypy is gone, ty is configured in pyproject.toml."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import toml
+
+_PYPROJECT = Path(__file__).parent.parent / "pyproject.toml"
+
+
+def _load() -> dict[str, object]:
+    with _PYPROJECT.open() as f:
+        return toml.load(f)
+
+
+def test_mypy_config_absent() -> None:
+    """The [tool.mypy] section must not exist after migrating to ty."""
+    data = _load()
+    assert "mypy" not in data.get("tool", {}), (
+        "[tool.mypy] still present in pyproject.toml; migration to ty is incomplete."
+    )
+
+
+def test_ty_config_present() -> None:
+    """A [tool.ty] section must exist after migrating from mypy."""
+    data = _load()
+    assert "ty" in data.get("tool", {}), (
+        "[tool.ty] missing from pyproject.toml; ty is not configured."
+    )
+
+
+def test_mypy_dev_dependency_absent() -> None:
+    """Mypy must not appear in [dependency-groups.dev] after the toolchain swap."""
+    data = _load()
+    dev_deps: list[str] = data.get("dependency-groups", {}).get("dev", [])
+    assert not any(dep.startswith("mypy") for dep in dev_deps), (
+        "mypy still listed as a dev dependency."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -192,7 +192,6 @@ dev = [
     { name = "pytest-order" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
-    { name = "respx" },
     { name = "ruff" },
     { name = "types-defusedxml" },
     { name = "types-pyyaml" },
@@ -238,7 +237,6 @@ dev = [
     { name = "pytest-order", specifier = ">=1.3.0" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = ">=3.7.0" },
-    { name = "respx", specifier = ">=0.22.0" },
     { name = "ruff", specifier = ">=0.11.11" },
     { name = "types-defusedxml", specifier = ">=0.7.0.20250516" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250516" },
@@ -2135,18 +2133,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
-]
-
-[[package]]
-name = "respx"
-version = "0.23.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "httpx" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -121,26 +121,6 @@ wheels = [
 ]
 
 [[package]]
-name = "bandit"
-version = "1.9.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "pyyaml" },
-    { name = "rich" },
-    { name = "stevedore" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
-]
-
-[package.optional-dependencies]
-toml = [
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-]
-
-[[package]]
 name = "cadcutils"
 version = "1.5.5"
 source = { registry = "https://pypi.org/simple" }
@@ -180,7 +160,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "bandit", extra = ["toml"] },
     { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ipython", version = "9.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "mypy" },
@@ -196,7 +175,6 @@ dev = [
     { name = "types-defusedxml" },
     { name = "types-pyyaml" },
     { name = "types-toml" },
-    { name = "vulture" },
 ]
 docs = [
     { name = "mike" },
@@ -226,7 +204,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "bandit", extras = ["toml"], specifier = ">=1.7.5" },
     { name = "ipython", specifier = ">=8.37.0" },
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
@@ -241,7 +218,6 @@ dev = [
     { name = "types-defusedxml", specifier = ">=0.7.0.20250516" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250516" },
     { name = "types-toml", specifier = ">=0.10.8.20240310" },
-    { name = "vulture", specifier = ">=2.11" },
 ]
 docs = [
     { name = "mike", specifier = ">=2.1.3" },
@@ -2233,15 +2209,6 @@ wheels = [
 ]
 
 [[package]]
-name = "stevedore"
-version = "5.8.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e9/88/35e4d27d9177d7df76d060e0a18f69c6c5794c96960c94042e20a12c8ba2/stevedore-5.8.0.tar.gz", hash = "sha256:b49867b32ca3016e94100e68dbf26e72aa7b8708d0a3f73c08aeb220370ac715", size = 514710, upload-time = "2026-05-18T09:15:27.731Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl", hash = "sha256:88eede9e66ca80e34085b9174e2327da2c61ac91f24f70e41c3ad76e4bb4872b", size = 54553, upload-time = "2026-05-18T09:15:25.82Z" },
-]
-
-[[package]]
 name = "termynal"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2429,18 +2396,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e1/0d/4e93c8e6d1001a75763f87d8f5ecda8ebc7f4aa2153dddfaf4ae8892821a/virtualenv-21.4.2.tar.gz", hash = "sha256:38e6ee0a555615c0ea9da2ac7e9998fe8dc3b911dd33ad8eaad2020957653b0c", size = 7613326, upload-time = "2026-05-31T17:01:22.827Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/c4/557dc082be035381b85fdb2b74e21d3d21b57750b74f2b47a32f3a639ff9/virtualenv-21.4.2-py3-none-any.whl", hash = "sha256:854210ca524a1a4d0d744734f4acbc721c3ffe163b85bbf5d56d14d5ae2f0fae", size = 7594079, upload-time = "2026-05-31T17:01:20.735Z" },
-]
-
-[[package]]
-name = "vulture"
-version = "2.16"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/66/3e/4d08c5903b2c0c70cad583c170cc4a663fc6a61e2ad00b711fcda61358cd/vulture-2.16.tar.gz", hash = "sha256:f8d9f6e2af03011664a3c6c240c9765b3f392917d3135fddca6d6a68d359f717", size = 52680, upload-time = "2026-03-25T14:41:27.141Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/be/f935130312330614811dae2ea9df3f395f6d63889eb6c2e68c14507152ee/vulture-2.16-py3-none-any.whl", hash = "sha256:6e0f1c312cef1c87856957e5c2ca9608834a7c794c2180477f30bf0e4cc58eee", size = 26993, upload-time = "2026-03-25T14:41:26.21Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -41,46 +41,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ast-serialize"
-version = "0.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/9d/09e27731bd5864a9ce04e3244074e674bb8936bf62b45e0357248717adac/ast_serialize-0.5.0.tar.gz", hash = "sha256:5880091bfe6f4f986f22866375c2e884843e7a0b6343ae41aeea659613d879b6", size = 61157, upload-time = "2026-05-17T17:48:29.429Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/9a/13dde51ba9e15f8b97957ab7cb0120d0e381524d651c6bd630b9c359227f/ast_serialize-0.5.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8f5c14f169eb0972c0c21bada5358b23d6047c76583b005234f865b11f1fa00a", size = 1183520, upload-time = "2026-05-17T17:47:30.831Z" },
-    { url = "https://files.pythonhosted.org/packages/37/de/5a7f0a9fe68944f536632a5af84676739c7d2582be42deb082634bf3a754/ast_serialize-0.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7d1a2de9de5be04652f0ed60738356ef94f66db37924a9499fffe98dc491aa0b", size = 1175779, upload-time = "2026-05-17T17:47:32.551Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/81/0bb853e76e4f6e9a1855d569003c59e19ffac45f7079d91505d1bb212f92/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be5173fb66f9b49026d9d5a2ff0fc7c7009077107c0eb285b2d60fdf1fe10bd1", size = 1233750, upload-time = "2026-05-17T17:47:34.731Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/d3/4cf705beeccc08754d0bbda99aefff26110e209b9a07ac8a6b60eec48531/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f8015cd071ac1339924ee2b8098c93e00e155f30a16f40ec9816fcf84f4753f6", size = 1235942, upload-time = "2026-05-17T17:47:36.287Z" },
-    { url = "https://files.pythonhosted.org/packages/26/c8/ee097e437ea27dd2b8b227865c875492b585650a5802a22d82b304c8201b/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5499e8797edff2a9186aa313ed382c6b422e798e9332d9953badcee6e69a88f2", size = 1442517, upload-time = "2026-05-17T17:47:38.17Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/bd/68063442838f1ba68ec72b5436430bc75b3bb17a1a3c3063f09b0c05ae2b/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6848f2a093fb5548751a9a09bff8fcd229e2bbeb0e3331f391b6ae6d26cd9903", size = 1254081, upload-time = "2026-05-17T17:47:39.826Z" },
-    { url = "https://files.pythonhosted.org/packages/50/e2/1e520793bc6a4e4524a6ab022391e827825eaa0c3811828bfdc6852eca26/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:832d4c998e0b091fd60a6d6bceee535483c4d490de9ba85003af835225719261", size = 1259910, upload-time = "2026-05-17T17:47:41.369Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/e1/49b60f467979979cfe6913b43948ff25bca971ad0591d181812f163a988e/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:16db7c62ec0b8efe1d7afd283a388d8f74f2605d56032e5a37747d2de8dba027", size = 1250678, upload-time = "2026-05-17T17:47:43.702Z" },
-    { url = "https://files.pythonhosted.org/packages/74/ba/66ab9555de6275677566f6574e5ef6c29cb185ea866f643bc06f8280a8ee/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:baf5eb061eb5bccade4128ad42da33787d72f6013809cd1b590376ece8b3c937", size = 1301603, upload-time = "2026-05-17T17:47:46.256Z" },
-    { url = "https://files.pythonhosted.org/packages/66/42/6aca9b9abc710014b2be9059689e5dd1679339e78f567ffb4d255a9e2050/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:104e4a35bd7c124173c41760ef9aaea17ddb3f86c65cb643671d59afbe3ee94c", size = 1410332, upload-time = "2026-05-17T17:47:47.899Z" },
-    { url = "https://files.pythonhosted.org/packages/47/68/2f76594432a22581ecf878b5e75a9b8601c24b2241cf0bbeb1e21fcf370c/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:36be371028fc1675acb38a331bde160dbab7ff907fdf00b67eb6911aa106951b", size = 1509979, upload-time = "2026-05-17T17:47:50.942Z" },
-    { url = "https://files.pythonhosted.org/packages/40/ac/a93c9b58292653f6c595752f677a08e608f903b710594909e9231a389b3b/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:061ee58bdb52341c8201a6df41182a977736bae3b7ded87ca7176ca25a8a47ab", size = 1505002, upload-time = "2026-05-17T17:47:54.093Z" },
-    { url = "https://files.pythonhosted.org/packages/14/2e/b278f68c497ee2f1d1576cbbef8db5281cd4a5f2db040537592ac9c8862e/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b15219e9cdc9f53f6f4cb51c009203507228226148c05c5e8fe451c28b435eb3", size = 1456231, upload-time = "2026-05-17T17:47:56.311Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/43/419be1c566a4c504cd8fd60ce2f84e790f295495c0f327cfaeadf3d51012/ast_serialize-0.5.0-cp314-cp314t-win32.whl", hash = "sha256:842d1c004bb466c7df036f95fabef789570541922b10976b12f5592a69cf0b38", size = 1058668, upload-time = "2026-05-17T17:47:58.305Z" },
-    { url = "https://files.pythonhosted.org/packages/03/6f/c9d4d549295ed05111aeb8853232d1afd9d0a179fddb01eeffbb3a4a6842/ast_serialize-0.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b0c06d760909b095cc466356dfccd05a1c7233a6ca191c020dca2c6a6f16c24c", size = 1101075, upload-time = "2026-05-17T17:48:00.35Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/8e/d00c5ab30c58222e07d62956fca86c59d91b9ad32997e633c38b526623a3/ast_serialize-0.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:787baedb0262cc49e8ce37cc15c00ae818e46a165a3b36f5e21ed174998104cb", size = 1075347, upload-time = "2026-05-17T17:48:01.753Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/9e/dc2530acb3a60dc6e46d65abf27d1d9f86721694757906a148d90a6860de/ast_serialize-0.5.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:0668aa9459cfa8c9c49ddd2163ebcf43088ba045ef7492af6fe22e0098303101", size = 1191380, upload-time = "2026-05-17T17:48:03.738Z" },
-    { url = "https://files.pythonhosted.org/packages/26/0a/bd3d18a582f273d6c843d16bb9e22e9e16365ff7991e92f18f798e9f1224/ast_serialize-0.5.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:bf683d6363edf2b39eed6b6d4fe22d34b6203867a67e27134d9e2a2680c4bc4a", size = 1183879, upload-time = "2026-05-17T17:48:05.463Z" },
-    { url = "https://files.pythonhosted.org/packages/40/ae/1f919100f8620887af58fcc381c61a1f218cdf89c6e155f87b213e61010a/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cc22cf0c9be65e71cf88fda130af60d61eb4a79370ad4cfe7900d48a4aa2211", size = 1244529, upload-time = "2026-05-17T17:48:07.008Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/ca/6376559dcce707cdbc1d0d9a13c8d3baaaa501e949ce0ebdc4230cd881aa/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f66173891548c9f2726bf27957b41cabce12fa679dc6da505ddbde4d4b3b31cf", size = 1240560, upload-time = "2026-05-17T17:48:08.46Z" },
-    { url = "https://files.pythonhosted.org/packages/35/b2/a620e206b5aeb7efbf2710336df57d457cffbb3991076bbcc1147ef9abd4/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e42d729ef2be96a14efbad355093284739e3670ece3e534f82cc8832790911d9", size = 1451172, upload-time = "2026-05-17T17:48:09.922Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/e0/4ad5c04c24a40481b2935ce9a0ccdb6023dc8b667167d06ae530cc3512f2/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b725026bafa801dbd7310eb13a75f0a2e370e7e51b2cb225f9d21fcfadf919ee", size = 1265072, upload-time = "2026-05-17T17:48:11.469Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/71/4d1d479aa56d0101c40e17720c3d6ac2af7269ea0487a80b18e7bfd1a5b7/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b54f60c1d78767a53b67eaa663f0dfac3afe606aa07f1301572f588b73d64809", size = 1270488, upload-time = "2026-05-17T17:48:13.575Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/4f/0de1bbe06f6edef9fde4ed12ca8e7b3ec7e6e2bd4e672c5af487f7957665/ast_serialize-0.5.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:27d51654fc240a1e87e742d353d98eb45b75f62f129086b3596ab53df2ac2a43", size = 1260702, upload-time = "2026-05-17T17:48:15.141Z" },
-    { url = "https://files.pythonhosted.org/packages/75/61/e00872439cfdddcc3c1b6cdaa6e5d904ba8e26a18807c67c4e14409d0ca8/ast_serialize-0.5.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c36237c46dd1674542f2109740ea5ea485a169bf1431939ada0434e17934", size = 1311182, upload-time = "2026-05-17T17:48:16.779Z" },
-    { url = "https://files.pythonhosted.org/packages/76/8e/699a5b955f7926956c95e9e1d74132acad73c2fe7a426f94da89123c20aa/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1943db345233cc7194a470f13afa9c59772c0b123dea0c9414c4d4ca54369759", size = 1421410, upload-time = "2026-05-17T17:48:18.527Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/ae/d5b7626874478997adc7a29ab28accf21e596fb590c944290401dfd0b29e/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:df1c00022cbbcb064bfaa505aa9c9295362443ce5dacb459d1331d3da353f887", size = 1516587, upload-time = "2026-05-17T17:48:20.133Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/ce/b59e02a82d9c4244d64cde502e0b00e83e38816abe19155ceb5437402c7f/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:cae65289fc456fde04af979a2be09302ef5d8ab92ef23e596d6746dc267ada27", size = 1515171, upload-time = "2026-05-17T17:48:21.921Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/38/d8d90042747d05aa08d4efcf1c99035a5f670a6bf4c214d31644392afbca/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:239a4c354e8d676e9d94631d1d4a64edc6b266f86ff3a5a80aedd344f342c01d", size = 1464668, upload-time = "2026-05-17T17:48:23.544Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/51/5b840c4df7334104cecffa28f23904fe81ca89ca223d2450e288de39fd3c/ast_serialize-0.5.0-cp39-abi3-win32.whl", hash = "sha256:143a4ef63285a075871908fda3672dc21864b83a8ec3ee12304aa3e4c5387b9a", size = 1068311, upload-time = "2026-05-17T17:48:25.027Z" },
-    { url = "https://files.pythonhosted.org/packages/41/11/ca5672c7d491825bc4cd6702dea106a6b60d928707712ec257c7833ae476/ast_serialize-0.5.0-cp39-abi3-win_amd64.whl", hash = "sha256:cf25572c526add400f26a4750dc6ce0c3bb93fc1f75e7ae0cad4ce4f2cd5c590", size = 1108931, upload-time = "2026-05-17T17:48:26.591Z" },
-    { url = "https://files.pythonhosted.org/packages/45/19/cc8bd127d28a43da249aa955cfd164cf8fd534e79e42cea96c4854d72fd0/ast_serialize-0.5.0-cp39-abi3-win_arm64.whl", hash = "sha256:92a31c9c20d25a076edaeec76b128a3535d74a24f340b9a8a7e96c9b86dc9642", size = 1081181, upload-time = "2026-05-17T17:48:28.122Z" },
-]
-
-[[package]]
 name = "asttokens"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -162,7 +122,6 @@ dependencies = [
 dev = [
     { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ipython", version = "9.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -172,9 +131,7 @@ dev = [
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
-    { name = "types-defusedxml" },
-    { name = "types-pyyaml" },
-    { name = "types-toml" },
+    { name = "ty" },
 ]
 docs = [
     { name = "mike" },
@@ -205,7 +162,6 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "ipython", specifier = ">=8.37.0" },
-    { name = "mypy", specifier = ">=1.15.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
@@ -215,9 +171,7 @@ dev = [
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = ">=3.7.0" },
     { name = "ruff", specifier = ">=0.11.11" },
-    { name = "types-defusedxml", specifier = ">=0.7.0.20250516" },
-    { name = "types-pyyaml", specifier = ">=6.0.12.20250516" },
-    { name = "types-toml", specifier = ">=0.10.8.20240310" },
+    { name = "ty", specifier = ">=0.0.51" },
 ]
 docs = [
     { name = "mike", specifier = ">=2.1.3" },
@@ -960,91 +914,6 @@ wheels = [
 ]
 
 [[package]]
-name = "librt"
-version = "0.11.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/40/08/9e7f6b5d2b5bed6ad055cdd5925f192bb403a51280f86b56554d9d0699a2/librt-0.11.0.tar.gz", hash = "sha256:075dc3ef4458a278e0195cbf6ac9d38808d9b906c5a6c7f7f79c3888276a3fb1", size = 200139, upload-time = "2026-05-10T18:17:25.138Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/10/37fd9e9ba96cb0bd742dfb20fc3d082e54bdbec759d7300df927f360ef07/librt-0.11.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6e94ebfcfa2d5e9926d6c3b9aa4617ffc42a845b4321fb84021b872358c82a0f", size = 141706, upload-time = "2026-05-10T18:15:16.129Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/72/1b1466f358e4a0b728051f69bc27e67b432c6eaa2e05b88db49d3785ae0d/librt-0.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ae627397a2f351560440d872d6f7c8dbb4072e57868e7b2fc5b8b430fe489d45", size = 142605, upload-time = "2026-05-10T18:15:18.148Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/85/ed26dd2f6bc9a0baf48306433e579e8d354d70b2bcb78134ed950a5d0e1e/librt-0.11.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc329359321b67d24efdf4bc69012b0597001649544db662c001db5a0184794c", size = 476555, upload-time = "2026-05-10T18:15:19.569Z" },
-    { url = "https://files.pythonhosted.org/packages/66/fe/11891191c0e0a3fd617724e891f6e67a71a7658974a892b9a9a97fdb2977/librt-0.11.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:7e82e642ab0f7608ce2fe53d76ca2280a9ee33a1b06556142c7c6fe80a86fc33", size = 468434, upload-time = "2026-05-10T18:15:20.87Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/50/5ec949d7f9ce1a07af903aa3e13abb98b717923bdead6e719b2f824ccc07/librt-0.11.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:88145c15c67731d54283d135b03244028c750cc9edc334a96a4f5950ebdb2884", size = 496918, upload-time = "2026-05-10T18:15:22.616Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/c4/177336c7524e34875a38bf668e88b193a6723a4eb4045d07f74df6e1506c/librt-0.11.0-cp310-cp310-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d36a51b3d93320b686588e27123f4995804dbf1bce81df78c02fc3c6eea9280", size = 490334, upload-time = "2026-05-10T18:15:24.2Z" },
-    { url = "https://files.pythonhosted.org/packages/13/1f/da3112f7569eda3b49f9a2629bae1fe059812b6085df16c885f6454dff49/librt-0.11.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d00f3ac06a2a8b246327f11e186a53a100a4d5c7ed52346367e5ec751d51586c", size = 511287, upload-time = "2026-05-10T18:15:26.226Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/94/03fec301522e172d105581431223be56b27594ff46440ebfbb658a3735d5/librt-0.11.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:461bbceede621f1ffb8839755f8663e886087ee7af16294cab7fb4d782c62eeb", size = 517202, upload-time = "2026-05-10T18:15:27.965Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/6e/339f6e5a7b413ce014f1917a756dae630fe59cc99f34153205b1cb540901/librt-0.11.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:0cad8a4d6a8ff03c9b76f9414caccd78e7cfbc8a2e12fa334d8e1d9932753783", size = 497517, upload-time = "2026-05-10T18:15:29.614Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/43/acdd5ce317cb46e8253ca9bfbdb8b12e68a24d745949336a7f3d5fb79ba0/librt-0.11.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f37aa505b3cf60701562eddb32df74b12a9e380c207fd8b06dd157a943ac7ea0", size = 538878, upload-time = "2026-05-10T18:15:30.928Z" },
-    { url = "https://files.pythonhosted.org/packages/29/b5/7a25bb12e3172839f647f196b3e988318b7bb1ca7501732a225c4dce2ec0/librt-0.11.0-cp310-cp310-win32.whl", hash = "sha256:94663a21534637f0e787ec2a2a756022df6e5b7b2335a5cdd7d8e33d68a2af89", size = 100070, upload-time = "2026-05-10T18:15:32.551Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/0d/ebbcf4d77999c02c937b05d2b90ff4cd4dcc7e9a365ba132329ac1fe7a0f/librt-0.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:dec7db73758c2b54953fd8b7fe348c45188fe26b39ee18446196edd08453a5d4", size = 117918, upload-time = "2026-05-10T18:15:33.678Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/87/2bf31fe17587b29e3f93ec31421e2b1e1c3e349b8bf6c7c313dbad1d5340/librt-0.11.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:93d95bd45b7d58343d8b90d904450a545144eec19a002511163426f8ab1fae29", size = 141092, upload-time = "2026-05-10T18:15:34.795Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/08/5c5bf772920b7ebac6e32bc91a643e0ab3870199c0b542356d3baa83970a/librt-0.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ee278c769a713638cdacd4c0436d72156e75df3ebc0166ab2b9dc43acc386c9", size = 142035, upload-time = "2026-05-10T18:15:36.242Z" },
-    { url = "https://files.pythonhosted.org/packages/06/20/662a03d254e5b000d838e8b345d83303ddb768c080fd488e40634c0fa66b/librt-0.11.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f230cb1cbc9faaa616f9a678f530ebcf186e414b6bcbd88b960e4ba1b92428d5", size = 475022, upload-time = "2026-05-10T18:15:37.56Z" },
-    { url = "https://files.pythonhosted.org/packages/de/f3/aa81523e45184c6ec23dc7f63263362ec55f80a09d424c012359ecbe7e35/librt-0.11.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:5d63c855d86938d9de93e265c9bd8c705b51ec494de5738340ee93767a686e4b", size = 467273, upload-time = "2026-05-10T18:15:39.182Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/6f/59c74b560ca8853834d5501d589c8a2519f4184f273a085ffd0f37a1cc47/librt-0.11.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:993f028be9e96a08d31df3479ac80d99be374d17f3b78e4796b3fd3c913d4e89", size = 497083, upload-time = "2026-05-10T18:15:40.634Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/7b/5aa4d2c9600a719401160bf7055417df0b2a47439b9d88286ce45e56b65f/librt-0.11.0-cp311-cp311-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:258d73a0aa66a055e65b2e4d1b8cdb23b9d132c5bb915d9547d804fcaed116cc", size = 489139, upload-time = "2026-05-10T18:15:41.934Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/31/9143803d7da6856a69153785768c4936864430eec0fd9461c3ea527d9922/librt-0.11.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0827efe7854718f04aaddf6496e96960a956e676fe1d0f04eb41511fd8ad06d5", size = 508442, upload-time = "2026-05-10T18:15:43.206Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/5a/bce08184488426bda4ccc2c4964ac048c8f68ae89bd7120082eef4233cfd/librt-0.11.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7753e57d6e12d019c0d8786f1c09c709f4c3fcc57c3887b24e36e6c06ec938b7", size = 514230, upload-time = "2026-05-10T18:15:44.761Z" },
-    { url = "https://files.pythonhosted.org/packages/89/8c/bb5e213d254b7505a0e658da199d8ab719086632ce09eef311ab27976523/librt-0.11.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:11bd19822431cc21af9f27374e7ae2e58103c7d98bda823536a6c47f6bb2bb3d", size = 494231, upload-time = "2026-05-10T18:15:46.308Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/fb/541cdad5b1ab1300398c74c4c9a497b88e5074c21b1244c8f49731d3a284/librt-0.11.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:22bdf239b219d3993761a148ffa134b19e52e9989c84f845d5d7b71d70a17412", size = 537585, upload-time = "2026-05-10T18:15:47.629Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/f2/464bb69295c320cb06bddb4f14a4ec67934ee14b2bffb12b19fb7ab287ba/librt-0.11.0-cp311-cp311-win32.whl", hash = "sha256:46c60b61e308eb535fbd6fa622b1ee1bb2815691c1ad9c98bf7b84952ec3bc8d", size = 100509, upload-time = "2026-05-10T18:15:49.157Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/e7/a17ee1788f9e4fbf548c19f4afa07c92089b9e24fef6cb2410863781ef4c/librt-0.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:902e546ff044f579ff1c953ff5fce97b636fe9e3943996b2177710c6ef076f73", size = 118628, upload-time = "2026-05-10T18:15:50.345Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/c7/6c766214f9f9903bcfcfbef97d807af8d8f5aa3502d247858ab17582d212/librt-0.11.0-cp311-cp311-win_arm64.whl", hash = "sha256:65ac3bc20f78aa0ee5ae84baa68917f89fef4af63e941084dd019a0d0e749f0c", size = 103122, upload-time = "2026-05-10T18:15:52.068Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/d0/07c77e067f0838949b43bd89232c29d72efebb9d2801a9750184eb706b71/librt-0.11.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b87504f1690a23b9a2cca841191a04f83895d4fc2dd04df91d82b1a04ca2ad46", size = 144147, upload-time = "2026-05-10T18:15:53.227Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/24/8493538fa4f62f982686398a5b8f68008138a75086abdea19ade64bf4255/librt-0.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40071fc5fe0ce8daa6de616702314a01e1250711682b0523d6ab8d4525910cb3", size = 143614, upload-time = "2026-05-10T18:15:54.657Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/1e/f8bad050810d9171f34a1648ed910e56814c2ba61639f2bd53c6377ae24b/librt-0.11.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:137e79445c896a0ea7b265f52d23954e05b64222ee1af69e2cb34219067cbb67", size = 485538, upload-time = "2026-05-10T18:15:56.117Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/fe/3594ebfbaf03084ba4b120c9ba5c3183fd938a48725e9bbe6ff0a5159ad8/librt-0.11.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:cca6644054e78746d8d4ef238681f9c34ff8b584fe6b988ecebb8db3b15e622a", size = 479623, upload-time = "2026-05-10T18:15:57.544Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/da/5d1876984b3746c85dbd219dbfcb73c85f54ee263fd32e5b2a632ec14571/librt-0.11.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5b0eea49f5562861ee8d757a32ef7d559c1d35be2aaaa1ec28941d74c9ffc8a", size = 513082, upload-time = "2026-05-10T18:15:58.805Z" },
-    { url = "https://files.pythonhosted.org/packages/19/6e/55bdf5d5ca00c3e18430690bf2c953d8d3ffd3c337418173d33dec985dc9/librt-0.11.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0d1029d7e1ae1a7e647ed6fb5df8c4ce2dffefb7a9f5fd1376a4554d96dac09f", size = 508105, upload-time = "2026-05-10T18:16:00.2Z" },
-    { url = "https://files.pythonhosted.org/packages/07/10/f1f23a7c595ee90ece4d35c851e5d104b1311a887ed1b4ac4c35bbd13da8/librt-0.11.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bc3ce6b33c5828d9e80592011a5c584cb2ce86edbc4088405f70da47dc1d1b3b", size = 522268, upload-time = "2026-05-10T18:16:01.708Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/02/5720f5697a7f54b78b3aefbe20df3a48cedcff1276618c4aa481177942ed/librt-0.11.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:936c5995f3514a42111f20099397d8177c79b4d7e70961e396c6f5a0a3566766", size = 527348, upload-time = "2026-05-10T18:16:03.496Z" },
-    { url = "https://files.pythonhosted.org/packages/50/db/b4a47c6f91db4ff76348a0b3dd0cc65e090a078b765a810a62ff9434c3d3/librt-0.11.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9bc0ca6ad9381cbe8e4aa6e5726e4c80c78115a6e9723c599ed1d73e092bc49d", size = 516294, upload-time = "2026-05-10T18:16:05.173Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/58/9384b2f4eb1ed1d273d40948a7c5c4b2360213b402ef3be4641c06299f9c/librt-0.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:070aa8c26c0a74774317a72df8851facc7f0f012a5b406557ac56992d92e1ec8", size = 553608, upload-time = "2026-05-10T18:16:06.839Z" },
-    { url = "https://files.pythonhosted.org/packages/21/7b/5aa8848a7c6a9278c79375146da1812e695754ceec5f005e6043461a7315/librt-0.11.0-cp312-cp312-win32.whl", hash = "sha256:6bf14feb84b05ae945277395451998c89c54d0def4070eb5c08de544930b245a", size = 101879, upload-time = "2026-05-10T18:16:08.103Z" },
-    { url = "https://files.pythonhosted.org/packages/37/33/8a745436944947575b584231750a41417de1a38cf6a2e9251d1065651c09/librt-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:75672f0bc524ede266287d532d7923dbce94c7514ad07627bac3d0c6d92cc4d9", size = 119831, upload-time = "2026-05-10T18:16:09.174Z" },
-    { url = "https://files.pythonhosted.org/packages/59/67/a6739ac96e28b7855808bdb0370e250606104a859750d209e5a0716fe7ab/librt-0.11.0-cp312-cp312-win_arm64.whl", hash = "sha256:2f10cf143e4a9bb0f4f5af568a00df94a2d69ef41c2579584454bb0fe5cc642c", size = 103470, upload-time = "2026-05-10T18:16:10.369Z" },
-    { url = "https://files.pythonhosted.org/packages/82/61/e59168d4d0bf2bf90f4f0caf7a001bfc60254c3af4586013b04dc3ef517b/librt-0.11.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:78dc31f7fdfe9c9d0eb0e8f42d139db230e826415bbcabd9f0e9faaaee909894", size = 144119, upload-time = "2026-05-10T18:16:11.771Z" },
-    { url = "https://files.pythonhosted.org/packages/61/fd/caa1d60b12f7dd79ccea23054e06eeaebe266a5f52c40a6b651069200ce5/librt-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fa475675db22290c3158e1d42326d0f5a65f04f44a0e68c3630a25b53560fb9c", size = 143565, upload-time = "2026-05-10T18:16:13.334Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/a9/dc744f5c2b4978d48db970be29f22716d3413d28b14ad99740817315cf2c/librt-0.11.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:621db29691044bdeda22e789e482e1b0f3a985d90e3426c9c6d17606416205ea", size = 485395, upload-time = "2026-05-10T18:16:14.729Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/21/7f8e97a1e4dae952a5a95948f6f8507a173bc1e669f54340bba6ca1ca31b/librt-0.11.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:a9010e2ed5b3a9e158c5fd966b3ab7e834bb3d3aacc8f66c91dd4b57a3799230", size = 479383, upload-time = "2026-05-10T18:16:16.321Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/6d/d8ee9c114bebf2c50e29ec2aa940826fccb62a645c3e4c18760987d0e16d/librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c39513d8b7477a2e1ed8c43fc21c524e8d5a0f8d4e8b7b074dbdbe7820a08e2", size = 513010, upload-time = "2026-05-10T18:16:17.647Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/43/0b5708af2bd30a46400e72ba6bdaa8f066f15fb9a688527e34220e8d6c06/librt-0.11.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7aef3cf1d5af86e770ab04bfd993dfc4ae8b8c17f66fb77dd4a7d50de7bbb1a3", size = 508433, upload-time = "2026-05-10T18:16:19.309Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/50/356187247d09013490481033183b3532b58acf8028bcb34b2b56a375c9b2/librt-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:557183ddc36babe46b27dd60facbd5adb4492181a5be887587d57cda6e092f21", size = 522595, upload-time = "2026-05-10T18:16:20.642Z" },
-    { url = "https://files.pythonhosted.org/packages/40/e7/c6ac4240899c7f3248079d5a9900debe0dadb3fdeaf856684c987105ba47/librt-0.11.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:83d3e1f72bd42f6c5c0b7daec530c3f829bd02db42c70b8ddf0c2d90a2459930", size = 527255, upload-time = "2026-05-10T18:16:22.352Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/b5/a81322dbeedeeaf9c1ee6f001734d28a09d8383ac9e6779bc24bbd0743c6/librt-0.11.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4ce1f21fbe589bc1afd7872dece84fb0e1144f794a288e58a10d2c54a55c43be", size = 516847, upload-time = "2026-05-10T18:16:23.627Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/66/6e6323787d592b55204a42595ff1102da5115601b53a7e9ddebc889a6da5/librt-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b09f7044ea2b64c9da42fd3d335666518cfd1c6e8a182c95da73d0214b41e", size = 553920, upload-time = "2026-05-10T18:16:25.025Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/21/623f8ca230857102066d9ca8c6c1734995908c4d0d1bee7bb2ef0021cb33/librt-0.11.0-cp313-cp313-win32.whl", hash = "sha256:78fddc31cd4d3caa897ad5d31f856b1faadc9474021ad6cb182b9018793e254e", size = 101898, upload-time = "2026-05-10T18:16:26.649Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/1d/b4ebd44dd723f768469007515cb92251e0ae286c94c140f374801140fa74/librt-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:8ca8aa88751a775870b764e93bad5135385f563cb8dcee399abf034ea4d3cb47", size = 119812, upload-time = "2026-05-10T18:16:27.859Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/e4/b2f4ca7965ca373b491cdb4bc25cdb30c1649ca81a8782056a83850292a9/librt-0.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:96f044bb325fd9cf1a723015638c219e9143f0dfbc0ca54c565df2b7fc748b44", size = 103448, upload-time = "2026-05-10T18:16:29.066Z" },
-    { url = "https://files.pythonhosted.org/packages/29/eb/dbce197da4e227779e56b5735f2decc3eb36e55a1cdbf1bd65d6639d76c1/librt-0.11.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4a017a95e5837dc15a8c5661d60e05daa96b90908b1aa6b7acdf443cd25c8ebd", size = 143345, upload-time = "2026-05-10T18:16:30.674Z" },
-    { url = "https://files.pythonhosted.org/packages/76/a3/254bebd0c11c8ba684018efb8006ff22e466abce445215cca6c778e7d9de/librt-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b1ecbd9819deccc39b7542bf4d2a740d8a620694d39989e58661d3763458f8d4", size = 143131, upload-time = "2026-05-10T18:16:32.037Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/3f/f77d6122d21ac7bf6ae8a7dfced1bd2a7ac545d3273ebdcaf8042f6d619f/librt-0.11.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7da327dacd7be8f8ec36547373550744a3cc0e536d54665cd83f8bcd961200e8", size = 477024, upload-time = "2026-05-10T18:16:33.493Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/0a/2c996dadebaa7d9bbbd43ef2d4f3e66b6da545f838a41694ef6172cebec8/librt-0.11.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0dc56b1f8d06e60db362cc3fdae206681817f86ce4725d34511473487f12a34b", size = 474221, upload-time = "2026-05-10T18:16:34.864Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/7e/f5d92af8486b8272c23b3e686b46ff72d89c8169585eb61eef01a2ac7147/librt-0.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05fb8fb2ab90e21c8d12ea240d744ad514da9baf381ebfa70d91d20d21713175", size = 505174, upload-time = "2026-05-10T18:16:36.705Z" },
-    { url = "https://files.pythonhosted.org/packages/af/1a/cb0734fe86398eb33193ab753b7326255c74cac5eb09e76b9b16536e7adb/librt-0.11.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cae74872be221df4374d10fec61f93ed1513b9546ea84f2c0bf73ab3e9bd0b03", size = 497216, upload-time = "2026-05-10T18:16:38.418Z" },
-    { url = "https://files.pythonhosted.org/packages/18/06/094820f91558b66e29943c0ec41c9914f460f48dd51fc503c3101e10842d/librt-0.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32bcc918c0148eb7e3d57385125bac7e5f9e4359d05f07448b09f6f778c2f31c", size = 513921, upload-time = "2026-05-10T18:16:39.848Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/c2/00de9018871a282f530cacb457d5ec0428f6ac7e6fedde9aff7468d9fb04/librt-0.11.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f9743fc99135d5f78d2454435615f6dec0473ca507c26ce9d92b10b562a280d3", size = 520850, upload-time = "2026-05-10T18:16:41.471Z" },
-    { url = "https://files.pythonhosted.org/packages/51/9d/64631832348fd1834fb3a61b996434edddaaf25a31d03b0a76273159d2cf/librt-0.11.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5ba067f4aadae8fda802d91d2124c90c42195ff32d9161d3549e6d05cfe26f96", size = 504237, upload-time = "2026-05-10T18:16:43.15Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/ec/ae5525eb16edc827a044e7bb8777a455ff95d4bca9379e7e6bddd7383647/librt-0.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:de3bf945454d032f9e390b85c4072e0a0570bf825421c8be0e71209fa65e1abe", size = 546261, upload-time = "2026-05-10T18:16:44.408Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/09/adce371f27ca039411da9659f7430fcc2ba6cd0c7b3e4467a0f091be7fa9/librt-0.11.0-cp314-cp314-win32.whl", hash = "sha256:d2277a05f6dcb9fd13db9566aac4fabd68c3ea1ea46ee5567d4eef8efa495a2f", size = 96965, upload-time = "2026-05-10T18:16:46.039Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/ee/8ac720d98548f173c7ce2e632a7ca94673f74cacd5c8162a84af5b35958a/librt-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:ab73e8db5e3f564d812c1f5c3a175930a5f9bc96ccb5e3b22a34d7858b401cf7", size = 115151, upload-time = "2026-05-10T18:16:47.133Z" },
-    { url = "https://files.pythonhosted.org/packages/94/20/c900cf14efeb09b6bef2b2dff20779f73464b97fd58d1c6bccc379588ae3/librt-0.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:aea3caa317752e3a466fa8af45d91ee0ea8c7fdd96e42b0a8dd9b76a7931eba1", size = 98850, upload-time = "2026-05-10T18:16:48.597Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/71/944bfe4b64e12abffcd3c15e1cce07f72f3d55655083786285f4dedeb532/librt-0.11.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d1b36540d7aaf9b9101b3a6f376c8d8e9f7a9aec93ed05918f2c69d493ffef72", size = 151138, upload-time = "2026-05-10T18:16:49.839Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/10/99e64a5c86989357fda078c8143c533389585f6473b7439172dd8f3b3b2d/librt-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:efbb343ab2ce3540f4ecbe6315d677ed70f37cd9a72b1e58066c918ca83acbaa", size = 151976, upload-time = "2026-05-10T18:16:51.062Z" },
-    { url = "https://files.pythonhosted.org/packages/21/31/5072ad880946d83e5ea4147d6d018c78eefce85b77819b19bdd0ee229435/librt-0.11.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0dd688aab3f7914d3e6e5e3554978e0383312fb8e771d84be008a35b9ee548", size = 557927, upload-time = "2026-05-10T18:16:52.632Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/8d/70b5fb7cfbab60edbe7381614ab985da58e144fbf465c86d44c95f43cdca/librt-0.11.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f5fb36b8c6c63fdcbb1d526d94c0d1331610d43f4118cc1beb4efef4f3faacb2", size = 539698, upload-time = "2026-05-10T18:16:53.934Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/a3/ba3495a0b3edbd24a4cae0d1d3c64f39a9fc45d06e812101289b50c1a619/librt-0.11.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4a9a237d13addb93715b6fee74023d5ee3469b53fce527626c0e088aa585805f", size = 577162, upload-time = "2026-05-10T18:16:55.589Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/db/36e25fb81f99937ff1b96612a1dc9fd66f039cb9cc3aee12c01fac31aab9/librt-0.11.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5ddd17bd87b2c56ddd60e546a7984a2e64c4e8eab92fb4cf3830a48ad5469d51", size = 566494, upload-time = "2026-05-10T18:16:56.975Z" },
-    { url = "https://files.pythonhosted.org/packages/33/0d/3f622b47f0b013eeb9cf4cc07ae9bfe378d832a4eec998b2b209fe84244d/librt-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd43992b4473d42f12ff9e68326079f0696d9d4e6000e8f39a0238d482ba6ee2", size = 596858, upload-time = "2026-05-10T18:16:58.374Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/02/71b90bc93039c46a2000651f6ad60122b114c8f54c4ad306e0e96f5b75ad/librt-0.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:f8e3e8056dd674e279741485e2e512d6e9a751c7455809d0114e6ebf8d781085", size = 590318, upload-time = "2026-05-10T18:16:59.676Z" },
-    { url = "https://files.pythonhosted.org/packages/04/04/418cb3f75621e2b761fb1ab0f017f4d70a1a72a6e7c74ee4f7e8d198c2f3/librt-0.11.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c1f708d8ae9c56cf38a903c44297243d2ec83fd82b396b977e0144a3e76217e3", size = 575115, upload-time = "2026-05-10T18:17:01.007Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/2c/5a2183ac58dd911f26b5d7e7d7d8f1d87fcecdddd99d6c12169a258ff62c/librt-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0add982e0e7b9fc14cf4b33789d5f13f66581889b88c2f58099f6ce8f92617bd", size = 617918, upload-time = "2026-05-10T18:17:02.682Z" },
-    { url = "https://files.pythonhosted.org/packages/15/1f/dc6771a52592a4451be6effa200cbfc9cec61e4393d3033d81a9d307961d/librt-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:2b481d846ac894c4e8403c5fd0e87c5d11d6499e404b474602508a224ff531c8", size = 103562, upload-time = "2026-05-10T18:17:03.99Z" },
-    { url = "https://files.pythonhosted.org/packages/62/4a/7d1415567027286a75ba1093ec4aca11f073e0f559c530cf3e0a757ad55c/librt-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:28edb433edde181112a908c78907af28f964eabc15f4dd16c9d66c834302677c", size = 124327, upload-time = "2026-05-10T18:17:05.465Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/62/b40b382fa0c66fee1478073eb8db352a4a6beda4a1adccf1df911d8c289c/librt-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dee008f20b542e3cd162ba338a7f9ec0f6d23d395f66fe8aeeec3c9d067ea253", size = 102572, upload-time = "2026-05-10T18:17:06.809Z" },
-]
-
-[[package]]
 name = "lxml"
 version = "6.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1462,74 +1331,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a4/b4/5fed370d8ebd96e4e399460a7146ae989263f16588b05a6facd6dbd51e60/mkdocstrings_python-2.0.4.tar.gz", hash = "sha256:58c73c5d358e64e9b1673447663f4a2f8a8941e392e225fc0a0c893758cc452f", size = 199219, upload-time = "2026-06-05T08:13:01.819Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/e3/00ec594aef5f55522e6d373bc2ac53e53a8f5e9ae32f2d6854b0de4270f3/mkdocstrings_python-2.0.4-py3-none-any.whl", hash = "sha256:fd87c173e1e719a85997b6d4f852cdc55f36710e0ed08da3a7bd9abe79c9db00", size = 104790, upload-time = "2026-06-05T08:13:00.393Z" },
-]
-
-[[package]]
-name = "mypy"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ast-serialize" },
-    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "mypy-extensions" },
-    { name = "pathspec" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/82/15/cca9d88503549ed6fedeaa1d448cdddd542ee8a490232d732e278036fbf2/mypy-2.1.0.tar.gz", hash = "sha256:81e76ad12c2d804512e9b13240d1588316531bfba07558286078bfbce9613633", size = 3898359, upload-time = "2026-05-11T18:37:36.237Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/71/d351dca3e9b30da2328ee9d445c88b8388072808ebfbc49eb69d30b67749/mypy-2.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:11a6beb180257a805961aea9ec591bbd0bd17f1e18d35b8456d57aee5bedfedc", size = 14778792, upload-time = "2026-05-11T18:36:23.605Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/45/7d51594b644c17c0bcf74ed8cd5fc33b324276d708e8506f220b70dab9d9/mypy-2.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8ef78c1d306bbf9a8a12f526c44902c9c28dffd6c52c52bf6a72641ce18d3849", size = 13645739, upload-time = "2026-05-11T18:37:22.752Z" },
-    { url = "https://files.pythonhosted.org/packages/65/01/455c31b170e9468265074840bf18863a8482a24103fdaabe4e199392aa5f/mypy-2.1.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c209a90853081ff01d01ee895cafe10f7db1474e0d95beaeef0f6c1db9119bbd", size = 14074199, upload-time = "2026-05-11T18:35:09.292Z" },
-    { url = "https://files.pythonhosted.org/packages/41/5a/93093f0b29a9e982deafde698f740a2eb2e05886e79ccf0594c7fd5413a3/mypy-2.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47cebf61abde7c088a4e27718a8b13a81655686b2e9c251f5c0915a802248166", size = 14953128, upload-time = "2026-05-11T18:31:57.678Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/2f/a196f5331d96170ad3d28f144d2aba690d4b2911381f68d51e489c7ab82a/mypy-2.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d57a90ae5e872138a425ec328edbc9b235d1934c4377881a33ec05b341acc9a8", size = 15249378, upload-time = "2026-05-11T18:33:00.101Z" },
-    { url = "https://files.pythonhosted.org/packages/54/de/94d321cc12da9f71341ac0c270efbed5c725750c7b4c334d957de9a087d9/mypy-2.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:aea7f7a8a55b459c34275fc468ada6ca7c173a5e43a68f5dbe588a563d8a06b8", size = 11060994, upload-time = "2026-05-11T18:33:18.848Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/62/0c27ca55219a7c764a7fb88c7bb2b7b2f9780ade8bbf16bc8ed8400eef6b/mypy-2.1.0-cp310-cp310-win_arm64.whl", hash = "sha256:c989640253f0d76843e9c6c1bbf4bd48c5e85ada61bde4beb37cb3eca035685e", size = 9976743, upload-time = "2026-05-11T18:31:25.554Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/a1/639f3024794a2a15899cb90707fe02e044c4412794c39c5769fd3df2e2ef/mypy-2.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a683016b16fe2f572dc04c72be7ee0504ac1605a265d0200f5cea695fb788f41", size = 14691685, upload-time = "2026-05-11T18:33:27.973Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/08/9a585dea4325f20d8b80dc78623fa50d1fd2173b710f6237afd6ba6ab39b/mypy-2.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1a293c534adb55271fef24a26da04b855540a8c13cc07bc5917b9fd2c394f2ca", size = 13555165, upload-time = "2026-05-11T18:32:16.107Z" },
-    { url = "https://files.pythonhosted.org/packages/81/dc/7c42cc9c6cb01e8eb09961f1f738741d3e9c7e9d5c5b30ec69222625cd5f/mypy-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7406f4d048e71e576f5356d317e5b0a9e666dfd966bd99f9d14ca06e1a341538", size = 13994376, upload-time = "2026-05-11T18:32:39.256Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/fa/285946c33bce716e082c11dfeee9ee196eaf1f5042efb3581a31f9f205e4/mypy-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e0210d626fc8b31ccc90233754c7bc90e1f43205e85d96387f7db1285b55c398", size = 14864618, upload-time = "2026-05-11T18:34:49.765Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/83/82397f48af6c27e295d57979ded8490c9829040152cf7571b2f026aeb9a0/mypy-2.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3712c20deed54e814eaaa825603bada8ea1c390670a397c95b98405347acc563", size = 15102063, upload-time = "2026-05-11T18:34:05.855Z" },
-    { url = "https://files.pythonhosted.org/packages/40/68/b02dec39057b88eb03dc0aa854732e26e8361f34f9d0e20c7614967d1eba/mypy-2.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:fcaa0e479066e31f7cceb6a3bea39cb22b2ff51a6b2f24f193d19179ba17c389", size = 11060564, upload-time = "2026-05-11T18:35:36.494Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/a8/ea3dcbef31f99b634f2ee23bb0321cbc8c1b388b76a861eb849f13c347dc/mypy-2.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:0b1a5260c95aa443083f9ed3592662941951bca3d4ca224a5dc517c38b7cf666", size = 9966983, upload-time = "2026-05-11T18:37:14.139Z" },
-    { url = "https://files.pythonhosted.org/packages/95/b1/55861beb5c339b44f9a2ba92df9e2cb1eeb4ae1eee674cdf7772c797778b/mypy-2.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:244358bf1c0da7722230bce60683d52e8e9fd030554926f15b747a84efb5b3af", size = 14874381, upload-time = "2026-05-11T18:37:31.784Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/b3/b7f770114b7d0ac92d0f76e8d93c2780844a70488a90e91821927850da86/mypy-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4ec7c57657493c7a75534df2751c8ae2cda383c16ecc55d2106c54476b1b16f6", size = 13665501, upload-time = "2026-05-11T18:34:23.063Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/f3/8ae2037967e2126689a0c11d99e2b707134a565191e92c60ca2572aec60a/mypy-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8161b6ff4392410023224f0969d17db93e1e154bc3e4ba62598e720723ae211", size = 14045750, upload-time = "2026-05-11T18:31:48.151Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/32/615eb5911859e43d054941b0d0a7d06cfa2870eba86529cf385b052b111c/mypy-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf03e12003084a67395184d3eb8cbd6a489dc3655b5664b28c210a9e2403ab0b", size = 15061630, upload-time = "2026-05-11T18:37:06.898Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/03/4eafbfff8bfab1b87082741eae6e6a624028c984e6708b73bce2a8570c9d/mypy-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:20509760fd791c51579d573153407d226385ec1f8bcce55d730b354f3336bc22", size = 15288831, upload-time = "2026-05-11T18:31:18.07Z" },
-    { url = "https://files.pythonhosted.org/packages/99/ee/919661478e5891a3c96e549c036e467e64563ab85995b10c53c8358e16a3/mypy-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:6753d0c1fdd6b1a23b9e4f283ce80b2153b724adcb2653b20b85a8a28ac6436b", size = 11135228, upload-time = "2026-05-11T18:34:31.23Z" },
-    { url = "https://files.pythonhosted.org/packages/24/0a/6a12b9782ca0831a553192f351679f4548abc9d19a7cc93bb7feb02084c7/mypy-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:98ebb6589bb3b6d0c6f0c459d53ca55b8091fbc13d277c4041c885392e8195e8", size = 10040684, upload-time = "2026-05-11T18:36:48.199Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/dd/c7191469c777f07689c032a8f7326e393ea34c92d6d76eb7ce5ba57ea66d/mypy-2.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:35aac3bb114e03888f535d5eb51b8bafbb3266586b599da1940f9b1be3ec5bd5", size = 14852174, upload-time = "2026-05-11T18:31:38.929Z" },
-    { url = "https://files.pythonhosted.org/packages/55/8c/aed55408879043d72bb9135f4d0d19a02b886dd569631e113e3d2706cb8d/mypy-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8de55a8c861f2a49331f807be98d90caeceeef520bde13d43a160207f8af613e", size = 13651542, upload-time = "2026-05-11T18:36:04.636Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/8e/f371a824b1f1fa8ea6e3dbb8703d232977d572be2329554a3bc4d960302f/mypy-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5fdf2941a07434af755837d9880f7d7d25f1dacb1af9dcd4b9b66f2220a3024e", size = 14033929, upload-time = "2026-05-11T18:35:55.742Z" },
-    { url = "https://files.pythonhosted.org/packages/94/21/f54be870d6dd53a82c674407e0f8eed7174b05ec78d42e5abd7b42e84fd5/mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e195b817c13f02352a9c124301f9f30f078405444679b6753c1b96b6eed37285", size = 15039200, upload-time = "2026-05-11T18:33:10.281Z" },
-    { url = "https://files.pythonhosted.org/packages/17/99/bf21748626a40ce59fd29a39386ab46afec88b7bd2f0fa6c3a97c995523f/mypy-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5431d42af987ebd92ba2f71d45c85ed41d8e6ca9f5fd209a69f68f707d2469e5", size = 15272690, upload-time = "2026-05-11T18:32:07.205Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/d7/9e90d2cf47100bea550ed2bc7b0d4de3a62181d84d5e37da0003e8462637/mypy-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:767fe8c66dc3e01e19e1737d4c38ebefead16125e1b8e58ad421903b376f5c65", size = 11147435, upload-time = "2026-05-11T18:33:56.477Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/46/e5c449e858798e35ffc90946282a27c62a77be743fe17480e4977374eb91/mypy-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:ecfe70d43775ab99562ab128ce49854a362044c9f894961f68f898c23cb7429d", size = 10035052, upload-time = "2026-05-11T18:32:30.049Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/ca/b279a672e874aedd5498ae25f722dacc8aa86bbffb939b3f97cbb1cf6686/mypy-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7354c5a7f69d9345c3d6e69921d57088eea3ddeeb6b20d34c1b3855b02c36ec2", size = 14848422, upload-time = "2026-05-11T18:35:45.984Z" },
-    { url = "https://files.pythonhosted.org/packages/27/e6/3efe56c631d959b9b4454e208b0ac4b7f4f58b404c89f8bec7b49efdfc21/mypy-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:49890d4f76ac9e06ec117f9e09f3174da70a620a0c300953d8595c926e80947f", size = 13677374, upload-time = "2026-05-11T18:36:57.188Z" },
-    { url = "https://files.pythonhosted.org/packages/84/7f/8107ea87a44fd1f1b59882442f033c9c3488c127201b1d1d15f1cbd6022e/mypy-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:761be68e023ef5d94678772396a8af1220030f80837a3afd8d0aef3b419666f4", size = 14055743, upload-time = "2026-05-11T18:35:18.361Z" },
-    { url = "https://files.pythonhosted.org/packages/51/4d/b6d34db183133b83761b9199a82d31557cdbb70a380d8c3b3438e11882a3/mypy-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c90345fc182dc363b891350457ec69c35140858538f38b4540845afcc32b1aef", size = 15020937, upload-time = "2026-05-11T18:34:59.618Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/d7/f08360c691d758acb02f45022c34d98b92892f4ea756644e1000d4b9f3d8/mypy-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b84802e7b5a6daf1f5e15bc9fcd7ddae77be13981ffab037f1c67bb84d67d135", size = 15253371, upload-time = "2026-05-11T18:36:41.081Z" },
-    { url = "https://files.pythonhosted.org/packages/67/1b/09460a13719530a19bce27bd3bc8449e83569dd2ba7faf51c9c3c30c0b61/mypy-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:022c771234936ceac541ebaf836fe9e2abeb3f5e09aff21588fe543ff006fe21", size = 11326429, upload-time = "2026-05-11T18:34:13.526Z" },
-    { url = "https://files.pythonhosted.org/packages/40/62/75dbf0f82f7b6680340efc614af29dd0b3c17b8a4f1cd09b8bd2fd6bc814/mypy-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:498207db725cec88829a6a5c2fc771205fd043719ef98bc49aba8fb9fc4e6d57", size = 10218799, upload-time = "2026-05-11T18:32:23.491Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/66/caca04ed7d972fb6eb6dd1ccd6df1de5c38fae8c5b3dc1c4e8e0d85ee6b9/mypy-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7d5e5cad0efeba72b93cd17490cc0d69c5ac9ca132994fe3fb0314808aeeb83e", size = 15923458, upload-time = "2026-05-11T18:35:28.64Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/52/2d90cbe49d014b13ed7ff337930c30bad35893fe38a1e4641e756bb62191/mypy-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ff715050c127d724fd260a2e666e7747fdd83511c0c47d449d98238970aef780", size = 14757697, upload-time = "2026-05-11T18:36:14.208Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/37/d98f4a14e081b238992d0ed96b6d39c7cc0148c9699eb71eaa68629665ea/mypy-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82208da9e09414d520e912d3e462d454854bed0810b71540bb016dcbca7308fd", size = 15405638, upload-time = "2026-05-11T18:33:48.249Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/c2/15c46613b24a84fad2aea1248bf9619b99c2767ae9071fe224c179a0b7d4/mypy-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e79ebc1b904b84f0310dff7469655a9c36c7a68bddb37bdd42b67a332df61d08", size = 16215852, upload-time = "2026-05-11T18:32:50.296Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/90/9c16a57f482c76d25f6379762b56bbf65c711d8158cf271fb2802cfb0640/mypy-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e583edc957cfb0deb142079162ae826f58449b116c1d442f2d91c69d9fced081", size = 16452695, upload-time = "2026-05-11T18:33:38.182Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/4c/215a4eeb63cacc5f17f516691ea7285d11e249802b942476bff15922a314/mypy-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b33b6cd332695bba180d55e717a79d3038e479a2c49cc5eb3d53603409b9a5d7", size = 12866622, upload-time = "2026-05-11T18:34:39.945Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/50/1043e1db5f455ffe4c9ab22747cd8ca2bc492b1e4f4e21b130a44ee2b217/mypy-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:4f910fe825376a7b66ef7ca8c98e5a149e8cd64c19ae71d84047a74ee060d4e6", size = 10610798, upload-time = "2026-05-11T18:36:31.444Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/2a/13ca1f292f6db1b98ff495ef3467736b331621c5917cad984b7043e7348d/mypy-2.1.0-py3-none-any.whl", hash = "sha256:a663814603a5c563fb87a4f96fb473eeb30d1f5a4885afcf44f9db000a366289", size = 2693302, upload-time = "2026-05-11T18:31:29.246Z" },
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
 ]
 
 [[package]]
@@ -2293,6 +2094,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ty"
+version = "0.0.51"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ce/352fcdba5c72ea20e5d2e46e28809cdb617575b71209d971eff2ace8e6c4/ty-0.0.51.tar.gz", hash = "sha256:b90172d46365bb9d51a7011cbb5c60cc4f514f42c86635df6c092b717f85e1ac", size = 5953151, upload-time = "2026-06-19T01:48:58.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/8f/8fe7cab79a45320b2cdcd602f16d44c8108d2f418ff7ec316c6212f1f0cc/ty-0.0.51-py3-none-linux_armv6l.whl", hash = "sha256:947986bd82d324b3a5c58ce03f1dad160cdf36443d3e8f64b3484b861ba9bc64", size = 11884805, upload-time = "2026-06-19T01:48:20.184Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/b4/56fdc39a3f44c0564fd157e1e59e1f9c3fc5ba57ae4472ded85c67c63d74/ty-0.0.51-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:25a5b31e6f23fd5dc63ad29087ded09932409e4154e2fe07bbaed015035990bb", size = 11633593, upload-time = "2026-06-19T01:48:22.998Z" },
+    { url = "https://files.pythonhosted.org/packages/33/57/136e83f24fc04f5afdcabff42f40fa27eae5ac3f0e3f12627d072a55f679/ty-0.0.51-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2faed19a8f1505370de071c008df52a994fc03a204f3267c3a33a32ca26f854f", size = 11063076, upload-time = "2026-06-19T01:48:25.223Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f8/5d32f0df5692446440ab781b9b119aa3e0c0dbfa78c583fe9be8417d54fa/ty-0.0.51-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08adbe53fb8bc9e7f00e89bf1d3c875a02cda76d83f109d2e6ab1ff35a7bfa8c", size = 11579542, upload-time = "2026-06-19T01:48:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/0c/4f54ef338e9623886809ecd508931b0cd5b3aba1e591586a2f6aeaa8bd11/ty-0.0.51-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:dc5e93695ab5dcbf1eef663aee60ec23a413547cc9cb06adcb0d842e9166bd0f", size = 11676189, upload-time = "2026-06-19T01:48:29.518Z" },
+    { url = "https://files.pythonhosted.org/packages/56/27/31729066f9b9d3596941edaf267894eefc0b30df4518f003dba5f7276258/ty-0.0.51-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:abd92913bc90d1705ef9391ff8c6822b61e2e827fa295eb30bf0dfabcf815645", size = 12188154, upload-time = "2026-06-19T01:48:31.68Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/38/d4301aa12d2283c7130908baf1417a37dfe3e10f5669cb4ce2853c2540b4/ty-0.0.51-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:429a997394dac73870d71b87cc90efc54da3efaf319e72ca18aeef35a78aef90", size = 12780597, upload-time = "2026-06-19T01:48:33.839Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/52/4b2e67e53f126d39abe201bd2299e467e27463a284e965ad195cbc217fa0/ty-0.0.51-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62d94f06e8c317e89b6884f2bde443040e596b88c7c79bd944c84c105b06257a", size = 12491115, upload-time = "2026-06-19T01:48:36.169Z" },
+    { url = "https://files.pythonhosted.org/packages/74/50/aabfe55c132ebe72b4d639cbf772d931e11b0990d29c1f691922b6ccabc1/ty-0.0.51-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8f52952cff665bc52a36147e610c10f5699d30007d7a14ab7f345cff93476ff", size = 12230135, upload-time = "2026-06-19T01:48:38.445Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1b/9aa428052dbed91c50919cd080426a313cf20ce14c6bfe2b71345e548671/ty-0.0.51-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:c1bd1355aee86af01e4e21b0bc16fc460fb05905761f0d8b8d70841de0feade8", size = 12468123, upload-time = "2026-06-19T01:48:40.47Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5a/f6ce69f2575259386c950c40e02578d0902760cb61f95045e9971182c24e/ty-0.0.51-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:79d1877e93460f936bc10ed1a31525702b7ce51075763ccba993be17f0b9e905", size = 11541672, upload-time = "2026-06-19T01:48:42.635Z" },
+    { url = "https://files.pythonhosted.org/packages/35/3a/2af48924a683e959e95e5cc4dc88e5a8595206a0812b869032b95196f2b0/ty-0.0.51-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:cc233a6235fb23e2a44b14731a10043e37ba2f30f2c361cf49ad3633c5b9da9c", size = 11694015, upload-time = "2026-06-19T01:48:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/12/899875d8a60b198c8121cb92ce18e18cc072d23ca2130fcdaa176383ef72/ty-0.0.51-py3-none-musllinux_1_2_i686.whl", hash = "sha256:bc7459348a253247bbfb2669a021e614281b86bbea24c36112b8a6e1a2499a16", size = 11832856, upload-time = "2026-06-19T01:48:47.028Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/a2/88f681d826d97cc96ef9f6cadd4935f775758944cee07340aa46113bce28/ty-0.0.51-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:49a21237f6fd1de56beaff0a3e85fe022a09a3401e67e3abec41ce838a5d4d2e", size = 12333449, upload-time = "2026-06-19T01:48:49.091Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/535a4163b4452c6978c31fedfd7b5803cf3a2253e9455cde350f86638d6a/ty-0.0.51-py3-none-win32.whl", hash = "sha256:61b4b6a003c3ebe53a63a1125c9b6542aa01bc1b6c9a235d01ee328d000d61a9", size = 11177338, upload-time = "2026-06-19T01:48:51.433Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4d/2334fbb74291a20129fa7aaa8f789619ec9b6883b27f997b8baa27e4674f/ty-0.0.51-py3-none-win_amd64.whl", hash = "sha256:608d417cd1eaf79bcbd713d9830d5e3db9d57ec225c3af3e4ac9a9ff66b45d70", size = 12325675, upload-time = "2026-06-19T01:48:53.774Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b5/d49096cd5f3694becb86a5a6ccd0f229ead695fc7430d6bc4dd0a104c6fe/ty-0.0.51-py3-none-win_arm64.whl", hash = "sha256:62ced5e380284f12b2dc4802a3e4ed3dac39913fc6719afde7978814a4c7f169", size = 11657350, upload-time = "2026-06-19T01:48:55.904Z" },
+]
+
+[[package]]
 name = "typer"
 version = "0.26.7"
 source = { registry = "https://pypi.org/simple" }
@@ -2305,33 +2131,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58", size = 122456, upload-time = "2026-06-03T07:18:05.732Z" },
-]
-
-[[package]]
-name = "types-defusedxml"
-version = "0.7.0.20260504"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/da/d2/4553c8fa9cdebfe1e84b950cf790a4d2376a97fa016e43f7c65323fa6c7d/types_defusedxml-0.7.0.20260504.tar.gz", hash = "sha256:2ab2828a3f97111ba1c16cee273ad4124a831fc9198c41bf8368ff6ea48ad300", size = 10729, upload-time = "2026-05-04T05:22:50.192Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/2d/8a4b5ba1d732b8bc691f0efbb1c6f77cb5f6f473b2afe181d83d910773c5/types_defusedxml-0.7.0.20260504-py3-none-any.whl", hash = "sha256:a959e3a0a43b93e464bd625d91ec9193a2703ddc10443bdd627792485fae0b10", size = 13467, upload-time = "2026-05-04T05:22:49.319Z" },
-]
-
-[[package]]
-name = "types-pyyaml"
-version = "6.0.12.20260518"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
-]
-
-[[package]]
-name = "types-toml"
-version = "0.10.8.20260518"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4b/11/6ece999e91f2ccb848ab4420f3f4816e78ac0541f739e6864affdaaa5737/types_toml-0.10.8.20260518.tar.gz", hash = "sha256:80e10facd24fdeda9d5c672187d72be3ac284843788d67f5aae59e3e016db6fe", size = 9419, upload-time = "2026-05-18T06:02:16.719Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/25/489751806bf5c95e4007f8e17409199c54d31e49ffbea07c5729b1286c8e/types_toml-0.10.8.20260518-py3-none-any.whl", hash = "sha256:0e564ab05f6fde62a315b3b5a9b6624fda569399795d30a37e64705a70459303", size = 9669, upload-time = "2026-05-18T06:02:15.86Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Integration branch for the over-engineering audit (PRD #129). Removes verified dead weight and collapses structural smells with **zero behavior change** to the shipped package — CLI human output, `--json`/`--yaml` output, exit codes, library API, and config-file format are all unchanged. Each slice was implemented TDD-first, adversarially reviewed to consensus, and gated locally before squash-merge.

Closes #129.

## What changed (8 squash-merged slices)

| Issue | Change |
|-------|--------|
| #137 | Remove dead empty CLI modules (`cli/run.py`, `cli/alias.py`) + unused `respx` dev dep |
| #130 | Consolidate linters on ruff — drop `bandit`/`vulture`/`pyupgrade` (subsumed by ruff `S`/`ERA`/`UP`); keep interrogate/radon/actionlint (they run in CI via pre-commit) |
| #131 | Remove dead commented-out "Instances column" block in `cli/stats.py` |
| #133 | Centralize the repeated `async def _cmd()` + `asyncio.run()` boilerplate into one CLI runner helper |
| #134 | `LegacyContextsMapping` subclasses `collections.abc.Mapping` (implement `__getitem__`/`__iter__`/`__len__`; explicit `__contains__` preserves membership semantics) |
| #135 | Break the `models/config.py` ↔ `config/selection.py` import cycle — 14 function-local imports lifted to module level, `# noqa: PLC0415` markers removed |
| #136 | Dedupe httpx sync/async hooks (`errors`/`auth`/`expiry`) via shared cores; `errors.py` uses a shared `_error_handling()` context manager that keeps the body read inside the guarded try (read-stage warnings preserved) |
| #143 | Replace mypy with Astral **ty** as the type checker (`canfar/` scope only); remove mypy dev dep/config/overrides/pre-commit hook/types-* stubs; add `[tool.ty]` + official `astral-sh/ty-pre-commit` hook |

#132 (RTK instruction dedup) was closed as not-applicable (local-only).

## Net

~43 files, +943 / −690. Production code shrank; the increase is TDD characterization tests added alongside each refactor.

## How it was verified

- Every slice kept the local gate green: `ruff check`, type-check (`mypy canfar` → `ty check canfar` after #143), and `pytest -m "not slow"` (737 passing at the tip).
- Each PR went through a 3-lens adversarial review panel (correctness / simplicity / spec) plus a synthesis verdict; merged only on consensus.
- Zero-behavior-change spot-checks: error-message constants byte-identical to baseline (#136); every `canfar/*.py` diff in #143 is a type-checker ignore-comment only (no `[tool.ty.rules]` relaxation; suppressions are load-bearing false-positives from ty lacking a pydantic plugin).

## Reviewer notes

- **CI implication of #143:** type-checking runs through the `pre-commit/action` in `ci.yml`, so the mypy→ty swap flows through pre-commit — there is no separate CI type-check step. `ty` is preview-stage (pinned v0.0.51).
- **#136 errors.py** intentionally accepts a small re-share via a context manager to keep read-stage `ReadTimeout`/`RequestError` warning-logged for both sync and async (deliberate decision to honor the "behavior unchanged" criterion).
- History is a clean sequence of conventional-commit squashes, one per slice — easy to review commit-by-commit.