### PR TITLE
feat(config): add named VOSpace services

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,6 +16,14 @@ _Avoid_: Base URL, host, cluster
 Required, unique, user-facing handle for one **Science Platform Server**, used to reference it in configuration and commands.
 _Avoid_: Label, alias, key
 
+**VOSpace Service**:
+Storage service associated with a **Science Platform Server**, identified by an IVOA registry resource URI and accessed through a base HTTP endpoint.
+_Avoid_: Storage backend, filesystem
+
+**Storage Name**:
+Required, globally unique, user-facing handle for one **VOSpace Service**. `local` is reserved for the user's local filesystem.
+_Avoid_: Server Name, alias, key
+
 **Identity Provider (IDP)**:
 Organization that issues user identity for CANFAR authentication.
 Initial IDPs are `Canadian Astronomy Data Centre (CADC)` and `SKA Regional Centre Network (SRCNet)`.
@@ -69,6 +77,8 @@ _Avoid_: Resource profile, quota
 
 - A **CANFAR Science Platform** exposes one or more **Science Platform Servers**.
 - A **Science Platform Server** is identified by its **Server Name**; its IVOA URI is discovery metadata, and two Server Names may point at the same endpoint.
+- A **Science Platform Server** can expose multiple **VOSpace Services**.
+- A **VOSpace Service** is identified by its **Storage Name** and uses its parent **Science Platform Server**'s **Identity Provider (IDP)**.
 - An **Identity Provider (IDP)** can support one or more **Science Platform Servers**.
 - **Authentication** and **Platform** are separate seams with independent ownership.
 - An **Authentication Record** belongs to one **Identity Provider (IDP)**.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,11 +17,11 @@ Required, unique, user-facing handle for one **Science Platform Server**, used t
 _Avoid_: Label, alias, key
 
 **VOSpace Service**:
-Storage service associated with a **Science Platform Server**, identified by an IVOA registry resource URI and accessed through a base HTTP endpoint.
+Remote astronomical storage service associated with a **Science Platform Server**.
 _Avoid_: Storage backend, filesystem
 
 **Storage Name**:
-Required, globally unique, user-facing handle for one **VOSpace Service**. `local` is reserved for the user's local filesystem.
+Required, globally unique, user-facing handle for one **VOSpace Service**.
 _Avoid_: Server Name, alias, key
 
 **Identity Provider (IDP)**:

--- a/canfar/models/config.py
+++ b/canfar/models/config.py
@@ -179,8 +179,8 @@ class Configuration(BaseSettings):
         )
 
     @model_validator(mode="after")
-    def _inject_server_names(self) -> Configuration:
-        """Inject dict keys into each server record and validate Server Names."""
+    def _normalize_and_validate_servers(self) -> Configuration:
+        """Inject Server Names and validate Server and Storage Name keys."""
         updated: dict[str, Server] = {}
         storage_servers: dict[str, str] = {}
         for name, server in self.servers.items():

--- a/canfar/models/config.py
+++ b/canfar/models/config.py
@@ -182,6 +182,7 @@ class Configuration(BaseSettings):
     def _inject_server_names(self) -> Configuration:
         """Inject dict keys into each server record and validate Server Names."""
         updated: dict[str, Server] = {}
+        storage_servers: dict[str, str] = {}
         for name, server in self.servers.items():
             if not _SERVER_NAME_PATTERN.match(name):
                 msg = (
@@ -189,6 +190,14 @@ class Configuration(BaseSettings):
                     r"^[A-Za-z][A-Za-z0-9_-]*$"
                 )
                 raise ValueError(msg)
+            for storage_name in server.storage:
+                if previous_server := storage_servers.get(storage_name):
+                    msg = (
+                        f"Duplicate Storage Name '{storage_name}' in Science Platform "
+                        f"Servers '{previous_server}' and '{name}'."
+                    )
+                    raise ValueError(msg)
+                storage_servers[storage_name] = name
             updated[name] = server.model_copy(update={"name": name}, deep=True)
         self.servers = updated
         return self

