### PR TITLE
feat(storage): materialize authenticated vosfs sources

### DIFF
--- a/canfar/_storage.py
+++ b/canfar/_storage.py
@@ -1,0 +1,144 @@
+"""Private adapters for configured VOSpace Services."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, cast
+
+from canfar.auth import oidc, x509
+from canfar.client import HTTPClient
+from canfar.exceptions.context import AuthContextError
+from canfar.models.auth import OIDCCredential, X509Credential
+from canfar.models.config import Configuration
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+    from typing import NoReturn
+
+    from fsspec.spec import AbstractFileSystem
+    from fsspec_cli import AsyncFilesystemSource
+    from pydantic import SecretStr
+
+
+def _vospace_source(
+    storage_name: str,
+    *,
+    token: str | SecretStr | None = None,
+    certificate: Path | None = None,
+) -> AsyncFilesystemSource:
+    """Return a fresh authenticated async filesystem source."""
+
+    @asynccontextmanager
+    async def source() -> AsyncIterator[AbstractFileSystem]:
+        config = Configuration()
+        endpoint, idp = _resolve_storage(config, storage_name)
+        credentials = await _materialize_credentials(
+            config,
+            idp,
+            endpoint,
+            token=token,
+            certificate=certificate,
+        )
+
+        from vosfs import VOSpaceFileSystem  # noqa: PLC0415
+
+        if token_value := credentials.get("token"):
+            filesystem = VOSpaceFileSystem(
+                endpoint,
+                token=token_value,
+                asynchronous=True,
+                skip_instance_cache=True,
+            )
+        else:
+            filesystem = VOSpaceFileSystem(
+                endpoint,
+                certfile=credentials["certfile"],
+                asynchronous=True,
+                skip_instance_cache=True,
+            )
+        try:
+            yield filesystem
+        finally:
+            await filesystem.aclose()
+
+    return source
+
+
+def _resolve_storage(config: Configuration, storage_name: str) -> tuple[str, str]:
+    """Resolve one Storage Name to its endpoint and parent server IDP."""
+    for server in config.servers.values():
+        service = server.storage.get(storage_name)
+        if service is not None:
+            if server.idp is None:
+                msg = (
+                    f"Storage Name '{storage_name}' belongs to a Science Platform "
+                    "Server without an IDP."
+                )
+                raise ValueError(msg)
+            return str(service.url), server.idp
+    msg = f"Storage Name '{storage_name}' is not configured."
+    raise KeyError(msg)
+
+
+async def _materialize_credentials(
+    config: Configuration,
+    idp: str,
+    endpoint: str,
+    *,
+    token: str | SecretStr | None,
+    certificate: Path | None,
+) -> dict[str, str]:
+    """Return only literal credential material accepted by vosfs."""
+    try:
+        client = HTTPClient(
+            config=config,
+            authentication_idp=idp,
+            url=endpoint,
+            token=token,
+            certificate=certificate,
+        )
+        if client.token is not None:
+            return {"token": client.token.get_secret_value()}
+        if client.certificate is not None:
+            return {"certfile": x509.valid(client.certificate)}
+
+        credential = client.authentication_record
+        if isinstance(credential, X509Credential):
+            if credential.path is None:
+                _fail_authentication(idp)
+            return {"certfile": cast("str", x509.inspect(credential.path)["path"])}
+        if not isinstance(credential, OIDCCredential):
+            _fail_authentication(idp)
+
+        if credential.expired:
+            parameters = _refresh_parameters(credential)
+            refreshed = await oidc.refresh(*parameters)
+            credential = oidc._persist_refreshed_credential(  # noqa: SLF001
+                config,
+                credential,
+                refreshed,
+            )
+        if credential.token.access is None:
+            _fail_authentication(idp)
+        return {"token": credential.token.access.get_secret_value()}
+    except (KeyError, OSError, TypeError, ValueError):
+        _fail_authentication(idp)
+
+
+def _fail_authentication(idp: str) -> NoReturn:
+    """Raise the fixed secret-safe authentication failure."""
+    reason = "Credential cannot be used. Run 'canfar login' for this IDP."
+    raise AuthContextError(idp, reason) from None
+
+
+def _refresh_parameters(credential: OIDCCredential) -> tuple[str, str, str, str]:
+    """Return literal refresh inputs for an eligible Authentication Record."""
+    if not credential.refreshable:
+        raise ValueError
+    return (
+        cast("str", credential.endpoints.token),
+        cast("str", credential.client.identity),
+        cast("SecretStr", credential.client.secret).get_secret_value(),
+        cast("SecretStr", credential.token.refresh).get_secret_value(),
+    )

--- a/canfar/_storage.py
+++ b/canfar/_storage.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
-from canfar.auth import oidc, x509
 from canfar.client import HTTPClient
 from canfar.exceptions.context import AuthContextError
-from canfar.models.auth import OIDCCredential, X509Credential
 from canfar.models.config import Configuration
 
 if TYPE_CHECKING:
@@ -32,18 +30,22 @@ def _vospace_source(
     @asynccontextmanager
     async def source() -> AsyncIterator[AbstractFileSystem]:
         config = Configuration()
-        endpoint, idp = _resolve_storage(config, storage_name)
-        credentials = await _materialize_credentials(
-            config,
-            idp,
-            endpoint,
-            token=token,
-            certificate=certificate,
-        )
+        endpoint, idp = config._resolve_storage(storage_name)  # noqa: SLF001
+        try:
+            client = HTTPClient(
+                config=config,
+                authentication_idp=idp,
+                url=endpoint,
+                token=token,
+                certificate=certificate,
+            )
+            token_value, certfile = await client._materialize_credentials()  # noqa: SLF001
+        except (KeyError, OSError, TypeError, ValueError):
+            _fail_authentication(idp)
 
         from vosfs import VOSpaceFileSystem  # noqa: PLC0415
 
-        if token_value := credentials.get("token"):
+        if token_value is not None:
             filesystem = VOSpaceFileSystem(
                 endpoint,
                 token=token_value,
@@ -51,9 +53,10 @@ def _vospace_source(
                 skip_instance_cache=True,
             )
         else:
+            assert certfile is not None
             filesystem = VOSpaceFileSystem(
                 endpoint,
-                certfile=credentials["certfile"],
+                certfile=certfile,
                 asynchronous=True,
                 skip_instance_cache=True,
             )
@@ -65,80 +68,7 @@ def _vospace_source(
     return source
 
 
-def _resolve_storage(config: Configuration, storage_name: str) -> tuple[str, str]:
-    """Resolve one Storage Name to its endpoint and parent server IDP."""
-    for server in config.servers.values():
-        service = server.storage.get(storage_name)
-        if service is not None:
-            if server.idp is None:
-                msg = (
-                    f"Storage Name '{storage_name}' belongs to a Science Platform "
-                    "Server without an IDP."
-                )
-                raise ValueError(msg)
-            return str(service.url), server.idp
-    msg = f"Storage Name '{storage_name}' is not configured."
-    raise KeyError(msg)
-
-
-async def _materialize_credentials(
-    config: Configuration,
-    idp: str,
-    endpoint: str,
-    *,
-    token: str | SecretStr | None,
-    certificate: Path | None,
-) -> dict[str, str]:
-    """Return only literal credential material accepted by vosfs."""
-    try:
-        client = HTTPClient(
-            config=config,
-            authentication_idp=idp,
-            url=endpoint,
-            token=token,
-            certificate=certificate,
-        )
-        if client.token is not None:
-            return {"token": client.token.get_secret_value()}
-        if client.certificate is not None:
-            return {"certfile": x509.valid(client.certificate)}
-
-        credential = client.authentication_record
-        if isinstance(credential, X509Credential):
-            if credential.path is None:
-                _fail_authentication(idp)
-            return {"certfile": cast("str", x509.inspect(credential.path)["path"])}
-        if not isinstance(credential, OIDCCredential):
-            _fail_authentication(idp)
-
-        if credential.expired:
-            parameters = _refresh_parameters(credential)
-            refreshed = await oidc.refresh(*parameters)
-            credential = oidc._persist_refreshed_credential(  # noqa: SLF001
-                config,
-                credential,
-                refreshed,
-            )
-        if credential.token.access is None:
-            _fail_authentication(idp)
-        return {"token": credential.token.access.get_secret_value()}
-    except (KeyError, OSError, TypeError, ValueError):
-        _fail_authentication(idp)
-
-
 def _fail_authentication(idp: str) -> NoReturn:
     """Raise the fixed secret-safe authentication failure."""
     reason = "Credential cannot be used. Run 'canfar login' for this IDP."
     raise AuthContextError(idp, reason) from None
-
-
-def _refresh_parameters(credential: OIDCCredential) -> tuple[str, str, str, str]:
-    """Return literal refresh inputs for an eligible Authentication Record."""
-    if not credential.refreshable:
-        raise ValueError
-    return (
-        cast("str", credential.endpoints.token),
-        cast("str", credential.client.identity),
-        cast("SecretStr", credential.client.secret).get_secret_value(),
-        cast("SecretStr", credential.token.refresh).get_secret_value(),
-    )

--- a/canfar/auth/oidc.py
+++ b/canfar/auth/oidc.py
@@ -7,7 +7,7 @@ import socket
 import time
 from collections.abc import Awaitable, Callable, Generator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import httpx
 from authlib.integrations.base_client.errors import OAuthError
@@ -193,6 +193,20 @@ def _validated_refresh(refreshed: Any) -> dict[str, Any]:
         msg = "OIDC token refresh failed: malformed token response"
         raise ValueError(msg)
     return dict(refreshed)
+
+
+def _refresh_parameters(
+    credential: OIDCCredential,
+) -> tuple[str, str, str, str] | None:
+    """Return complete literal refresh inputs when the record is eligible."""
+    if not credential.refreshable:
+        return None
+    return (
+        cast("str", credential.endpoints.token),
+        cast("str", credential.client.identity),
+        cast("SecretStr", credential.client.secret).get_secret_value(),
+        cast("SecretStr", credential.token.refresh).get_secret_value(),
+    )
 
 
 def _persist_refreshed_credential(

--- a/canfar/auth/oidc.py
+++ b/canfar/auth/oidc.py
@@ -20,6 +20,8 @@ from canfar.models.auth import DeviceAuthorization, Expiry, OIDCCredential, Toke
 if TYPE_CHECKING:
     from authlib.integrations.httpx_client import AsyncOAuth2Client
 
+    from canfar.models.config import Configuration
+
 log = get_logger(__name__)
 _BASIC_AUTH_METHOD = "client_secret_basic"
 
@@ -191,6 +193,53 @@ def _validated_refresh(refreshed: Any) -> dict[str, Any]:
         msg = "OIDC token refresh failed: malformed token response"
         raise ValueError(msg)
     return dict(refreshed)
+
+
+def _persist_refreshed_credential(
+    config: Configuration,
+    credential: OIDCCredential,
+    refreshed: dict[str, Any],
+) -> OIDCCredential:
+    """Validate and atomically persist refreshed OIDC state."""
+    previous_refresh = credential.token.refresh
+    previous_refresh_value = (
+        previous_refresh.get_secret_value() if previous_refresh is not None else None
+    )
+    returned_refresh = refreshed.get("refresh_token")
+    refresh_value = (
+        returned_refresh
+        if isinstance(returned_refresh, str) and returned_refresh
+        else previous_refresh_value
+    )
+    access_value = refreshed.get("access_token")
+    if not isinstance(access_value, str) or not access_value:
+        msg = "OIDC token refresh failed: malformed token response"
+        raise ValueError(msg)
+    try:
+        token = Token(
+            access=SecretStr(access_value),
+            refresh=SecretStr(refresh_value) if refresh_value is not None else None,
+            token_type=refreshed.get("token_type") or credential.token.token_type,
+            scope=refreshed.get("scope") or credential.token.scope,
+        )
+        expiry = Expiry(
+            access=refreshed.get("expires_at"),
+            refresh=(
+                None
+                if refresh_value != previous_refresh_value
+                else credential.expiry.refresh
+            ),
+        )
+    except (KeyError, TypeError, ValidationError):
+        msg = "OIDC token refresh failed: malformed token response"
+        raise ValueError(msg) from None
+
+    updated = credential.model_copy(update={"token": token, "expiry": expiry})
+    candidate = config.model_copy(deep=True)
+    candidate.update_credential(updated)
+    candidate.save()
+    config.update_credential(updated)
+    return updated
 
 
 async def refresh(

--- a/canfar/client.py
+++ b/canfar/client.py
@@ -20,7 +20,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing_extensions import Self
 
 from canfar import __version__, get_logger
-from canfar.auth import x509
+from canfar.auth import oidc, x509
 from canfar.exceptions.context import AuthContextError
 from canfar.hooks.httpx import auth, debug, errors, expiry
 from canfar.models.auth import (
@@ -230,6 +230,41 @@ class HTTPClient(BaseSettings):
                 "OIDC Authentication Record cannot refresh tokens.",
             )
         return credential
+
+    async def _materialize_credentials(self) -> tuple[str | None, str | None]:
+        """Return one literal token or validated certificate path."""
+        if self.token is not None:
+            token = self.token.get_secret_value()
+            if token:
+                return token, None
+            raise ValueError
+        if self.certificate is not None:
+            return None, x509.valid(self.certificate)
+
+        credential = self.authentication_record
+        if isinstance(credential, X509Credential):
+            if credential.path is None:
+                raise ValueError
+            return None, str(x509.inspect(credential.path)["path"])
+        if not isinstance(credential, OIDCCredential):
+            raise TypeError
+
+        if credential.expired:
+            parameters = oidc._refresh_parameters(credential)  # noqa: SLF001
+            if parameters is None:
+                raise ValueError
+            refreshed = await oidc.refresh(*parameters)
+            credential = oidc._persist_refreshed_credential(  # noqa: SLF001
+                self.config,
+                credential,
+                refreshed,
+            )
+        if credential.token.access is None:
+            raise ValueError
+        token = credential.token.access.get_secret_value()
+        if not token:
+            raise ValueError
+        return token, None
 
     def _get_base_url(self) -> URL:
         """Get the base URL for the client.

