### PR TITLE
Emit the active-server banner from terminal command dispatch

### DIFF
--- a/canfar/cli/auth.py
+++ b/canfar/cli/auth.py
@@ -27,7 +27,7 @@ from canfar.authentication import (
     show as auth_show,
 )
 from canfar.cli import output
-from canfar.cli.machine import JsonOption, YamlOption, maybe_emit_banner, resolve_mode
+from canfar.cli.machine import JsonOption, YamlOption, resolve_mode
 from canfar.config.migration import ConfigResetRequiredError
 from canfar.errors import StructuredError
 from canfar.hooks.typer.aliases import AliasGroup
@@ -216,7 +216,6 @@ def auth_default(
         return
 
     mode = resolve_mode(json_output, yaml_output)
-    maybe_emit_banner(mode)
     _auth_show(mode)
 
 
@@ -227,7 +226,6 @@ def auth_show_command(
 ) -> None:
     """Active authentication state."""
     mode = resolve_mode(json_output, yaml_output)
-    maybe_emit_banner(mode)
     _auth_show(mode)
 
 
@@ -238,7 +236,6 @@ def auth_list_command(
 ) -> None:
     """Available auth providers."""
     mode = resolve_mode(json_output, yaml_output)
-    maybe_emit_banner(mode)
     try:
         summaries = auth_list()
     except ConfigResetRequiredError as exc:
@@ -278,7 +275,6 @@ def auth_login_command(
     from canfar.cli.prompts import select_idp  # noqa: PLC0415
     from canfar.idp import list_idps  # noqa: PLC0415
 
-    maybe_emit_banner(output.OutputMode.HUMAN)
     get_console(stderr=True).print(
         "\n[red]Deprecation Notice:[/red]"
         "\n[yellow]canfar auth login[/yellow] will be removed soon."
@@ -293,7 +289,6 @@ def auth_use_command(
     idp: Annotated[str, typer.Argument(help="Canonical Identity Provider key.")],
 ) -> None:
     """Switch auth provider."""
-    maybe_emit_banner(output.OutputMode.HUMAN)
     config = Configuration()  # ty: ignore[missing-argument]
 
     try:
@@ -334,7 +329,6 @@ def auth_remove_command(
     ] = False,
 ) -> None:
     """Remove auth and associated servers."""
-    maybe_emit_banner(output.OutputMode.HUMAN)
     config = Configuration()  # ty: ignore[missing-argument]
     if config.active.authentication == idp and not force:
         should_remove = Confirm.ask(
@@ -370,7 +364,6 @@ def auth_purge_command(
     ] = False,
 ) -> None:
     """Remove all auths and servers."""
-    maybe_emit_banner(output.OutputMode.HUMAN)
     if not force:
         get_console(stderr=True).print(
             "[bold red]Authentication purge requires --force.[/bold red]"

--- a/canfar/cli/config.py
+++ b/canfar/cli/config.py
@@ -10,7 +10,7 @@ from pydantic_settings.exceptions import SettingsError
 
 from canfar import CONFIG_PATH
 from canfar.cli import output
-from canfar.cli.machine import JsonOption, YamlOption, maybe_emit_banner, resolve_mode
+from canfar.cli.machine import JsonOption, YamlOption, resolve_mode
 from canfar.config.migration import ConfigResetRequiredError
 from canfar.errors import ErrorCode, StructuredError
 from canfar.hooks.typer.aliases import AliasGroup
@@ -44,7 +44,6 @@ def show(
 ) -> None:
     """Display client configuration."""
     mode = resolve_mode(json_output, yaml_output)
-    maybe_emit_banner(mode)
     try:
         cfg = Configuration()  # ty: ignore[missing-argument]
     except (
@@ -106,7 +105,6 @@ def get(
     canfar config get servers.canfar.url
     """
     mode = resolve_mode(json_output, yaml_output)
-    maybe_emit_banner(mode)
     try:
         cfg = Configuration()  # ty: ignore[missing-argument]
     except (
@@ -158,7 +156,6 @@ def set_value(
     canfar config set active.authentication cadc
     canfar config set servers.canfar.url https://ws-uv.canfar.net/skaha
     """
-    maybe_emit_banner(output.OutputMode.HUMAN)
     cfg = Configuration()  # ty: ignore[missing-argument]
     try:
         parsed = yaml.safe_load(value)
@@ -172,5 +169,4 @@ def set_value(
 @config.command("path", help="Local path of config")
 def path() -> None:
     """Local path of config."""
-    maybe_emit_banner(output.OutputMode.HUMAN)
     get_console().print(f"[green]{CONFIG_PATH}[/green]")

--- a/canfar/cli/create.py
+++ b/canfar/cli/create.py
@@ -14,7 +14,6 @@ from canfar.cli._run import run
 from canfar.cli.machine import (
     JsonOption,
     YamlOption,
-    maybe_emit_banner,
     resolve_mode,
 )
 from canfar.config.migration import ConfigResetRequiredError
@@ -220,7 +219,6 @@ def creation(
     canfar create headless skaha/base-notebook:latest -- python3 /path/to/script.py
     """
     mode = resolve_mode(json_output, yaml_output)
-    maybe_emit_banner(mode)
     if dry and mode is not output.OutputMode.HUMAN:
         typer.echo(
             "Incompatible flags: --dry-run cannot be used with --json or --yaml.",

--- a/canfar/cli/delete.py
+++ b/canfar/cli/delete.py
@@ -8,8 +8,6 @@ import typer
 from rich.prompt import Confirm
 
 from canfar.cli._run import run
-from canfar.cli.machine import maybe_emit_banner
-from canfar.cli.output import OutputMode
 from canfar.hooks.typer.aliases import AliasGroup
 from canfar.sessions import AsyncSession
 from canfar.utils.console import get_console
@@ -42,7 +40,6 @@ def delete_sessions(
     canfar delete abc123
     canfar delete abc123 def456
     """
-    maybe_emit_banner(OutputMode.HUMAN)
     if force:
         proceed: bool = True
     else:

--- a/canfar/cli/events.py
+++ b/canfar/cli/events.py
@@ -10,8 +10,6 @@ from rich import box
 from rich.table import Table
 
 from canfar.cli._run import run
-from canfar.cli.machine import maybe_emit_banner
-from canfar.cli.output import OutputMode
 from canfar.sessions import AsyncSession
 from canfar.utils.console import get_console
 
@@ -30,7 +28,6 @@ def get_events(
     ],
 ) -> None:
     """Get events from the science platform server."""
-    maybe_emit_banner(OutputMode.HUMAN)
 
     async def _get_events() -> None:
         """Fetch events for the requested sessions and render them."""

--- a/canfar/cli/image.py
+++ b/canfar/cli/image.py
@@ -10,8 +10,6 @@ from rich import box
 from rich.table import Table
 from rich.text import Text
 
-from canfar.cli.machine import maybe_emit_banner
-from canfar.cli.output import OutputMode
 from canfar.images import Images
 from canfar.models.types import Kind
 from canfar.utils.console import get_console
@@ -82,7 +80,6 @@ def ls(
     ] = None,
 ) -> None:
     """List available images."""
-    maybe_emit_banner(OutputMode.HUMAN)
     payload: list[Image] = Images().details()
     images = [image for image in payload if not kind or kind in image.types]
     if not images:

--- a/canfar/cli/info.py
+++ b/canfar/cli/info.py
@@ -12,8 +12,6 @@ from rich import box
 from rich.table import Table
 
 from canfar.cli._run import run
-from canfar.cli.machine import maybe_emit_banner
-from canfar.cli.output import OutputMode
 from canfar.models.session import FetchResponse
 from canfar.sessions import AsyncSession
 from canfar.utils.console import get_console
@@ -185,5 +183,4 @@ def get_info(
     ] = False,
 ) -> None:
     """Get detailed information about one or more sessions."""
-    maybe_emit_banner(OutputMode.HUMAN)
     run(_get_info(session_ids, debug))

--- a/canfar/cli/login.py
+++ b/canfar/cli/login.py
@@ -7,9 +7,7 @@ from typing import Annotated
 import typer
 
 from canfar import CONFIG_PATH
-from canfar.cli import output
 from canfar.cli.login_auth import authenticate_for_cli
-from canfar.cli.machine import maybe_emit_banner
 from canfar.cli.prompts import select_idp, select_server
 from canfar.idp import get_idp, list_idps
 from canfar.models.config import Configuration
@@ -144,7 +142,6 @@ def register_login_command(app: typer.Typer) -> None:
         ] = 10,
     ) -> None:
         """Login to CANFAR Science Platform."""
-        maybe_emit_banner(output.OutputMode.HUMAN)
         selected_idp = idp or select_idp(list_idps())
         try:
             get_idp(selected_idp)

--- a/canfar/cli/logs.py
+++ b/canfar/cli/logs.py
@@ -7,8 +7,6 @@ from typing import Annotated
 import typer
 
 from canfar.cli._run import run
-from canfar.cli.machine import maybe_emit_banner
-from canfar.cli.output import OutputMode
 from canfar.sessions import AsyncSession
 from canfar.utils.console import get_console
 
@@ -27,7 +25,6 @@ def get_logs(
     ],
 ) -> None:
     """Get logs from the science platform server."""
-    maybe_emit_banner(OutputMode.HUMAN)
 
     async def _get_logs() -> None:
         """Fetch logs for the requested sessions and render them."""

--- a/canfar/cli/machine.py
+++ b/canfar/cli/machine.py
@@ -7,7 +7,6 @@ from typing import Annotated
 import typer
 
 from canfar.cli import output
-from canfar.utils.console import emit_active_server_banner, reset_banner_state
 
 JsonOption = Annotated[
     bool,
@@ -20,11 +19,6 @@ YamlOption = Annotated[
     typer.Option("--yaml", help="Emit machine-readable YAML on stdout."),
 ]
 """Leaf command flag for YAML machine output."""
-
-
-def reset() -> None:
-    """Reset CLI banner state for a new invocation."""
-    reset_banner_state()
 
 
 def resolve_mode(json_output: bool, yaml_output: bool) -> output.OutputMode:
@@ -51,13 +45,3 @@ def resolve_mode(json_output: bool, yaml_output: bool) -> output.OutputMode:
     if yaml_output:
         return output.OutputMode.YAML
     return output.OutputMode.HUMAN
-
-
-def maybe_emit_banner(mode: output.OutputMode) -> None:
-    """Emit the active-server banner when output is human-readable.
-
-    Args:
-        mode: Resolved output mode for the current command.
-    """
-    if mode is output.OutputMode.HUMAN:
-        emit_active_server_banner()

--- a/canfar/cli/main.py
+++ b/canfar/cli/main.py
@@ -49,14 +49,15 @@ def _leaf_output_mode(args: list[str]) -> output.OutputMode:
 
 def _is_help_request(ctx: typer.Context, args: list[str]) -> bool:
     """Return whether root dispatch will resolve to explicit or implicit help."""
-    if "--help" in args:
-        return True
-    if args or ctx.invoked_subcommand is None:
-        return False
-    if not isinstance(ctx.command, AliasGroup):
+    if not isinstance(ctx.command, AliasGroup) or ctx.invoked_subcommand is None:
         return False
     command = ctx.command.get_command(ctx, ctx.invoked_subcommand)
-    return bool(command and getattr(command, "no_args_is_help", False))
+    if command is None:
+        return False
+    help_options = (command.context_settings or {}).get("help_option_names", ["--help"])
+    return any(option in args for option in help_options) or bool(
+        not args and command.no_args_is_help
+    )
 
 
 def callback(
@@ -87,6 +88,8 @@ def callback(
 ) -> None:
     """Main callback that handles no subcommand case."""
     child_args: list[str] = ctx.meta.get(ROOT_CHILD_ARGS_META_KEY, [])
+    if "--" in child_args:
+        child_args = child_args[: child_args.index("--")]
     mode = _leaf_output_mode(child_args)
 
     def warning_writer(error: StructuredError) -> None:

--- a/canfar/cli/main.py
+++ b/canfar/cli/main.py
@@ -25,7 +25,11 @@ from canfar.cli.stats import stats
 from canfar.cli.version import version
 from canfar.config.migration import ConfigResetRequiredError
 from canfar.exceptions.context import AuthContextError, AuthExpiredError
-from canfar.hooks.typer.aliases import ROOT_CHILD_ARGS_META_KEY, AliasGroup
+from canfar.hooks.typer.aliases import (
+    ROOT_CHILD_ARGS_META_KEY,
+    AliasGroup,
+    set_before_command,
+)
 from canfar.utils.console import emit_active_server_banner, get_console
 from canfar.utils.logging import (
     InvalidLogFilePathError,
@@ -35,6 +39,8 @@ from canfar.utils.logging import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from canfar.errors import StructuredError
 
 
@@ -47,17 +53,11 @@ def _leaf_output_mode(args: list[str]) -> output.OutputMode:
     return output.OutputMode.HUMAN
 
 
-def _is_help_request(ctx: typer.Context, args: list[str]) -> bool:
-    """Return whether root dispatch will resolve to explicit or implicit help."""
-    if not isinstance(ctx.command, AliasGroup) or ctx.invoked_subcommand is None:
-        return False
-    command = ctx.command.get_command(ctx, ctx.invoked_subcommand)
-    if command is None:
-        return False
-    help_options = (command.context_settings or {}).get("help_option_names", ["--help"])
-    return any(option in args for option in help_options) or bool(
-        not args and command.no_args_is_help
-    )
+def _emit_banner_for_command(params: Mapping[str, object]) -> None:
+    """Emit the active-server banner for a parsed human-output command."""
+    if params.get("json_output") or params.get("yaml_output"):
+        return
+    emit_active_server_banner()
 
 
 def callback(
@@ -90,13 +90,13 @@ def callback(
     child_args: list[str] = ctx.meta.get(ROOT_CHILD_ARGS_META_KEY, [])
     if "--" in child_args:
         child_args = child_args[: child_args.index("--")]
-    mode = _leaf_output_mode(child_args)
+    setup_mode = _leaf_output_mode(child_args)
 
     def warning_writer(error: StructuredError) -> None:
-        if mode is output.OutputMode.HUMAN:
+        if setup_mode is output.OutputMode.HUMAN:
             typer.echo(f"{error.code}: {error.message}", err=True)
         else:
-            output.to_stderr(error, mode)
+            output.to_stderr(error, setup_mode)
 
     try:
         configure_logging(
@@ -106,17 +106,16 @@ def callback(
             warning_writer=warning_writer,
         )
     except (InvalidLoggingEnvironmentError, InvalidLogFilePathError) as err:
-        if mode is output.OutputMode.HUMAN:
+        if setup_mode is output.OutputMode.HUMAN:
             typer.echo(str(err), err=True)
         else:
-            output.to_stderr(err.error, mode)
+            output.to_stderr(err.error, setup_mode)
         raise typer.Exit(2) from err
 
     if ctx.invoked_subcommand is None:
         get_console().print(ctx.get_help())
         raise typer.Exit(0)
-    if mode is output.OutputMode.HUMAN and not _is_help_request(ctx, child_args):
-        emit_active_server_banner()
+    set_before_command(ctx, _emit_banner_for_command)
 
 
 cli: typer.Typer = typer.Typer(

--- a/canfar/cli/main.py
+++ b/canfar/cli/main.py
@@ -17,7 +17,6 @@ from canfar.cli.image import image
 from canfar.cli.info import info
 from canfar.cli.login import register_login_command
 from canfar.cli.logs import logs
-from canfar.cli.machine import reset
 from canfar.cli.open import open_command
 from canfar.cli.prune import prune
 from canfar.cli.ps import ps
@@ -27,7 +26,7 @@ from canfar.cli.version import version
 from canfar.config.migration import ConfigResetRequiredError
 from canfar.exceptions.context import AuthContextError, AuthExpiredError
 from canfar.hooks.typer.aliases import ROOT_CHILD_ARGS_META_KEY, AliasGroup
-from canfar.utils.console import get_console
+from canfar.utils.console import emit_active_server_banner, get_console
 from canfar.utils.logging import (
     InvalidLogFilePathError,
     InvalidLoggingEnvironmentError,
@@ -46,6 +45,18 @@ def _leaf_output_mode(args: list[str]) -> output.OutputMode:
     if "--yaml" in args:
         return output.OutputMode.YAML
     return output.OutputMode.HUMAN
+
+
+def _is_help_request(ctx: typer.Context, args: list[str]) -> bool:
+    """Return whether root dispatch will resolve to explicit or implicit help."""
+    if "--help" in args:
+        return True
+    if args or ctx.invoked_subcommand is None:
+        return False
+    if not isinstance(ctx.command, AliasGroup):
+        return False
+    command = ctx.command.get_command(ctx, ctx.invoked_subcommand)
+    return bool(command and getattr(command, "no_args_is_help", False))
 
 
 def callback(
@@ -75,7 +86,6 @@ def callback(
     ] = None,
 ) -> None:
     """Main callback that handles no subcommand case."""
-    reset()
     child_args: list[str] = ctx.meta.get(ROOT_CHILD_ARGS_META_KEY, [])
     mode = _leaf_output_mode(child_args)
 
@@ -102,6 +112,8 @@ def callback(
     if ctx.invoked_subcommand is None:
         get_console().print(ctx.get_help())
         raise typer.Exit(0)
+    if mode is output.OutputMode.HUMAN and not _is_help_request(ctx, child_args):
+        emit_active_server_banner()
 
 
 cli: typer.Typer = typer.Typer(
@@ -247,7 +259,6 @@ cli.add_typer(
 
 def main() -> None:
     """Main entry point."""
-    reset()
     try:
         cli()
     except AuthExpiredError as err:
@@ -260,8 +271,6 @@ def main() -> None:
     except ConfigResetRequiredError as err:
         get_console(stderr=True).print(err)
         raise typer.Exit(1) from err
-    finally:
-        reset()
 
 
 if __name__ == "__main__":

--- a/canfar/cli/open.py
+++ b/canfar/cli/open.py
@@ -8,8 +8,6 @@ from typing import Annotated
 import typer
 
 from canfar.cli._run import run
-from canfar.cli.machine import maybe_emit_banner
-from canfar.cli.output import OutputMode
 from canfar.sessions import AsyncSession, connection_url
 
 open_command = typer.Typer(
@@ -27,7 +25,6 @@ def open_sessions(
     ],
 ) -> None:
     """Open one or more sessions in a web browser."""
-    maybe_emit_banner(OutputMode.HUMAN)
 
     async def _open_sessions() -> None:
         """Look up the requested sessions and open their connect URLs."""

--- a/canfar/cli/prune.py
+++ b/canfar/cli/prune.py
@@ -9,8 +9,6 @@ import typer
 import typer.core
 
 from canfar.cli._run import run
-from canfar.cli.machine import maybe_emit_banner
-from canfar.cli.output import OutputMode
 from canfar.models.types import Pruneable, Status
 from canfar.sessions import AsyncSession
 from canfar.utils.console import get_console
@@ -84,7 +82,6 @@ def prune_sessions(
     canfar prune session-name headless Succeeded
     canfar prune 'session.*' notebook Running
     """
-    maybe_emit_banner(OutputMode.HUMAN)
 
     async def _prune() -> None:
         """Delete matching sessions from the science platform server."""

--- a/canfar/cli/ps.py
+++ b/canfar/cli/ps.py
@@ -15,7 +15,7 @@ from rich.table import Table
 
 from canfar.cli import output
 from canfar.cli._run import run
-from canfar.cli.machine import JsonOption, YamlOption, maybe_emit_banner, resolve_mode
+from canfar.cli.machine import JsonOption, YamlOption, resolve_mode
 from canfar.config.migration import ConfigResetRequiredError
 from canfar.exceptions.context import AuthContextError, AuthExpiredError
 from canfar.hooks.typer.aliases import AliasGroup
@@ -200,7 +200,6 @@ def show(
 ) -> None:
     """Show sessions."""
     mode = resolve_mode(json_output, yaml_output)
-    maybe_emit_banner(mode)
 
     if quiet and mode is not output.OutputMode.HUMAN:
         typer.echo(

--- a/canfar/cli/server.py
+++ b/canfar/cli/server.py
@@ -11,7 +11,7 @@ from rich.table import Table
 from canfar.authentication import AuthenticationError
 from canfar.authentication import show as auth_show
 from canfar.cli import output
-from canfar.cli.machine import JsonOption, YamlOption, maybe_emit_banner, resolve_mode
+from canfar.cli.machine import JsonOption, YamlOption, resolve_mode
 from canfar.config.migration import ConfigResetRequiredError
 from canfar.errors import ErrorCode, StructuredError
 from canfar.hooks.typer.aliases import AliasGroup
@@ -70,7 +70,6 @@ def server_list_command(
 ) -> None:
     """List servers for the active Identity Provider."""
     mode = resolve_mode(json_output, yaml_output)
-    maybe_emit_banner(mode)
 
     try:
         auth_show()
@@ -128,7 +127,6 @@ def server_use_command(
     selector: Annotated[str, typer.Argument(help="Server name or URI.")],
 ) -> None:
     """Select the active server by name or URI."""
-    maybe_emit_banner(output.OutputMode.HUMAN)
     try:
         server_use(selector)
     except ServerSelectorError as exc:

--- a/canfar/cli/stats.py
+++ b/canfar/cli/stats.py
@@ -7,8 +7,6 @@ from rich import box
 from rich.table import Table
 
 from canfar.cli._run import run
-from canfar.cli.machine import maybe_emit_banner
-from canfar.cli.output import OutputMode
 from canfar.sessions import AsyncSession
 from canfar.utils.console import get_console
 
@@ -22,7 +20,6 @@ stats = typer.Typer(
 @stats.callback(invoke_without_command=True)
 def get_stats() -> None:
     """Display cluster-wide usage and status statistics."""
-    maybe_emit_banner(OutputMode.HUMAN)
 
     async def _get_stats() -> None:
         """Fetch cluster-wide statistics and render them."""

--- a/canfar/cli/version.py
+++ b/canfar/cli/version.py
@@ -10,8 +10,6 @@ import typer
 from rich.table import Table
 
 from canfar import __version__
-from canfar.cli.machine import maybe_emit_banner
-from canfar.cli.output import OutputMode
 from canfar.utils.console import get_console
 
 
@@ -24,7 +22,6 @@ def callback(
     ),
 ) -> None:
     """CANFAR Python Client version information."""
-    maybe_emit_banner(OutputMode.HUMAN)
     if not debug:
         # Simple version output
         get_console().print(f"CANFAR Python Client {__version__}")

--- a/canfar/hooks/typer/aliases.py
+++ b/canfar/hooks/typer/aliases.py
@@ -1,35 +1,74 @@
-"""AliasGroup for extending command aliases in Typer."""
+"""Typer group extensions for aliases and terminal command dispatch."""
 
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, TypeVar
 
+from typer import Context
 from typer.core import TyperGroup
 
 if TYPE_CHECKING:
-    from typer._click.core import Command, Context
+    from collections.abc import Callable, Mapping
+
+    from typer._click.core import Command
+    from typer._click.core import Context as ClickContext
 
 ROOT_CHILD_ARGS_META_KEY = "canfar.root_child_args"
+_BEFORE_COMMAND_META_KEY = "canfar.before_command"
+_Value = TypeVar("_Value")
+
+
+def set_before_command(
+    ctx: Context,
+    callback: Callable[[Mapping[str, object]], None],
+) -> None:
+    """Run a callback after terminal command parsing and before its handler."""
+    ctx.meta[_BEFORE_COMMAND_META_KEY] = callback
+
+
+def _run_before_command(ctx: Context) -> None:
+    callback = ctx.meta.pop(_BEFORE_COMMAND_META_KEY, None)
+    if callback is not None:
+        callback(ctx.params)
+
+
+class _BeforeCommandContext(Context):
+    """Run the pending hook immediately before a terminal command callback."""
+
+    def invoke(
+        self,
+        callback: Callable[..., _Value],
+        /,
+        *args: Any,
+        **kwargs: Any,
+    ) -> _Value:
+        if not isinstance(self.command, TyperGroup) or self.invoked_subcommand is None:
+            _run_before_command(self)
+        return super().invoke(callback, *args, **kwargs)
+
+
+def _install_before_command_context(command: Command) -> None:
+    command.context_class = _BeforeCommandContext
+    if isinstance(command, TyperGroup):
+        for child in command.commands.values():
+            _install_before_command_context(child)
 
 
 class AliasGroup(TyperGroup):
-    """AliasGroup to handle command aliases in Typer.
-
-    Args:
-        TyperGroup (TyperGroup): Base class for grouping commands in Typer.
-    """
+    """Typer group with command aliases and one-shot terminal hooks."""
 
     _CMD_SPLIT_P = re.compile(r" ?[,|] ?")
+    context_class = _BeforeCommandContext
 
-    def parse_args(self, ctx: Context, args: list[str]) -> list[str]:
+    def parse_args(self, ctx: ClickContext, args: list[str]) -> list[str]:
         """Preserve the root command's parsed child arguments for setup errors."""
         child_args = super().parse_args(ctx, args)
         if ctx.parent is None:
             ctx.meta[ROOT_CHILD_ARGS_META_KEY] = list(child_args)
         return child_args
 
-    def get_command(self, ctx: Context, cmd_name: str) -> Command | None:
+    def get_command(self, ctx: ClickContext, cmd_name: str) -> Command | None:
         """Retrieve a command by name, supporting aliases.
 
         Args:
@@ -40,7 +79,10 @@ class AliasGroup(TyperGroup):
             Command | None: The matched command or None if not found.
         """
         cmd_name = self._group_cmd_name(cmd_name)
-        return super().get_command(ctx, cmd_name)
+        command = super().get_command(ctx, cmd_name)
+        if command is not None:
+            _install_before_command_context(command)
+        return command
 
     def _group_cmd_name(self, default: str) -> str:
         for cmd in self.commands.values():

--- a/canfar/models/config.py
+++ b/canfar/models/config.py
@@ -84,6 +84,11 @@ class ConsoleConfig(BaseModel):
         description="Width of the console output.",
         ge=1,
     )
+    banner: bool = Field(
+        default=True,
+        title="Console Banner",
+        description="Show the active Server Selection in human CLI output.",
+    )
     file: Path | None = Field(
         default=None,
         title="Console File",

--- a/canfar/utils/console.py
+++ b/canfar/utils/console.py
@@ -2,19 +2,11 @@
 
 from __future__ import annotations
 
-from contextvars import ContextVar
 from functools import lru_cache
 
 from rich.console import Console
 
 from canfar.models.config import Configuration
-
-_banner_emitted: ContextVar[bool] = ContextVar("cli_banner_emitted", default=False)
-
-
-def reset_banner_state() -> None:
-    """Reset CLI banner emission state for a new invocation."""
-    _banner_emitted.set(False)
 
 
 @lru_cache(maxsize=2)
@@ -32,11 +24,10 @@ def get_console(*, stderr: bool = False) -> Console:
 
 
 def emit_active_server_banner() -> None:
-    """Print the active server banner once per CLI invocation in human mode."""
-    if _banner_emitted.get():
-        return
-    _banner_emitted.set(True)
+    """Print the active Server Selection when configured for human output."""
     cfg = Configuration()  # ty: ignore[missing-argument]
+    if not cfg.console.banner:
+        return
     try:
         name = cfg.get_active_server().name
     except KeyError:

--- a/docs/cli/cli-help.md
+++ b/docs/cli/cli-help.md
@@ -192,11 +192,15 @@ canfar config path
 canfar config get console.width
 canfar config get servers.canfar.url
 canfar config set console.width 132
+canfar config set console.banner false
 canfar version
 canfar version --debug
 ```
 
 `config set` parses values as YAML.
+`console.banner` defaults to `true`. Set it to `false` to hide the
+`@<server-name>` prefix from human-readable CLI output. The banner is always
+disabled for `--json` and `--yaml` output.
 `version --debug` shows environment and dependency details for bug reports; it
 does not change the logging level.
 

--- a/tests/test_cli_machine_output.py
+++ b/tests/test_cli_machine_output.py
@@ -136,6 +136,30 @@ def test_auth_ls_machine_stdout_is_data_only(
     parser(result.stdout)
 
 
+def test_passthrough_json_argument_keeps_human_banner(tmp_path: Path) -> None:
+    """A container argument named ``--json`` does not select machine output."""
+    config_path = tmp_path / "config.yaml"
+    _write_config(config_path)
+
+    with _patch_config(config_path):
+        result = runner.invoke(
+            cli,
+            [
+                "create",
+                "--dry-run",
+                "headless",
+                "example.invalid/image",
+                "--",
+                "echo",
+                "--json",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert result.stdout.startswith("@CADC-CANFAR")
+    assert "Arguments: --json" in result.stdout
+
+
 def test_auth_group_flag_before_subcommand_is_rejected(tmp_path: Path) -> None:
     """Group-level ``--json``/``--yaml`` placement exits 2 with guidance."""
     config_path = tmp_path / "config.yaml"

--- a/tests/test_cli_machine_output.py
+++ b/tests/test_cli_machine_output.py
@@ -74,6 +74,21 @@ def test_auth_ls_human_mode_emits_banner(tmp_path: Path) -> None:
     assert result.stdout.startswith("@")
 
 
+def test_nested_image_command_emits_banner(tmp_path: Path) -> None:
+    """Nested human commands emit the banner at terminal dispatch."""
+    config_path = tmp_path / "config.yaml"
+    _write_config(config_path)
+
+    with (
+        _patch_config(config_path),
+        patch("canfar.cli.image.Images.details", return_value=[]),
+    ):
+        result = runner.invoke(cli, ["image", "ls"])
+
+    assert result.exit_code == 0
+    assert result.stdout.startswith("@CADC-CANFAR")
+
+
 def test_config_can_disable_human_banner(tmp_path: Path) -> None:
     """``console.banner=false`` keeps human CLI stdout banner-free."""
     config_path = tmp_path / "config.yaml"
@@ -158,6 +173,33 @@ def test_passthrough_json_argument_keeps_human_banner(tmp_path: Path) -> None:
     assert result.exit_code == 0
     assert result.stdout.startswith("@CADC-CANFAR")
     assert "Arguments: --json" in result.stdout
+
+
+@pytest.mark.parametrize("name", ["--json", "--yaml"])
+def test_machine_flag_spelling_as_option_value_keeps_human_banner(
+    tmp_path: Path,
+    name: str,
+) -> None:
+    """Machine flag spellings used as values leave output in human mode."""
+    config_path = tmp_path / "config.yaml"
+    _write_config(config_path)
+
+    with _patch_config(config_path):
+        result = runner.invoke(
+            cli,
+            [
+                "create",
+                "--dry-run",
+                "headless",
+                "example.invalid/image",
+                "--name",
+                name,
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert result.stdout.startswith("@CADC-CANFAR")
+    assert f"Name: {name}" in result.stdout
 
 
 def test_auth_group_flag_before_subcommand_is_rejected(tmp_path: Path) -> None:

--- a/tests/test_cli_machine_output.py
+++ b/tests/test_cli_machine_output.py
@@ -7,12 +7,14 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
 import click
+import pytest
 import yaml
 from typer.testing import CliRunner
 
 from canfar.cli.main import cli
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 runner = CliRunner()
@@ -26,7 +28,7 @@ def _patch_config(path: Path):
     return patch("canfar.models.config.CONFIG_PATH", path)
 
 
-def _write_config(path: Path) -> None:
+def _write_config(path: Path, *, banner: bool | None = None) -> None:
     """Write a minimal config fixture for machine-output tests."""
     data = {
         "version": 1,
@@ -55,6 +57,8 @@ def _write_config(path: Path) -> None:
             }
         },
     }
+    if banner is not None:
+        data["console"] = {"banner": banner}
     path.write_text(yaml.dump(data), encoding="utf-8")
 
 
@@ -70,17 +74,66 @@ def test_auth_ls_human_mode_emits_banner(tmp_path: Path) -> None:
     assert result.stdout.startswith("@")
 
 
-def test_auth_ls_json_stdout_is_data_only(tmp_path: Path) -> None:
-    """``auth ls --json`` emits JSON on stdout without the human-mode banner."""
+def test_config_can_disable_human_banner(tmp_path: Path) -> None:
+    """``console.banner=false`` keeps human CLI stdout banner-free."""
     config_path = tmp_path / "config.yaml"
     _write_config(config_path)
 
     with _patch_config(config_path):
-        result = runner.invoke(cli, ["auth", "ls", "--json"])
+        set_result = runner.invoke(
+            cli,
+            ["config", "set", "console.banner", "false"],
+        )
+        command_result = runner.invoke(cli, ["auth", "ls"])
+        enable_result = runner.invoke(
+            cli,
+            ["config", "set", "console.banner", "true"],
+        )
+        enabled_command_result = runner.invoke(cli, ["auth", "ls"])
+
+    assert set_result.exit_code == 0
+    assert command_result.exit_code == 0
+    assert not command_result.stdout.startswith("@")
+    assert enable_result.exit_code == 0
+    assert enabled_command_result.exit_code == 0
+    assert enabled_command_result.stdout.startswith("@")
+
+
+def test_invalid_console_banner_value_fails_validation(tmp_path: Path) -> None:
+    """``console.banner`` accepts only values Pydantic can parse as booleans."""
+    config_path = tmp_path / "config.yaml"
+    _write_config(config_path)
+
+    with _patch_config(config_path):
+        result = runner.invoke(
+            cli,
+            ["config", "set", "console.banner", "sometimes"],
+        )
+
+    assert result.exit_code == 1
+
+
+@pytest.mark.parametrize(
+    ("flag", "parser"),
+    [("--json", json.loads), ("--yaml", yaml.safe_load)],
+)
+@pytest.mark.parametrize("banner", [True, False])
+def test_auth_ls_machine_stdout_is_data_only(
+    tmp_path: Path,
+    flag: str,
+    parser: Callable[[str], object],
+    banner: bool,
+) -> None:
+    """Machine flags always suppress the human banner configuration."""
+    config_path = tmp_path / "config.yaml"
+    _write_config(config_path, banner=banner)
+
+    with _patch_config(config_path):
+        result = runner.invoke(cli, ["auth", "ls", flag])
 
     assert result.exit_code == 0
     assert not result.stdout.startswith("@")
-    json.loads(result.stdout)
+    parser(result.stdout)
 
 
 def test_auth_group_flag_before_subcommand_is_rejected(tmp_path: Path) -> None:

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -78,6 +78,14 @@ def test_nested_help_does_not_emit_banner() -> None:
     assert not result.stdout.startswith("@")
 
 
+def test_short_nested_help_does_not_emit_banner() -> None:
+    """Nested short help remains free of command output decoration."""
+    result = runner.invoke(cli, ["create", "-h"])
+
+    assert result.exit_code == 0
+    assert not result.stdout.startswith("@")
+
+
 def test_implicit_nested_help_does_not_emit_banner() -> None:
     """Bare nested groups keep implicit help free of command output."""
     result = runner.invoke(cli, ["config"])

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -70,6 +70,22 @@ def test_main_cli_with_help_option() -> None:
     assert result.exit_code == 0
 
 
+def test_nested_help_does_not_emit_banner() -> None:
+    """Nested help remains free of command output decoration."""
+    result = runner.invoke(cli, ["config", "--help"])
+
+    assert result.exit_code == 0
+    assert not result.stdout.startswith("@")
+
+
+def test_implicit_nested_help_does_not_emit_banner() -> None:
+    """Bare nested groups keep implicit help free of command output."""
+    result = runner.invoke(cli, ["config"])
+
+    assert result.exit_code == 2
+    assert not result.stdout.startswith("@")
+
+
 def test_human_cli_runs_when_active_server_is_null(tmp_path: Path) -> None:
     """Human-mode CLI remains usable when no active server is selected."""
     config_path = tmp_path / "config.yaml"


### PR DESCRIPTION
## Summary
- Move active-server banner emission out of individual CLI commands and into terminal dispatch so human output is handled consistently
- Add a `console.banner` config toggle to suppress the banner when desired
- Keep `--json` and `--yaml` output data-only, including when `--` passthrough arguments contain banner-like flag names
- Update CLI help and add coverage for human, machine, and passthrough cases

## Testing
- Added regression tests for banner emission, banner suppression via config, and machine-output stdout cleanliness
- Added coverage for nested commands and passthrough argument handling
- Not run (not requested)