--- a/canfar/models/config.py
+++ b/canfar/models/config.py
@@ -182,7 +182,7 @@ class Configuration(BaseSettings):
     def _normalize_and_validate_servers(self) -> Configuration:
         """Inject Server Names and validate Server and Storage Name keys."""
         updated: dict[str, Server] = {}
-        storage_servers: dict[str, str] = {}
+        server_name_by_storage_name: dict[str, str] = {}
         for name, server in self.servers.items():
             if not _SERVER_NAME_PATTERN.match(name):
                 msg = (
@@ -191,13 +191,15 @@ class Configuration(BaseSettings):
                 )
                 raise ValueError(msg)
             for storage_name in server.storage:
-                if previous_server := storage_servers.get(storage_name):
+                if previous_server_name := server_name_by_storage_name.get(
+                    storage_name
+                ):
                     msg = (
                         f"Duplicate Storage Name '{storage_name}' in Science Platform "
-                        f"Servers '{previous_server}' and '{name}'."
+                        f"Servers '{previous_server_name}' and '{name}'."
                     )
                     raise ValueError(msg)
-                storage_servers[storage_name] = name
+                server_name_by_storage_name[storage_name] = name
             updated[name] = server.model_copy(update={"name": name}, deep=True)
         self.servers = updated
         return self

--- a/canfar/models/http.py
+++ b/canfar/models/http.py
@@ -24,6 +24,15 @@ class VOSpaceService(BaseModel):
     uri: AnyUrl
     url: AnyHttpUrl
 
+    @field_validator("url")
+    @classmethod
+    def _reject_capabilities_endpoint(cls, url: AnyHttpUrl) -> AnyHttpUrl:
+        """Require the VOSpace base endpoint rather than its capabilities URL."""
+        if (url.path or "").rstrip("/").endswith("/capabilities"):
+            msg = "VOSpace Service base URL must not end with /capabilities."
+            raise ValueError(msg)
+        return url
+
 
 class Server(BaseModel):
     """Science Platform Server Details."""
@@ -119,18 +128,33 @@ class Server(BaseModel):
     @field_validator("storage", mode="before")
     @classmethod
     def _validate_storage_names(cls, value: Any) -> Any:
-        """Validate Storage Names before global string constraints run."""
-        if isinstance(value, dict):
-            for name in value:
-                if not isinstance(name, str) or (
-                    not name
-                    or name == "local"
-                    or any(character in name for character in ":\x00\n")
-                    or name.startswith("-")
-                ):
-                    msg = (
-                        f"Invalid Storage Name {name!r}: must be non-empty, must not "
-                        "be 'local', contain colon, NUL, or newline, or start with '-'."
-                    )
-                    raise ValueError(msg)
-        return value
+        """Normalize and validate Storage Names before Pydantic transforms keys."""
+        if not isinstance(value, dict):
+            return value
+
+        normalized: dict[str, Any] = {}
+        original_name_by_normalized_name: dict[str, str] = {}
+        for original_name, service in value.items():
+            name = original_name.strip() if isinstance(original_name, str) else None
+            if name is None or (
+                not name
+                or name == "local"
+                or any(character in name for character in ":\x00\n")
+                or name.startswith("-")
+            ):
+                msg = (
+                    f"Invalid Storage Name {original_name!r}: after whitespace "
+                    "normalization it must be non-empty, differ from reserved 'local', "
+                    "contain no colon, NUL, or newline, and not start with '-'."
+                )
+                raise ValueError(msg)
+            if name in normalized:
+                previous_original_name = original_name_by_normalized_name[name]
+                msg = (
+                    f"Storage Names {previous_original_name!r} and {original_name!r} "
+                    f"both normalize to {name!r}; use unique names."
+                )
+                raise ValueError(msg)
+            normalized[name] = service
+            original_name_by_normalized_name[name] = original_name
+        return normalized