--- a/canfar/hooks/httpx/auth.py
+++ b/canfar/hooks/httpx/auth.py
@@ -32,16 +32,15 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any, Callable, cast
 
-from pydantic import SecretStr, ValidationError
-
 from canfar import get_logger
 from canfar.auth import oidc
-from canfar.models.auth import Expiry, OIDCCredential, Token
+from canfar.models.auth import OIDCCredential
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, MutableMapping
 
     import httpx
+    from pydantic import SecretStr
 
     from canfar.client import HTTPClient
 
@@ -97,51 +96,13 @@ def _apply_refreshed_token(
     request: httpx.Request,
 ) -> None:
     """Atomically persist refreshed OIDC state, then update active headers."""
-    previous_refresh = credential.token.refresh
-    previous_refresh_value = (
-        previous_refresh.get_secret_value() if previous_refresh is not None else None
+    updated = oidc._persist_refreshed_credential(  # noqa: SLF001
+        client.config, credential, refreshed
     )
-    returned_refresh = refreshed.get("refresh_token")
-    refresh_value = (
-        returned_refresh
-        if isinstance(returned_refresh, str) and returned_refresh
-        else previous_refresh_value
-    )
-    rotated = refresh_value != previous_refresh_value
-    access_value = refreshed.get("access_token")
-    if not isinstance(access_value, str) or not access_value:
-        msg = "OIDC token refresh failed: malformed token response"
-        raise ValueError(msg)
-    access_token = SecretStr(access_value)
-    token_type = refreshed.get("token_type")
-    if token_type is None or token_type == "":
-        token_type = credential.token.token_type
-    scope = refreshed.get("scope")
-    if scope is None or scope == "":
-        scope = credential.token.scope
-    try:
-        token = Token(
-            access=access_token,
-            refresh=SecretStr(refresh_value) if refresh_value is not None else None,
-            token_type=token_type,
-            scope=scope,
-        )
-        expiry = Expiry(
-            access=refreshed.get("expires_at"),
-            refresh=None if rotated else credential.expiry.refresh,
-        )
-    except (KeyError, TypeError, ValidationError):
-        msg = "OIDC token refresh failed: malformed token response"
-        raise ValueError(msg) from None
-
-    updated = credential.model_copy(update={"token": token, "expiry": expiry})
-    candidate = client.config.model_copy(deep=True)
-    candidate.update_credential(updated)
-    candidate.save()
-    client.config.update_credential(updated)
     log.debug("Authentication refreshed and configuration saved.")
 
-    _apply_access_header(access_token, httpx_client_headers, request)
+    assert updated.token.access is not None
+    _apply_access_header(updated.token.access, httpx_client_headers, request)
     log.debug("HTTP request headers updated with new token.")
     log.info("OIDC Access Token Refreshed.")
 

--- a/canfar/hooks/httpx/auth.py
+++ b/canfar/hooks/httpx/auth.py
@@ -30,7 +30,7 @@ Note:
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any, Callable, cast
+from typing import TYPE_CHECKING, Any, Callable
 
 from canfar import get_logger
 from canfar.auth import oidc
@@ -68,24 +68,6 @@ def _apply_access_header(
     header = f"Bearer {token.get_secret_value()}"
     httpx_client_headers["Authorization"] = header
     request.headers["Authorization"] = header
-
-
-def _refresh_parameters(
-    credential: OIDCCredential,
-) -> tuple[str, str, str, str] | None:
-    """Return complete refresh inputs when the record is eligible."""
-    if not credential.refreshable:
-        return None
-    token_url = cast("str", credential.endpoints.token)
-    identity = cast("str", credential.client.identity)
-    client_secret = cast("SecretStr", credential.client.secret)
-    refresh_token = cast("SecretStr", credential.token.refresh)
-    return (
-        token_url,
-        identity,
-        client_secret.get_secret_value(),
-        refresh_token.get_secret_value(),
-    )
 
 
 def _apply_refreshed_token(
@@ -138,7 +120,7 @@ def refresh(client: HTTPClient) -> Callable[[httpx.Request], None]:
             log.debug("Skipping auth refresh, access token is not expired.")
             return
 
-        parameters = _refresh_parameters(credential)
+        parameters = oidc._refresh_parameters(credential)  # noqa: SLF001
         if parameters is None:
             log.warning("OIDC Authentication Record cannot be refreshed.")
             return
@@ -200,7 +182,7 @@ def arefresh(client: HTTPClient) -> Callable[[httpx.Request], Awaitable[None]]:
                     )
                 return
 
-            parameters = _refresh_parameters(credential)
+            parameters = oidc._refresh_parameters(credential)  # noqa: SLF001
             if parameters is None:
                 log.warning("OIDC Authentication Record cannot be refreshed.")
                 return

--- a/canfar/models/config.py
+++ b/canfar/models/config.py
@@ -340,6 +340,21 @@ class Configuration(BaseSettings):
             raise KeyError(msg)
         return self.servers[name]
 
+    def _resolve_storage(self, storage_name: str) -> tuple[str, str]:
+        """Resolve a Storage Name to its endpoint and parent server IDP."""
+        for server in self.servers.values():
+            service = server.storage.get(storage_name)
+            if service is not None:
+                if server.idp is None:
+                    msg = (
+                        f"Storage Name '{storage_name}' belongs to a Science Platform "
+                        "Server without an IDP."
+                    )
+                    raise ValueError(msg)
+                return str(service.url), server.idp
+        msg = f"Storage Name '{storage_name}' is not configured."
+        raise KeyError(msg)
+
     def upsert_credential(self, credential: AuthenticationCredential) -> None:
         """Insert or replace a validated Authentication Record.
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -63,14 +63,19 @@ def _config(
     )
 
 
+@pytest.fixture(autouse=True)
+def _isolate_configuration(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Isolate every source test from the developer's configuration."""
+    config_path = tmp_path / "config.yaml"
+    monkeypatch.setattr("canfar.models.config.CONFIG_PATH", config_path)
+
+
 @pytest.mark.asyncio
 async def test_source_reloads_config_and_runtime_token_wins(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     """Entry reloads endpoint state and keeps token-over-certificate precedence."""
-    config_path = tmp_path / "config.yaml"
-    monkeypatch.setattr("canfar.models.config.CONFIG_PATH", config_path)
     config = _config(credential=oidc_credential("inactive"))
     config.save()
     source = _vospace_source(
@@ -102,11 +107,8 @@ async def test_source_reloads_config_and_runtime_token_wins(
 @pytest.mark.asyncio
 async def test_expired_inactive_oidc_refreshes_once_and_persists(
     monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
 ) -> None:
     """An inactive Science Platform Server uses its IDP and persists refresh."""
-    config_path = tmp_path / "config.yaml"
-    monkeypatch.setattr("canfar.models.config.CONFIG_PATH", config_path)
     config = _config(
         credential=oidc_credential(
             "inactive",
@@ -144,11 +146,8 @@ async def test_expired_inactive_oidc_refreshes_once_and_persists(
 @pytest.mark.asyncio
 async def test_valid_saved_oidc_access_token_is_reused(
     monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
 ) -> None:
     """A current saved OIDC Authentication Record needs no refresh."""
-    config_path = tmp_path / "config.yaml"
-    monkeypatch.setattr("canfar.models.config.CONFIG_PATH", config_path)
     _config(credential=oidc_credential("inactive", access="current-token")).save()
     refresh = AsyncMock()
     monkeypatch.setattr("canfar.client.oidc.refresh", refresh)
@@ -166,9 +165,7 @@ async def test_saved_x509_is_validated_before_construction(
     tmp_path: Path,
 ) -> None:
     """Saved X.509 material becomes only an inspected literal certfile path."""
-    config_path = tmp_path / "config.yaml"
     certificate = tmp_path / "saved.pem"
-    monkeypatch.setattr("canfar.models.config.CONFIG_PATH", config_path)
     _config(credential=x509_credential("inactive", path=certificate)).save()
     inspect = Mock()
 
@@ -191,9 +188,7 @@ async def test_runtime_x509_overrides_saved_authentication_record(
     tmp_path: Path,
 ) -> None:
     """A validated runtime certificate wins over the saved Authentication Record."""
-    config_path = tmp_path / "config.yaml"
     certificate = tmp_path / "runtime.pem"
-    monkeypatch.setattr("canfar.models.config.CONFIG_PATH", config_path)
     _config(credential=oidc_credential("inactive")).save()
     monkeypatch.setattr(
         "canfar.client.x509.inspect",
@@ -215,9 +210,7 @@ async def test_invalid_saved_x509_fails_before_vospace(
     tmp_path: Path,
 ) -> None:
     """An invalid X.509 Authentication Record fails with a clean login hint."""
-    config_path = tmp_path / "config.yaml"
     certificate = tmp_path / "invalid.pem"
-    monkeypatch.setattr("canfar.models.config.CONFIG_PATH", config_path)
     _config(credential=x509_credential("inactive", path=certificate)).save()
     monkeypatch.setattr(
         "canfar.client.x509.inspect",
@@ -239,11 +232,8 @@ async def test_invalid_saved_x509_fails_before_vospace(
 async def test_source_closes_on_failure_and_cancellation(
     exit_kind: str,
     monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
 ) -> None:
     """Context exit always closes a yielded filesystem."""
-    config_path = tmp_path / "config.yaml"
-    monkeypatch.setattr("canfar.models.config.CONFIG_PATH", config_path)
     _config(credential=oidc_credential("inactive")).save()
     filesystems: list[_Filesystem] = []
 
@@ -276,11 +266,8 @@ async def test_source_closes_on_failure_and_cancellation(
 @pytest.mark.asyncio
 async def test_unrefreshable_oidc_fails_secret_safe_before_vospace(
     monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
 ) -> None:
-    """Bad saved Authentication reports a hint without exposing secret values."""
-    config_path = tmp_path / "config.yaml"
-    monkeypatch.setattr("canfar.models.config.CONFIG_PATH", config_path)
+    """Bad saved Authentication Record reports a secret-safe login hint."""
     _config(
         credential=oidc_credential(
             "inactive",
@@ -306,11 +293,8 @@ async def test_unrefreshable_oidc_fails_secret_safe_before_vospace(
 @pytest.mark.asyncio
 async def test_empty_saved_oidc_token_fails_cleanly(
     monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
 ) -> None:
     """An empty saved token cannot fall through to certificate construction."""
-    config_path = tmp_path / "config.yaml"
-    monkeypatch.setattr("canfar.models.config.CONFIG_PATH", config_path)
     _config(credential=oidc_credential("inactive", access="")).save()
     constructor = Mock()
     monkeypatch.setattr(vosfs, "VOSpaceFileSystem", constructor)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,259 @@
+"""Tests for private authenticated VOSpace source adapters."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+import vosfs
+from pydantic import AnyHttpUrl, AnyUrl
+
+from canfar._storage import _vospace_source
+from canfar.exceptions.context import AuthContextError
+from canfar.models.active import ActiveConfig
+from canfar.models.config import Configuration
+from canfar.models.http import Server, VOSpaceService
+from tests.helpers.config import oidc_credential, x509_credential
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class _Filesystem:
+    """Record construction and cleanup without VOSpace I/O."""
+
+    async_impl = True
+
+    def __init__(self, endpoint: str, **kwargs: Any) -> None:
+        self.endpoint = endpoint
+        self.kwargs = kwargs
+        self.asynchronous = kwargs["asynchronous"]
+        self.closed = False
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _config(
+    *,
+    credential: Any,
+    endpoint: str = "https://inactive.example/vospace",
+) -> Configuration:
+    server = Server(
+        idp=credential.idp,
+        uri=AnyUrl("ivo://inactive.example/skaha"),
+        url=AnyHttpUrl("https://inactive.example/skaha"),
+        version="v1",
+        storage={
+            "archive": VOSpaceService(
+                uri=AnyUrl("ivo://inactive.example/arc"),
+                url=AnyHttpUrl(endpoint),
+            )
+        },
+    )
+    return Configuration(
+        active=ActiveConfig(authentication="active", server=None),
+        authentication={
+            "active": x509_credential("active"),
+            credential.idp: credential,
+        },
+        servers={"inactive": server},
+    )
+
+
+@pytest.mark.asyncio
+async def test_source_reloads_config_and_runtime_token_wins(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Entry reloads endpoint state and keeps token-over-certificate precedence."""
+    config_path = tmp_path / "config.yaml"
+    monkeypatch.setattr("canfar.models.config.CONFIG_PATH", config_path)
+    config = _config(credential=oidc_credential("inactive"))
+    config.save()
+    source = _vospace_source(
+        "archive",
+        token="runtime-token",
+        certificate=tmp_path / "ignored.pem",
+    )
+
+    config.servers["inactive"].storage["archive"].url = AnyHttpUrl(
+        "https://changed.example/vospace"
+    )
+    config.save()
+    monkeypatch.setattr(vosfs, "VOSpaceFileSystem", _Filesystem)
+
+    async with source() as filesystem:
+        assert filesystem.endpoint == "https://changed.example/vospace"
+        assert filesystem.kwargs == {
+            "token": "runtime-token",
+            "asynchronous": True,
+            "skip_instance_cache": True,
+        }
+        assert filesystem.async_impl is True
+        assert filesystem.asynchronous is True
+        assert filesystem.closed is False
+
+    assert filesystem.closed is True
+
+
+@pytest.mark.asyncio
+async def test_expired_inactive_oidc_refreshes_once_and_persists(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An inactive Server uses its own IDP and persists one shared refresh."""
+    config_path = tmp_path / "config.yaml"
+    monkeypatch.setattr("canfar.models.config.CONFIG_PATH", config_path)
+    config = _config(
+        credential=oidc_credential(
+            "inactive",
+            access="old-access-secret",
+            refresh="refresh-secret",
+            access_expiry=1.0,
+        )
+    )
+    config.save()
+    refresh = AsyncMock(
+        return_value={
+            "access_token": "new-access-secret",
+            "expires_at": 9_999_999_999.0,
+        }
+    )
+    monkeypatch.setattr("canfar._storage.oidc.refresh", refresh)
+    monkeypatch.setattr(vosfs, "VOSpaceFileSystem", _Filesystem)
+
+    async with _vospace_source("archive")() as filesystem:
+        assert filesystem.kwargs["token"] == "new-access-secret"
+
+    refresh.assert_awaited_once_with(
+        "https://oidc.example.com/token",
+        "test-client",
+        "test-secret",
+        "refresh-secret",
+    )
+    persisted = Configuration()  # ty: ignore[missing-argument]
+    saved = persisted.get_credential("inactive")
+    assert saved.mode == "oidc"
+    assert saved.token.access is not None
+    assert saved.token.access.get_secret_value() == "new-access-secret"
+
+
+@pytest.mark.asyncio
+async def test_saved_x509_is_validated_before_construction(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Saved X.509 material becomes only an inspected literal certfile path."""
+    config_path = tmp_path / "config.yaml"
+    certificate = tmp_path / "saved.pem"
+    monkeypatch.setattr("canfar.models.config.CONFIG_PATH", config_path)
+    _config(credential=x509_credential("inactive", path=certificate)).save()
+    inspect = Mock()
+
+    def inspect_certificate(path: Path) -> dict[str, object]:
+        inspect(path)
+        return {"path": path.as_posix(), "expiry": 9_999_999_999.0}
+
+    monkeypatch.setattr("canfar._storage.x509.inspect", inspect_certificate)
+    monkeypatch.setattr(vosfs, "VOSpaceFileSystem", _Filesystem)
+
+    async with _vospace_source("archive")() as filesystem:
+        assert filesystem.kwargs["certfile"] == certificate.as_posix()
+
+    inspect.assert_called_once_with(certificate)
+
+
+@pytest.mark.asyncio
+async def test_runtime_x509_overrides_saved_oidc(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A validated runtime certificate wins over the saved Authentication Record."""
+    config_path = tmp_path / "config.yaml"
+    certificate = tmp_path / "runtime.pem"
+    monkeypatch.setattr("canfar.models.config.CONFIG_PATH", config_path)
+    _config(credential=oidc_credential("inactive")).save()
+    monkeypatch.setattr(
+        "canfar._storage.x509.inspect",
+        lambda path: {"path": path.as_posix(), "expiry": 9_999_999_999.0},
+    )
+    valid = Mock(return_value=certificate.as_posix())
+    monkeypatch.setattr("canfar._storage.x509.valid", valid)
+    monkeypatch.setattr(vosfs, "VOSpaceFileSystem", _Filesystem)
+
+    async with _vospace_source("archive", certificate=certificate)() as filesystem:
+        assert filesystem.kwargs["certfile"] == certificate.as_posix()
+
+    valid.assert_called_once_with(certificate)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exit_kind", ["error", "cancel"])
+async def test_source_closes_on_failure_and_cancellation(
+    exit_kind: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Context exit always closes a yielded filesystem."""
+    config_path = tmp_path / "config.yaml"
+    monkeypatch.setattr("canfar.models.config.CONFIG_PATH", config_path)
+    _config(credential=oidc_credential("inactive")).save()
+    filesystems: list[_Filesystem] = []
+
+    def build(endpoint: str, **kwargs: Any) -> _Filesystem:
+        filesystem = _Filesystem(endpoint, **kwargs)
+        filesystems.append(filesystem)
+        return filesystem
+
+    monkeypatch.setattr(vosfs, "VOSpaceFileSystem", build)
+
+    async def use_source() -> None:
+        async with _vospace_source("archive")():
+            if exit_kind == "error":
+                raise RuntimeError
+            await asyncio.Event().wait()
+
+    task = asyncio.create_task(use_source())
+    await asyncio.sleep(0)
+    if exit_kind == "error":
+        with pytest.raises(RuntimeError):
+            await task
+    else:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert filesystems[0].closed is True
+
+
+@pytest.mark.asyncio
+async def test_unrefreshable_oidc_fails_secret_safe_before_vospace(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Bad saved auth reports a login hint without exposing secret values."""
+    config_path = tmp_path / "config.yaml"
+    monkeypatch.setattr("canfar.models.config.CONFIG_PATH", config_path)
+    _config(
+        credential=oidc_credential(
+            "inactive",
+            access="old-access-secret",
+            refresh="refresh-secret",
+            access_expiry=1.0,
+            refresh_expiry=1.0,
+        )
+    ).save()
+    constructor = AsyncMock()
+    monkeypatch.setattr(vosfs, "VOSpaceFileSystem", constructor)
+
+    with pytest.raises(AuthContextError, match="canfar login") as exc_info:
+        async with _vospace_source("archive")():
+            pass
+
+    message = str(exc_info.value)
+    assert "old-access-secret" not in message
+    assert "refresh-secret" not in message
+    constructor.assert_not_called()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -104,7 +104,7 @@ async def test_expired_inactive_oidc_refreshes_once_and_persists(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """An inactive Server uses its own IDP and persists one shared refresh."""
+    """An inactive Science Platform Server uses its IDP and persists refresh."""
     config_path = tmp_path / "config.yaml"
     monkeypatch.setattr("canfar.models.config.CONFIG_PATH", config_path)
     config = _config(
@@ -122,7 +122,7 @@ async def test_expired_inactive_oidc_refreshes_once_and_persists(
             "expires_at": 9_999_999_999.0,
         }
     )
-    monkeypatch.setattr("canfar._storage.oidc.refresh", refresh)
+    monkeypatch.setattr("canfar.client.oidc.refresh", refresh)
     monkeypatch.setattr(vosfs, "VOSpaceFileSystem", _Filesystem)
 
     async with _vospace_source("archive")() as filesystem:
@@ -142,6 +142,25 @@ async def test_expired_inactive_oidc_refreshes_once_and_persists(
 
 
 @pytest.mark.asyncio
+async def test_valid_saved_oidc_access_token_is_reused(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A current saved OIDC Authentication Record needs no refresh."""
+    config_path = tmp_path / "config.yaml"
+    monkeypatch.setattr("canfar.models.config.CONFIG_PATH", config_path)
+    _config(credential=oidc_credential("inactive", access="current-token")).save()
+    refresh = AsyncMock()
+    monkeypatch.setattr("canfar.client.oidc.refresh", refresh)
+    monkeypatch.setattr(vosfs, "VOSpaceFileSystem", _Filesystem)
+
+    async with _vospace_source("archive")() as filesystem:
+        assert filesystem.kwargs["token"] == "current-token"
+
+    refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_saved_x509_is_validated_before_construction(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -157,7 +176,7 @@ async def test_saved_x509_is_validated_before_construction(
         inspect(path)
         return {"path": path.as_posix(), "expiry": 9_999_999_999.0}
 
-    monkeypatch.setattr("canfar._storage.x509.inspect", inspect_certificate)
+    monkeypatch.setattr("canfar.client.x509.inspect", inspect_certificate)
     monkeypatch.setattr(vosfs, "VOSpaceFileSystem", _Filesystem)
 
     async with _vospace_source("archive")() as filesystem:
@@ -167,7 +186,7 @@ async def test_saved_x509_is_validated_before_construction(
 
 
 @pytest.mark.asyncio
-async def test_runtime_x509_overrides_saved_oidc(
+async def test_runtime_x509_overrides_saved_authentication_record(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -177,17 +196,42 @@ async def test_runtime_x509_overrides_saved_oidc(
     monkeypatch.setattr("canfar.models.config.CONFIG_PATH", config_path)
     _config(credential=oidc_credential("inactive")).save()
     monkeypatch.setattr(
-        "canfar._storage.x509.inspect",
+        "canfar.client.x509.inspect",
         lambda path: {"path": path.as_posix(), "expiry": 9_999_999_999.0},
     )
     valid = Mock(return_value=certificate.as_posix())
-    monkeypatch.setattr("canfar._storage.x509.valid", valid)
+    monkeypatch.setattr("canfar.client.x509.valid", valid)
     monkeypatch.setattr(vosfs, "VOSpaceFileSystem", _Filesystem)
 
     async with _vospace_source("archive", certificate=certificate)() as filesystem:
         assert filesystem.kwargs["certfile"] == certificate.as_posix()
 
     valid.assert_called_once_with(certificate)
+
+
+@pytest.mark.asyncio
+async def test_invalid_saved_x509_fails_before_vospace(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An invalid X.509 Authentication Record fails with a clean login hint."""
+    config_path = tmp_path / "config.yaml"
+    certificate = tmp_path / "invalid.pem"
+    monkeypatch.setattr("canfar.models.config.CONFIG_PATH", config_path)
+    _config(credential=x509_credential("inactive", path=certificate)).save()
+    monkeypatch.setattr(
+        "canfar.client.x509.inspect",
+        Mock(side_effect=ValueError("certificate parse detail")),
+    )
+    constructor = Mock()
+    monkeypatch.setattr(vosfs, "VOSpaceFileSystem", constructor)
+
+    with pytest.raises(AuthContextError, match="canfar login") as exc_info:
+        async with _vospace_source("archive")():
+            pass
+
+    assert "certificate parse detail" not in str(exc_info.value)
+    constructor.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -234,7 +278,7 @@ async def test_unrefreshable_oidc_fails_secret_safe_before_vospace(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Bad saved auth reports a login hint without exposing secret values."""
+    """Bad saved Authentication reports a hint without exposing secret values."""
     config_path = tmp_path / "config.yaml"
     monkeypatch.setattr("canfar.models.config.CONFIG_PATH", config_path)
     _config(
@@ -256,4 +300,23 @@ async def test_unrefreshable_oidc_fails_secret_safe_before_vospace(
     message = str(exc_info.value)
     assert "old-access-secret" not in message
     assert "refresh-secret" not in message
+    constructor.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_empty_saved_oidc_token_fails_cleanly(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An empty saved token cannot fall through to certificate construction."""
+    config_path = tmp_path / "config.yaml"
+    monkeypatch.setattr("canfar.models.config.CONFIG_PATH", config_path)
+    _config(credential=oidc_credential("inactive", access="")).save()
+    constructor = Mock()
+    monkeypatch.setattr(vosfs, "VOSpaceFileSystem", constructor)
+
+    with pytest.raises(AuthContextError, match="canfar login"):
+        async with _vospace_source("archive")():
+            pass
+
     constructor.assert_not_called()


### PR DESCRIPTION
## Summary

- add a private per-invocation async vosfs source factory for configured Storage Names
- keep credential precedence and literal credential materialization behind HTTPClient
- share OIDC refresh persistence and validate runtime or saved X.509 before filesystem construction
- guarantee fresh non-cached async filesystems and cleanup on success, error, and cancellation

Implements #153.

## Validation

- uv run --no-sync ruff check . --no-cache
- uv run --no-sync ruff format --check .
- uv run ty check canfar (exact accepted baseline: 22 unused-ignore diagnostics, no new diagnostics)
- uv run --no-sync pytest tests -m "not slow" --no-cov -q -o cache_dir=/tmp/canfar-pytest-cache (778 passed)
- uv run --group docs mkdocs build (completed; git-committers logged a GitHub API rate-limit warning without failing the build)
- fixed-base Standards review against feat/vosfs-support: clean

## Scope

No registry discovery, command mounting, packaging promotion, public storage API, docs changes, or mandatory live test.