### PR TITLE
feat(client): log HTTP URL and status at debug level

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,6 @@ This repo uses root `CONTEXT.md` as the current domain glossary. Specs and decis
 - Prefer Python stdlib utilities and Pydantic built-ins (`logging`, `model_dump`, `model_dump_json`, `SecretStr`) over custom serialization, config glue, Logfire, or telemetry stacks; keep the smallest footprint that preserves behavior (including CLI `--log-file`).
 - Prefer delete-first / net code and dependency reduction over new abstraction layers when cleaning maintainability debt.
 - Prefer fewer functional public-seam tests (CliRunner / httpx MockTransport) over large Authlib-mock or near-duplicate unit matrices.
-- For filesystem/data CLIs, prefer POSIX-shaped human output (`ls -l`/`-la`/`-lah`-style) over Rich tables/consoles; start with the most-used verbs, not full POSIX; embed via `fsspec_cli.App` (inject configured filesystems) rather than shipping a separate end-user binary.
-- For standalone/shared library specs (e.g. fsspec-cli), keep one self-contained reference document with no canfar domain-glossary or issue-tracker markdown cross-refs; external URLs are fine.
 
 ## Learned Workspace Facts
 
@@ -62,7 +60,6 @@ This repo uses root `CONTEXT.md` as the current domain glossary. Specs and decis
 - CLI machine output (`--json`/`--yaml`) must be data-only on stdout; the human-mode active-server banner must not precede JSON/YAML payloads; serialize via Pydantic `model_dump(mode="json")` or `to_jsonable_python`, not custom redaction helpers.
 - Built-in default CADC/CANFAR server metadata lists `x509` only; `oidc` and other auth modes are merged from VOSI capabilities enrichment after discovery/login, not static defaults.
 - `canfar ps -q` must print all matching session IDs and apply the same `--all`/running-only status filter as table mode; `canfar prune` PREFIX values with shell metacharacters (e.g. `*`) must be quoted so the shell does not expand them.
-- VOSpace/`canfar data` uses `shinybrar/vosfs` as the sole fsspec engine and embeds `fsspec-cli` (`from fsspec_cli import App`; interim under vosfs `src/fsspec_cli` for that repo’s release train) for POSIX verbs—thin domain glue that injects configured filesystems, not a released generic CLI or protocol reimplementation; work branch `feat/vosfs` (`feat/vospace` stale); call `AbstractFileSystem` directly (no UPath); v1 verbs `ls`/`cp`/`mv`/`rm`/`mkdir`/`stat`; consolidated local spec at `docs/agents/specs/fsspec-cli.md`.
 - `canfar.helpers.distributed` is documented public API used in user batch scripts, not internal/dead code.
 - When `HTTPClient` has runtime `token` or `certificate`, skip saved Authentication Record expiry and OIDC refresh httpx hooks (`uses_runtime_credentials`); saved-config hooks apply only without runtime credentials.
 - Observability is stdlib `logging` only (no Logfire or `canfar/utils/telemetry.py`); token masking relies on Pydantic `SecretStr`, not custom log redaction; CLI `--log-file` remains the local file sink.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,18 +47,22 @@ This repo uses root `CONTEXT.md` as the current domain glossary. Specs and decis
 - During broad refactors, preserve existing tests and avoid API/CLI output regressions unless the user explicitly approves those changes.
 - Do not introduce a separate DTO/request model layer; use the domain Pydantic models under `canfar/models/` directly and serialize the same model for `--json` output.
 - Prefer Python stdlib utilities and Pydantic built-ins (`logging`, `model_dump`, `model_dump_json`, `SecretStr`) over custom serialization, config glue, Logfire, or telemetry stacks; keep the smallest footprint that preserves behavior (including CLI `--log-file`).