--- a/canfar/models/http.py
+++ b/canfar/models/http.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from pydantic import AnyHttpUrl, AnyUrl, BaseModel, ConfigDict, Field
+from typing import Any
+
+from pydantic import AnyHttpUrl, AnyUrl, BaseModel, ConfigDict, Field, field_validator
 
 DEFAULT_SERVER_CORES = 2
 """Default CPU core limit when context enrichment is unavailable."""
@@ -12,6 +14,15 @@ DEFAULT_SERVER_RAM_GB = 16
 
 DEFAULT_SERVER_GPUS = 0
 """Default GPU count when context enrichment is unavailable."""
+
+
+class VOSpaceService(BaseModel):
+    """VOSpace Service discovered through an IVOA registry."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    uri: AnyUrl
+    url: AnyHttpUrl
 
 
 class Server(BaseModel):
@@ -72,6 +83,12 @@ class Server(BaseModel):
         min_length=1,
         max_length=64,
     )
+    storage: dict[str, VOSpaceService] = Field(
+        default_factory=dict,
+        title="VOSpace Services",
+        description="VOSpace Services keyed by globally unique Storage Name.",
+    )
+
     cores: int = Field(
         default=DEFAULT_SERVER_CORES,
         title="Default CPU Core Limit",
@@ -98,3 +115,22 @@ class Server(BaseModel):
             "when known."
         ),
     )
+
+    @field_validator("storage", mode="before")
+    @classmethod
+    def _validate_storage_names(cls, value: Any) -> Any:
+        """Validate Storage Names before global string constraints run."""
+        if isinstance(value, dict):
+            for name in value:
+                if not isinstance(name, str) or (
+                    not name
+                    or name == "local"
+                    or any(character in name for character in ":\x00\n")
+                    or name.startswith("-")
+                ):
+                    msg = (
+                        f"Invalid Storage Name {name!r}: must be non-empty, must not "
+                        "be 'local', contain colon, NUL, or newline, or start with '-'."
+                    )
+                    raise ValueError(msg)
+        return value

--- a/docs/cli/quick-start.md
+++ b/docs/cli/quick-start.md
@@ -8,6 +8,12 @@ Create a notebook Session from a terminal, open it, inspect it, and clean it up.
 pip install canfar --upgrade
 ```
 
+Install the pinned optional storage dependencies when you need data support:
+
+```bash
+pip install "canfar[data]" --upgrade
+```
+
 ## 2. Log in
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel.force-include]
 "canfar/utils/data/scientists.txt" = "canfar/utils/data/scientists.txt"
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [project]
 name = "canfar"
 version = "1.4.1"
@@ -56,6 +59,12 @@ dependencies = [
     "rich>=13.9.4",
     "segno>=1.6.6",
     "typer>=0.16.0",
+]
+
+[project.optional-dependencies]
+data = [
+    "vosfs @ git+https://github.com/shinybrar/vosfs@v0.6.0",
+    "fsspec-cli @ git+https://github.com/shinybrar/vosfs@fsspec-cli-v0.5.0#subdirectory=src/fsspec-cli",
 ]
 
 [tool.uv]

--- a/tests/test_cli_server.py
+++ b/tests/test_cli_server.py
@@ -149,6 +149,7 @@ def test_server_ls_json_output(tmp_path: Path) -> None:
         "version",
         "auths",
         "idp",
+        "storage",
         "cores",
         "ram",
         "gpus",

--- a/tests/test_models_config.py
+++ b/tests/test_models_config.py
@@ -139,18 +139,28 @@ class TestConfigurationValidation:
 
     @pytest.mark.parametrize(
         "storage_name",
-        ["", "local", "archive:old", "archive\x00old", "archive\nold", "-archive"],
+        [
+            "",
+            "local",
+            " local ",
+            "archive:old",
+            "archive\x00old",
+            "archive\nold",
+            "-archive",
+        ],
     )
     def test_invalid_storage_name_rejected(self, storage_name: str) -> None:
         """Invalid Storage Names fail with the rejected name and constraints."""
         with pytest.raises(ValidationError, match="Invalid Storage Name") as exc_info:
-            Configuration(
-                servers={
-                    "canfar": {
-                        "storage": {
-                            storage_name: {
-                                "uri": "ivo://cadc.nrc.ca/arc",
-                                "url": "https://ws-cadc.canfar.net/arc",
+            Configuration.model_validate(
+                {
+                    "servers": {
+                        "canfar": {
+                            "storage": {
+                                storage_name: {
+                                    "uri": "ivo://cadc.nrc.ca/arc",
+                                    "url": "https://ws-cadc.canfar.net/arc",
+                                }
                             }
                         }
                     }
@@ -160,7 +170,7 @@ class TestConfigurationValidation:
         assert repr(storage_name) in str(exc_info.value)
 
     def test_duplicate_storage_name_across_servers_rejected(self) -> None:
-        """A Storage Name identifies at most one service across all Servers."""
+        """A Storage Name identifies one service across Science Platform Servers."""
         service = VOSpaceService(
             uri="ivo://cadc.nrc.ca/arc",
             url="https://ws-cadc.canfar.net/arc",
@@ -173,12 +183,27 @@ class TestConfigurationValidation:
                 "'canfar' and 'srcnet'"
             ),
         ):
-            Configuration(
-                servers={
-                    "canfar": Server(storage={"shared": service}),
-                    "srcnet": Server(storage={"shared": service}),
+            Configuration.model_validate(
+                {
+                    "servers": {
+                        "canfar": Server(storage={"shared": service}),
+                        "srcnet": Server(storage={"shared": service}),
+                    }
                 }
             )
+
+    def test_normalized_storage_name_collision_rejected(self) -> None:
+        """Whitespace normalization cannot silently replace a VOSpace Service."""
+        service = {
+            "uri": "ivo://cadc.nrc.ca/arc",
+            "url": "https://ws-cadc.canfar.net/arc",
+        }
+
+        with pytest.raises(
+            ValidationError,
+            match="Storage Names 'arc' and ' arc ' both normalize to 'arc'",
+        ):
+            Server(storage={"arc": service, " arc ": service})
 
     def test_valid_active_references(self) -> None:
         """Validation passes when active authentication and server exist."""

--- a/tests/test_models_config.py
+++ b/tests/test_models_config.py
@@ -149,9 +149,14 @@ class TestConfigurationValidation:
             "-archive",
         ],
     )
-    def test_invalid_storage_name_rejected(self, storage_name: str) -> None:
+    def test_invalid_storage_name_rejected(
+        self, storage_name: str, tmp_path: Path
+    ) -> None:
         """Invalid Storage Names fail with the rejected name and constraints."""
-        with pytest.raises(ValidationError, match="Invalid Storage Name") as exc_info:
+        with (
+            patch("canfar.models.config.CONFIG_PATH", tmp_path / "config.yaml"),
+            pytest.raises(ValidationError, match="Invalid Storage Name") as exc_info,
+        ):
             Configuration.model_validate(
                 {
                     "servers": {
@@ -169,18 +174,23 @@ class TestConfigurationValidation:
 
         assert repr(storage_name) in str(exc_info.value)
 
-    def test_duplicate_storage_name_across_servers_rejected(self) -> None:
+    def test_duplicate_storage_name_across_servers_rejected(
+        self, tmp_path: Path
+    ) -> None:
         """A Storage Name identifies one service across Science Platform Servers."""
         service = VOSpaceService(
             uri="ivo://cadc.nrc.ca/arc",
             url="https://ws-cadc.canfar.net/arc",
         )
 
-        with pytest.raises(
-            ValidationError,
-            match=(
-                "Duplicate Storage Name 'shared' in Science Platform Servers "
-                "'canfar' and 'srcnet'"
+        with (
+            patch("canfar.models.config.CONFIG_PATH", tmp_path / "config.yaml"),
+            pytest.raises(
+                ValidationError,
+                match=(
+                    "Duplicate Storage Name 'shared' in Science Platform Servers "
+                    "'canfar' and 'srcnet'"
+                ),
             ),
         ):
             Configuration.model_validate(

--- a/tests/test_models_config.py
+++ b/tests/test_models_config.py
@@ -20,7 +20,7 @@ from canfar.models.auth import (
     X509Credential,
 )
 from canfar.models.config import Configuration, _CanfarEnvSettingsSource
-from canfar.models.http import Server
+from canfar.models.http import Server, VOSpaceService
 from canfar.models.registry import ContainerRegistry
 
 
@@ -135,6 +135,49 @@ class TestConfigurationValidation:
                         expiry=1.0,
                     ),
                 },
+            )
+
+    @pytest.mark.parametrize(
+        "storage_name",
+        ["", "local", "archive:old", "archive\x00old", "archive\nold", "-archive"],
+    )
+    def test_invalid_storage_name_rejected(self, storage_name: str) -> None:
+        """Invalid Storage Names fail with the rejected name and constraints."""
+        with pytest.raises(ValidationError, match="Invalid Storage Name") as exc_info:
+            Configuration(
+                servers={
+                    "canfar": {
+                        "storage": {
+                            storage_name: {
+                                "uri": "ivo://cadc.nrc.ca/arc",
+                                "url": "https://ws-cadc.canfar.net/arc",
+                            }
+                        }
+                    }
+                }
+            )
+
+        assert repr(storage_name) in str(exc_info.value)
+
+    def test_duplicate_storage_name_across_servers_rejected(self) -> None:
+        """A Storage Name identifies at most one service across all Servers."""
+        service = VOSpaceService(
+            uri="ivo://cadc.nrc.ca/arc",
+            url="https://ws-cadc.canfar.net/arc",
+        )
+
+        with pytest.raises(
+            ValidationError,
+            match=(
+                "Duplicate Storage Name 'shared' in Science Platform Servers "
+                "'canfar' and 'srcnet'"
+            ),
+        ):
+            Configuration(
+                servers={
+                    "canfar": Server(storage={"shared": service}),
+                    "srcnet": Server(storage={"shared": service}),
+                }
             )
 
     def test_valid_active_references(self) -> None:
@@ -315,6 +358,58 @@ class TestConfigurationSerialization:
         assert loaded_oidc.token.scope == "openid profile email"
         assert loaded_oidc.expiry.access == 1893456000
         assert loaded_oidc.expiry.refresh is None
+
+    def test_v1_storage_json_and_yaml_round_trip(self, tmp_path: Path) -> None:
+        """Multiple VOSpace Services retain stable nested Storage Names."""
+        config = Configuration.model_validate(
+            _sample_config(
+                servers={
+                    "canfar": {
+                        **_sample_config()["servers"]["canfar"],
+                        "storage": {
+                            "canSRC": {
+                                "uri": "ivo://cadc.nrc.ca/arc",
+                                "url": "https://ws-cadc.canfar.net/arc",
+                            },
+                            "canSRCs3": {
+                                "uri": "ivo://cadc.nrc.ca/arc-s3",
+                                "url": "https://ws-cadc.canfar.net/arc-s3",
+                            },
+                        },
+                    }
+                }
+            )
+        )
+
+        json_data = config.model_dump(mode="json")
+        assert list(json_data["servers"]["canfar"]["storage"]) == [
+            "canSRC",
+            "canSRCs3",
+        ]
+        assert "name" not in json_data["servers"]["canfar"]["storage"]["canSRC"]
+        assert Configuration.model_validate_json(config.model_dump_json()) == config
+
+        config_path = tmp_path / "config.yaml"
+        with patch("canfar.models.config.CONFIG_PATH", config_path):
+            config.save()
+            loaded = Configuration()
+
+        assert list(loaded.servers["canfar"].storage) == ["canSRC", "canSRCs3"]
+        assert loaded.servers["canfar"].idp == "cadc"
+        assert loaded == config
+
+    def test_existing_v1_configuration_without_storage_loads_unchanged(
+        self, tmp_path: Path
+    ) -> None:
+        """The optional storage mapping does not require a schema migration."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(yaml.safe_dump(_sample_config()), encoding="utf-8")
+
+        with patch("canfar.models.config.CONFIG_PATH", config_path):
+            config = Configuration()
+
+        assert config.version == 1
+        assert config.servers["canfar"].storage == {}
 
     def test_save_creates_directory(self, tmp_path: Path) -> None:
         """Save creates parent directories when missing."""

--- a/tests/test_models_http.py
+++ b/tests/test_models_http.py
@@ -3,7 +3,29 @@
 import pytest
 from pydantic import ValidationError
 
-from canfar.models.http import Server
+from canfar.models.http import Server, VOSpaceService
+
+
+class TestVOSpaceService:
+    """Test VOSpace Service configuration."""
+
+    def test_requires_registry_uri_and_http_endpoint(self) -> None:
+        """A VOSpace Service carries only its registry URI and base URL."""
+        service = VOSpaceService(
+            uri="ivo://cadc.nrc.ca/arc",
+            url="https://ws-cadc.canfar.net/arc",
+        )
+
+        assert service.model_dump(mode="json") == {
+            "uri": "ivo://cadc.nrc.ca/arc",
+            "url": "https://ws-cadc.canfar.net/arc",
+        }
+
+        with pytest.raises(ValidationError):
+            VOSpaceService(
+                uri="ivo://cadc.nrc.ca/arc",
+                url="vos://ws-cadc.canfar.net/arc",
+            )
 
 
 class TestServer:
@@ -33,6 +55,7 @@ class TestServer:
         assert server.url is None
         assert server.version is None
         assert server.status is None
+        assert server.storage == {}
 
     def test_with_all_values(self) -> None:
         """Test Server with all custom values."""