+- Prefer delete-first / net code and dependency reduction over new abstraction layers when cleaning maintainability debt.
+- Prefer fewer functional public-seam tests (CliRunner / httpx MockTransport) over large Authlib-mock or near-duplicate unit matrices.
+- For filesystem/data CLIs, prefer POSIX-shaped human output (`ls -l`/`-la`/`-lah`-style) over Rich tables/consoles; start with the most-used verbs, not full POSIX; embed via `fsspec_cli.App` (inject configured filesystems) rather than shipping a separate end-user binary.
+- For standalone/shared library specs (e.g. fsspec-cli), keep one self-contained reference document with no canfar domain-glossary or issue-tracker markdown cross-refs; external URLs are fine.
 
 ## Learned Workspace Facts
 
-- Issue tracking and PRDs/specs use Jira on `herzberg.atlassian.net` (CADC project, `CANFAR` label required; e.g. `CADC-15643`), not GitHub Issues; durable agent decisions live under `docs/agents/adrs/`.
-- Triage is status-based in Jira: `needs-triage` -> To Do, `needs-info` -> On Hold, `ready-for-agent` -> In Progress, `ready-for-human` -> Review, `wontfix` -> On Hold.
+- Issue tracking and PRDs/specs use Jira on `herzberg.atlassian.net` (CADC project, `CANFAR` label required; e.g. `CADC-15643`), not GitHub Issues; durable agent decisions live under `docs/agents/adrs/`; triage status mapping: `needs-triage` -> To Do, `needs-info` -> On Hold, `ready-for-agent` -> In Progress, `ready-for-human` -> Review, `wontfix` -> On Hold.
 - Domain documentation currently uses root `CONTEXT.md` as the glossary.
-- Client configuration stores `servers` and `authentication` as dicts keyed by Server Name and IDP; `Server.name` and credential `idp` may duplicate those keys in nested values; Server Selection and `active` references use server names, not IVOA URIs.
-- `Session.create` and `AsyncSession.create` should preserve parity and return `list[str]`, using `[]` on total HTTP/network failure without raising.
+- Client configuration stores `servers` and `authentication` as dicts keyed by Server Name and IDP; `Server.name` and credential `idp` may duplicate those keys in nested values; Server Selection and `active` references use server names, not IVOA URIs; server-selection helpers live on `Configuration` (`canfar/config/selection.py` was absorbed and deleted).
+- `Session.create` / `AsyncSession.create` should preserve parity and return `list[str]` (`[]` on total HTTP/network failure without raising); `destroy_with` is keyword-only for `kind`/`status` on both sync and async.
 - CLI layout is kubectl-style: `canfar auth` (bare runs `show`; canonical subcommand names only, `ls`/`rm`), `canfar server`, and `canfar login` (`canfar auth login` is a deprecated alias; `canfar context` was removed).
 - CLI machine output (`--json`/`--yaml`) must be data-only on stdout; the human-mode active-server banner must not precede JSON/YAML payloads; serialize via Pydantic `model_dump(mode="json")` or `to_jsonable_python`, not custom redaction helpers.
 - Built-in default CADC/CANFAR server metadata lists `x509` only; `oidc` and other auth modes are merged from VOSI capabilities enrichment after discovery/login, not static defaults.
-- `canfar ps -q` must print all matching session IDs and apply the same `--all`/running-only status filter as table mode.
+- `canfar ps -q` must print all matching session IDs and apply the same `--all`/running-only status filter as table mode; `canfar prune` PREFIX values with shell metacharacters (e.g. `*`) must be quoted so the shell does not expand them.
+- VOSpace/`canfar data` uses `shinybrar/vosfs` as the sole fsspec engine and embeds `fsspec-cli` (`from fsspec_cli import App`; interim under vosfs `src/fsspec_cli` for that repo’s release train) for POSIX verbs—thin domain glue that injects configured filesystems, not a released generic CLI or protocol reimplementation; work branch `feat/vosfs` (`feat/vospace` stale); call `AbstractFileSystem` directly (no UPath); v1 verbs `ls`/`cp`/`mv`/`rm`/`mkdir`/`stat`; consolidated local spec at `docs/agents/specs/fsspec-cli.md`.
 - `canfar.helpers.distributed` is documented public API used in user batch scripts, not internal/dead code.
 - When `HTTPClient` has runtime `token` or `certificate`, skip saved Authentication Record expiry and OIDC refresh httpx hooks (`uses_runtime_credentials`); saved-config hooks apply only without runtime credentials.
 - Observability is stdlib `logging` only (no Logfire or `canfar/utils/telemetry.py`); token masking relies on Pydantic `SecretStr`, not custom log redaction; CLI `--log-file` remains the local file sink.

--- a/canfar/client.py
+++ b/canfar/client.py
@@ -22,7 +22,7 @@ from typing_extensions import Self
 from canfar import __version__, get_logger
 from canfar.auth import x509
 from canfar.exceptions.context import AuthContextError
-from canfar.hooks.httpx import auth, errors, expiry
+from canfar.hooks.httpx import auth, debug, errors, expiry
 from canfar.models.auth import (
     AuthenticationCredential,
     OIDCCredential,
@@ -268,11 +268,16 @@ class HTTPClient(BaseSettings):
             dict[str, Any]: Keyword arguments for creating an HTTPx client.
         """
         catcher = errors.acatch if asynchronous else errors.catch
-        response_hooks = [catcher] if self.raise_http_errors else []
+        req_logger = debug.arequest if asynchronous else debug.request
+        resp_logger = debug.aresponse if asynchronous else debug.response
+        response_hooks = [resp_logger]
+        if self.raise_http_errors:
+            response_hooks.append(catcher)
         request_hooks: list[Any] = []
         if credential is not None:
             checker = expiry.acheck(self) if asynchronous else expiry.check(self)
             request_hooks.append(checker)
+        request_hooks.append(req_logger)
         kwargs: dict[str, Any] = {
             "timeout": Timeout(self.timeout),
             "event_hooks": {"request": request_hooks, "response": response_hooks},

--- a/canfar/hooks/httpx/debug.py
+++ b/canfar/hooks/httpx/debug.py
@@ -1,0 +1,39 @@
+"""HTTPx hooks that log request URLs and response bodies at DEBUG."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from canfar import get_logger
+
+if TYPE_CHECKING:
+    import httpx
+
+log = get_logger(__name__)
+
+
+def request(req: httpx.Request) -> None:
+    """Log the outgoing request method and URL."""
+    log.debug("%s %s", req.method, req.url)
+
+
+async def arequest(req: httpx.Request) -> None:
+    """Log the outgoing request method and URL (async)."""
+    log.debug("%s %s", req.method, req.url)
+
+
+def response(resp: httpx.Response) -> None:
+    """Log the response status code and body."""
+    if not log.isEnabledFor(logging.DEBUG):
+        return
+    resp.read()
+    log.debug("HTTP STATUS CODE -> %s\n%s", resp.status_code, resp.text)
+
+
+async def aresponse(resp: httpx.Response) -> None:
+    """Log the response status code and body (async)."""
+    if not log.isEnabledFor(logging.DEBUG):
+        return
+    await resp.aread()
+    log.debug("HTTP STATUS CODE -> %s\n%s", resp.status_code, resp.text)

--- a/docs/cli/logging.md
+++ b/docs/cli/logging.md
@@ -84,6 +84,21 @@ configure_logging(
 
 There is no per-`HTTPClient`, `Session`, or `AsyncSession` log-level setting.
 
+## HTTP request and response debug
+
+At `debug` (for example `--log-level debug` or `-vvvv`), every Science Platform
+HTTP call logs the request method and full URL, then the response status and
+body:
+
+```text
+DEBUG  GET https://ws-uv.canfar.net/skaha/v0/session?status=Running
+DEBUG  HTTP STATUS CODE -> 200
+[{"id":"...","status":"Running",...}]
+```
+
+These lines follow the normal logging policy: stderr (and the optional file
+sink), never mixed into `--json`/`--yaml` stdout payloads.
+
 ## stdout and stderr
 
 CANFAR keeps command data separate from diagnostics:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -693,8 +693,10 @@ class TestSSLContextAndClientKwargs:
             asynchronous=True, credential=client._resolved_authentication_record()
         )
 
-        assert sync_kwargs["event_hooks"]["request"] == []
-        assert async_kwargs["event_hooks"]["request"] == []
+        assert len(sync_kwargs["event_hooks"]["request"]) == 1
+        assert len(async_kwargs["event_hooks"]["request"]) == 1
+        assert sync_kwargs["event_hooks"]["request"][0].__name__ == "request"
+        assert async_kwargs["event_hooks"]["request"][0].__name__ == "arequest"
 
     def test_expiry_hook_present_for_saved_expired_x509(
         self, canfar_client_fixture, tmp_path
@@ -712,10 +714,12 @@ class TestSSLContextAndClientKwargs:
             asynchronous=True, credential=client._resolved_authentication_record()
         )
 
-        assert len(sync_kwargs["event_hooks"]["request"]) == 1
-        assert len(async_kwargs["event_hooks"]["request"]) == 1
+        assert len(sync_kwargs["event_hooks"]["request"]) == 2
+        assert len(async_kwargs["event_hooks"]["request"]) == 2
         assert sync_kwargs["event_hooks"]["request"][0].__name__ == "hook"
         assert async_kwargs["event_hooks"]["request"][0].__name__ == "hook"
+        assert sync_kwargs["event_hooks"]["request"][1].__name__ == "request"
+        assert async_kwargs["event_hooks"]["request"][1].__name__ == "arequest"
 
     def test_get_client_kwargs_with_certificate(
         self, canfar_client_fixture, tmp_path

--- a/tests/test_hooks_httpx_debug.py
+++ b/tests/test_hooks_httpx_debug.py
@@ -1,0 +1,71 @@
+"""HTTP debug hooks log request URL and response body at DEBUG."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+import httpx
+import pytest
+from pydantic import SecretStr
+
+from canfar.client import HTTPClient
+
+
+@pytest.mark.asyncio
+async def test_http_debug_hooks_log_url_and_response(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Sync and async clients log query URL plus response at DEBUG."""
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json=[{"id": "abc"}],
+            request=request,
+        )
+
+    base_url = "https://example.test/skaha/v0/"
+    transport = httpx.MockTransport(respond)
+    real_client = httpx.Client
+    real_async_client = httpx.AsyncClient
+
+    with (
+        patch(
+            "canfar.client.Client",
+            side_effect=lambda **kwargs: real_client(transport=transport, **kwargs),
+        ),
+        patch(
+            "canfar.client.AsyncClient",
+            side_effect=lambda **kwargs: real_async_client(
+                transport=transport,
+                **kwargs,
+            ),
+        ),
+        caplog.at_level(logging.DEBUG, logger="canfar.hooks.httpx.debug"),
+        HTTPClient(token=SecretStr("token"), url=base_url) as client,
+    ):
+        client.client.get("session", params={"status": "Running"})
+        async with HTTPClient(token=SecretStr("token"), url=base_url) as aclient:
+            await aclient.asynclient.get("session", params={"status": "Running"})
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "canfar.hooks.httpx.debug"
+    ]
+    assert any(
+        message.startswith("GET ") and "session?status=Running" in message
+        for message in messages
+    )
+    assert any(
+        message.startswith("HTTP STATUS CODE -> 200")
+        and '"id"' in message
+        and "abc" in message
+        for message in messages
+    )
+    assert sum(1 for message in messages if message.startswith("GET ")) == 2
+    assert (
+        sum(1 for message in messages if message.startswith("HTTP STATUS CODE -> 200"))
+        == 2
+    )


### PR DESCRIPTION
## Summary
- Add HTTPClient request/response debug hooks that log the query URL and `HTTP STATUS CODE -> …` with the response body when logging is at `debug` (`--log-level debug` / `-vvvv`).
- Document the behavior in `docs/cli/logging.md` and cover it with focused client hook tests.
- Drop stale fsspec-related notes from `AGENTS.md`.

## Test plan
- [x] `uv run --no-sync pytest tests/test_hooks_httpx_debug.py tests/test_client.py::TestSSLContextAndClientKwargs -m "not slow" --no-cov -q`
- [x] Run `canfar --log-level debug stats` (or `ps`) and confirm stderr shows one URL line then `HTTP STATUS CODE -> 200` plus body, with no duplicated URL on the status line
- [x] Confirm `--json`/`--yaml` stdout stays data-only while debug lines stay on stderr