--- a/tests/test_models_http.py
+++ b/tests/test_models_http.py
@@ -9,7 +9,7 @@ from canfar.models.http import Server, VOSpaceService
 class TestVOSpaceService:
     """Test VOSpace Service configuration."""
 
-    def test_requires_registry_uri_and_http_endpoint(self) -> None:
+    def test_serializes_registry_uri_and_http_endpoint(self) -> None:
         """A VOSpace Service carries only its registry URI and base URL."""
         service = VOSpaceService(
             uri="ivo://cadc.nrc.ca/arc",
@@ -21,11 +21,19 @@ class TestVOSpaceService:
             "url": "https://ws-cadc.canfar.net/arc",
         }
 
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"uri": "not-a-url", "url": "https://ws-cadc.canfar.net/arc"},
+            {"uri": "ivo://cadc.nrc.ca/arc", "url": "vos://example.com/arc"},
+            {"url": "https://ws-cadc.canfar.net/arc"},
+            {"uri": "ivo://cadc.nrc.ca/arc"},
+        ],
+    )
+    def test_requires_valid_registry_uri_and_http_endpoint(self, payload: dict) -> None:
+        """Both VOSpace Service identifiers are required and validated."""
         with pytest.raises(ValidationError):
-            VOSpaceService(
-                uri="ivo://cadc.nrc.ca/arc",
-                url="vos://ws-cadc.canfar.net/arc",
-            )
+            VOSpaceService.model_validate(payload)
 
 
 class TestServer:

--- a/tests/test_models_http.py
+++ b/tests/test_models_http.py
@@ -35,6 +35,18 @@ class TestVOSpaceService:
         with pytest.raises(ValidationError):
             VOSpaceService.model_validate(payload)
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://ws-cadc.canfar.net/arc/capabilities",
+            "https://ws-cadc.canfar.net/arc/capabilities/",
+        ],
+    )
+    def test_rejects_capabilities_endpoint_as_base_url(self, url: str) -> None:
+        """A VOSpace Service URL names the base service, not capabilities."""
+        with pytest.raises(ValidationError, match="must not end with /capabilities"):
+            VOSpaceService(uri="ivo://cadc.nrc.ca/arc", url=url)
+
 
 class TestServer:
     """Test Server class."""

--- a/uv.lock
+++ b/uv.lock
@@ -129,6 +129,12 @@ dependencies = [
     { name = "typer" },
 ]
 
+[package.optional-dependencies]
+data = [
+    { name = "fsspec-cli" },
+    { name = "vosfs" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -158,6 +164,7 @@ requires-dist = [
     { name = "cadcutils", specifier = ">=1.5.4" },
     { name = "click", specifier = ">=8.4.1" },
     { name = "defusedxml", specifier = ">=0.7.1" },
+    { name = "fsspec-cli", marker = "extra == 'data'", git = "https://github.com/shinybrar/vosfs?subdirectory=src%2Ffsspec-cli&rev=fsspec-cli-v0.5.0" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.28.1" },
     { name = "humanize", specifier = ">=4.12.3" },
     { name = "pydantic", specifier = ">=2.9.2" },
@@ -167,7 +174,9 @@ requires-dist = [
     { name = "rich", specifier = ">=13.9.4" },
     { name = "segno", specifier = ">=1.6.6" },
     { name = "typer", specifier = ">=0.16.0" },
+    { name = "vosfs", marker = "extra == 'data'", git = "https://github.com/shinybrar/vosfs?rev=v0.6.0" },
 ]
+provides-extras = ["data"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -660,6 +669,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/94/00f2059e4835eace3ae8fde680b932c496f8ec7bdc99168dfa53fb2e6b79/filelock-3.29.7.tar.gz", hash = "sha256:5b481979797ae69e72f0b389d89a80bdd585c260c5b3f1fb9c0a5ba9bb3f195d", size = 71521, upload-time = "2026-07-08T05:46:58.716Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/02/be4a57b60c7149b55b9e3b3c13f609cd8eb5307c751f22bd8fb8d262e75b/filelock-3.29.7-py3-none-any.whl", hash = "sha256:987db6f789a3a2a59f55081801b2b3697cb97e2a736b5f1a9e99b559285fbc51", size = 46036, upload-time = "2026-07-08T05:46:57.53Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
+]
+
+[[package]]
+name = "fsspec-cli"
+version = "0.5.0"
+source = { git = "https://github.com/shinybrar/vosfs?subdirectory=src%2Ffsspec-cli&rev=fsspec-cli-v0.5.0#ddef461b464d41811b6ddbad8eb1a64e37d2d85e" }
+dependencies = [
+    { name = "fsspec" },
+    { name = "typer" },
 ]
 
 [[package]]
@@ -2165,6 +2192,16 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/34/d9/b477fddb68840b570af8b22afe9b035cbc277b5fb7b33dea390617a8b10f/virtualenv-21.6.1.tar.gz", hash = "sha256:15f978b7cd329f24855ff4a0c4b4899cc7678589f49adbdcbbb4d3232e641128", size = 5526620, upload-time = "2026-07-10T19:33:53.312Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/7c/4e7225d46d634a0d8d534dd8a6ce0c319d09b4d0cf0337eb314ca4789d8c/virtualenv-21.6.1-py3-none-any.whl", hash = "sha256:afe991df855715a2b2f60edfcc0107ef95a79fdfd8cb4cdaa71603d1c12e463b", size = 5506392, upload-time = "2026-07-10T19:33:51.629Z" },
+]
+
+[[package]]
+name = "vosfs"
+version = "0.6.0"
+source = { git = "https://github.com/shinybrar/vosfs?rev=v0.6.0#200eae23fbc5e2bd58693b5c14ce12b2795d0636" }
+dependencies = [
+    { name = "defusedxml" },
+    { name = "fsspec" },
+    { name = "httpx" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add VOSpaceService and per-Science Platform Server named storage mappings
- normalize and validate Storage Names globally without silent key collapse while preserving Configuration schema v1
- reject capabilities URLs where a VOSpace Service base endpoint is required
- add the pinned data extra, lock entries, glossary terms, and install guidance

## Validation
- 763 deterministic non-slow tests passed
- ruff and ruff format passed
- ty reported the same 22 pre-existing unused-ignore diagnostics as the fixed base
- MkDocs built successfully
- wheel metadata and uv.lock resolve vosfs v0.6.0 and fsspec-cli v0.5.0 to their tagged commits
- fixed-base, End of Wave, and second-round review findings are addressed through 690f3bd0

Closes #151