### PR TITLE
feat(discovery): discover primary VOSpace services

### DIFF
--- a/canfar/idp.py
+++ b/canfar/idp.py
@@ -19,6 +19,7 @@ class IdpInfo(BaseModel):
         auth_mode: Default authentication mode for the IDP.
         registry_url: IVOA registry resource-caps URL for server discovery.
         registry_name: Registry display name used for server discovery.
+        preferred_storage_leaf: Preferred primary VOSpace registry URI leaf.
         dev_registries: Development registry resource-caps URLs keyed by URL.
         oidc_discovery_url: OIDC discovery URL when ``auth_mode`` is ``oidc``.
         oidc_issuer: Exact issuer expected from OIDC discovery metadata.
@@ -35,6 +36,10 @@ class IdpInfo(BaseModel):
     registry_name: str | None = Field(
         default=None,
         description="Registry display name used for server discovery.",
+    )
+    preferred_storage_leaf: str | None = Field(
+        default=None,
+        description="Preferred primary VOSpace registry URI leaf.",
     )
     dev_registries: dict[str, str] = Field(
         default_factory=dict,
@@ -56,6 +61,7 @@ _BUILTIN_IDPS: dict[str, IdpInfo] = {
         name="Canadian Astronomy Data Centre",
         auth_mode="x509",
         registry_name="CADC",
+        preferred_storage_leaf="arc",
         registry_url=AnyHttpUrl(
             "https://ws.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/reg/resource-caps"
         ),
@@ -70,6 +76,7 @@ _BUILTIN_IDPS: dict[str, IdpInfo] = {
         name="SKA Regional Centre Network",
         auth_mode="oidc",
         registry_name="SRCNet",
+        preferred_storage_leaf="cavern",
         registry_url=AnyHttpUrl("https://spsrc27.iaa.csic.es/reg/resource-caps"),
         oidc_discovery_url=AnyHttpUrl(
             "https://ska-iam.stfc.ac.uk/.well-known/openid-configuration"

--- a/canfar/models/registry.py
+++ b/canfar/models/registry.py
@@ -25,6 +25,8 @@ class IVOARegistrySearch(BaseModel):
         }
     )
 
+    preferred_storage_leaf: str | None = None
+
     names: dict[str, str] = Field(
         default={
             "ivo://canfar.net/src/skaha": "canSRC",

--- a/canfar/server.py
+++ b/canfar/server.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 from xml.etree.ElementTree import ParseError
 
 import httpx
@@ -16,22 +16,23 @@ from canfar.auth.x509 import CertificateError
 from canfar.errors import ErrorCode, StructuredError
 from canfar.exceptions.context import AuthContextError, AuthExpiredError
 from canfar.hooks.httpx.auth import AuthenticationError as HTTPAuthenticationError
-from canfar.idp import registry_sources
+from canfar.idp import get_idp, registry_sources
 from canfar.models.config import Configuration
 from canfar.models.http import (
     DEFAULT_SERVER_CORES,
     DEFAULT_SERVER_GPUS,
     DEFAULT_SERVER_RAM_GB,
     Server,
+    VOSpaceService,
 )
 from canfar.models.registry import IVOARegistrySearch
+from canfar.models.registry import Server as RegistryResource
 from canfar.utils import vosi
 from canfar.utils.discover import Discover
 
 log = get_logger(__name__)
 
-if TYPE_CHECKING:
-    from canfar.models.registry import Server as DiscoveredServer
+_STORAGE_RESOURCE_UNSET = object()
 
 
 class ServerSelectorError(ValueError):
@@ -136,6 +137,11 @@ def discover(
         known = canonical.get(name, known_servers.get(name))
         if server.version is None or not server.auths:
             if known is not None and known.version is not None and known.auths:
+                if server.storage:
+                    known = known.model_copy(
+                        update={"storage": {**known.storage, **server.storage}},
+                        deep=True,
+                    )
                 canonical[name] = known
             continue
         merged_server = server
@@ -144,6 +150,8 @@ def discover(
                 include={"idp", "name", "uri", "url", "version", "auths"},
                 exclude_none=True,
             )
+            if server.storage:
+                updates["storage"] = {**known.storage, **server.storage}
             merged_server = known.model_copy(update=updates, deep=True)
         canonical[name] = merged_server
 
@@ -397,7 +405,10 @@ async def _discover_for_idp(
         ServerDiscoveryError: If registry retrieval fails.
     """
     sources = registry_sources(idp, include_dev=dev)
-    search = IVOARegistrySearch(registries=sources)
+    search = IVOARegistrySearch(
+        registries=sources,
+        preferred_storage_leaf=get_idp(idp).preferred_storage_leaf,
+    )
     async with Discover(search, timeout=timeout) as discovery:
         registries = await asyncio.gather(
             *(discovery.fetch(url, name) for url, name in sources.items())
@@ -412,11 +423,20 @@ async def _discover_for_idp(
             msg = f"Failed to discover servers for IDP '{idp}': {errors}"
             raise ServerDiscoveryError(msg)
 
-        endpoints = []
+        resources = []
         for registry in successful_registries:
-            endpoints.extend(discovery.extract(registry, dev=dev))
+            resources.extend(discovery.extract(registry, dev=dev))
+        endpoints = [
+            resource for resource in resources if resource.uri.endswith("/skaha")
+        ]
         if not endpoints:
             return []
+
+        storage_by_namespace = {
+            (resource.registry, _registry_namespace(resource.uri)): resource
+            for resource in resources
+            if resource.uri.endswith(f"/{search.preferred_storage_leaf}")
+        }
 
         checked = await asyncio.gather(
             *(discovery.check(endpoint) for endpoint in endpoints)
@@ -427,6 +447,9 @@ async def _discover_for_idp(
                 idp,
                 config=config,
                 timeout=timeout,
+                storage_resource=storage_by_namespace.get(
+                    (endpoint.registry, _registry_namespace(endpoint.uri))
+                ),
             )
             for endpoint in checked
             if endpoint.status == 200
@@ -440,12 +463,18 @@ def _host_slug(uri: AnyUrl) -> str | None:
     return uri.host.replace(".", "-")
 
 
+def _registry_namespace(uri: str) -> str:
+    """Return the IVOA registry URI namespace before its resource leaf."""
+    return uri.rpartition("/")[0]
+
+
 def _discovered_to_server(
-    endpoint: DiscoveredServer,
+    endpoint: RegistryResource,
     idp: str,
     *,
     config: Configuration | None = None,
     timeout: int = 2,
+    storage_resource: RegistryResource | None = None,
 ) -> Server:
     """Convert a registry discovery record to a persisted HTTP server model.
 
@@ -457,6 +486,7 @@ def _discovered_to_server(
         idp: Canonical IDP key.
         config: Configuration whose Authentication Record authorizes enrichment.
         timeout: HTTP timeout in seconds for VOSI capabilities requests.
+        storage_resource: Same-namespace preferred VOSpace registry record, if any.
 
     Returns:
         Server: Persisted server model with capabilities metadata when available.
@@ -473,6 +503,7 @@ def _discovered_to_server(
         config=config,
         strict=False,
         timeout=timeout,
+        storage_resource=storage_resource,
     )
 
 
@@ -483,6 +514,7 @@ def enrich(
     authentication_idp: str | None = None,
     strict: bool = True,
     timeout: int = 2,
+    storage_resource: RegistryResource | None | object = _STORAGE_RESOURCE_UNSET,
 ) -> Server:
     """Return a validated Server enriched from its VOSI capabilities.
 
@@ -497,6 +529,9 @@ def enrich(
             cannot be retrieved or parsed. Discovery uses non-strict mode so
             one malformed endpoint does not abort listing for an IDP.
         timeout: HTTP timeout in seconds for VOSI capabilities requests.
+        storage_resource: Retained same-namespace VOSpace registry record. Passing
+            ``None`` records that the preferred resource was absent; omitting the
+            argument leaves storage outside this inspection.
 
     Returns:
         Server: Copy with version and auth modes populated when discoverable.
@@ -505,29 +540,33 @@ def enrich(
         ServerFetchError: If ``strict`` is ``True`` and capabilities cannot
             be retrieved, parsed, or contain no session capabilities.
     """
+    base_config = config or Configuration()  # ty: ignore[missing-argument]
+    active_idp = authentication_idp or server.idp or base_config.active.authentication
+    if storage_resource is not _STORAGE_RESOURCE_UNSET:
+        server = _enrich_storage(
+            server,
+            storage_resource=(
+                storage_resource
+                if isinstance(storage_resource, RegistryResource)
+                else None
+            ),
+            config=base_config,
+            authentication_idp=active_idp,
+            strict=strict,
+            timeout=timeout,
+        )
     if server.url is None:
         msg = "Server URL is required to inspect capabilities."
         raise ServerFetchError(msg)
-
-    base_config = config or Configuration()  # ty: ignore[missing-argument]
-    active_idp = authentication_idp or server.idp or base_config.active.authentication
     try:
-        from canfar.client import HTTPClient  # noqa: PLC0415
-
-        with HTTPClient(
-            config=base_config,
-            authentication_idp=active_idp,
-            url=server.url,
-            timeout=timeout,
-            raise_http_errors=False,
-        ) as client:
-            request_client = client.client
-            request_client.headers["Accept"] = "application/xml"
-            request_client.headers.pop("Content-Type", None)
-            request_client.headers.pop("X-Skaha-Registry-Auth", None)
-            response = request_client.get("capabilities")
-            response.raise_for_status()
-            capabilities = vosi.capabilities(xml=response.text)
+        capabilities = vosi.capabilities(
+            xml=_fetch_capabilities(
+                server.url,
+                config=base_config,
+                authentication_idp=active_idp,
+                timeout=timeout,
+            )
+        )
     except (
         httpx.HTTPError,
         OSError,
@@ -587,6 +626,102 @@ def enrich(
             ),
             args=(server.url, exc),
         )
+
+
+def _enrich_storage(
+    server: Server,
+    *,
+    storage_resource: RegistryResource | None,
+    config: Configuration,
+    authentication_idp: str,
+    strict: bool,
+    timeout: int,
+) -> Server:
+    """Validate and attach one retained primary VOSpace registry resource."""
+    error: BaseException | None = None
+    if storage_resource is None:
+        leaf = get_idp(authentication_idp).preferred_storage_leaf
+        subject = f"same-namespace '{leaf}' registry record"
+        error = ValueError(
+            f"No {subject} found for Science Platform Server '{server.name}'."
+        )
+    else:
+        subject = storage_resource.uri
+        try:
+            xml = _fetch_capabilities(
+                AnyHttpUrl(storage_resource.url),
+                config=config,
+                authentication_idp=authentication_idp,
+                timeout=timeout,
+            )
+            valid = vosi.is_vospace_service(xml)
+        except (
+            httpx.HTTPError,
+            OSError,
+            AuthContextError,
+            AuthExpiredError,
+            CertificateError,
+            HTTPAuthenticationError,
+            ParseError,
+            DefusedXmlException,
+            ValueError,
+        ) as exc:
+            error = exc
+        else:
+            if not valid:
+                error = ValueError(
+                    "required VOSpace node capability is missing or malformed"
+                )
+            elif server.name is None:
+                error = ValueError("Science Platform Server has no Server Name")
+
+    if error is not None:
+        return _keep_or_raise(
+            server,
+            strict=strict,
+            error=(
+                f"Failed to inspect VOSpace Service '{subject}' for Science "
+                f"Platform Server '{server.name}': {error}"
+            ),
+            cause=error,
+            debug="Skipping VOSpace Service %s during discovery: %s",
+            args=(subject, error),
+        )
+
+    assert storage_resource is not None
+    assert server.name is not None
+    service = VOSpaceService(uri=storage_resource.uri, url=storage_resource.url)
+
+    return server.model_copy(
+        update={"storage": {**server.storage, server.name: service}},
+        deep=True,
+    )
+
+
+def _fetch_capabilities(
+    url: AnyHttpUrl,
+    *,
+    config: Configuration,
+    authentication_idp: str,
+    timeout: int,
+) -> str:
+    """Fetch one VOSI capabilities document through the existing HTTP seam."""
+    from canfar.client import HTTPClient  # noqa: PLC0415
+
+    with HTTPClient(
+        config=config,
+        authentication_idp=authentication_idp,
+        url=url,
+        timeout=timeout,
+        raise_http_errors=False,
+    ) as client:
+        request_client = client.client
+        request_client.headers["Accept"] = "application/xml"
+        request_client.headers.pop("Content-Type", None)
+        request_client.headers.pop("X-Skaha-Registry-Auth", None)
+        response = request_client.get("capabilities")
+        response.raise_for_status()
+        return response.text
 
 
 def _keep_or_raise(

--- a/canfar/utils/discover.py
+++ b/canfar/utils/discover.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 from typing_extensions import Self
@@ -75,7 +76,7 @@ class Discover:
             return IVOARegistry(name=name, content="", success=False, error=error_msg)
 
     def extract(self, registry: IVOARegistry, dev: bool = False) -> list[Server]:
-        """Extract capabilities endpoints from registry content."""
+        """Extract Science Platform and preferred VOSpace registry records."""
         if not registry.success or not registry.content:
             return []
 
@@ -89,8 +90,11 @@ class Discover:
             uri, url = line.split("=", 1)
             uri, url = uri.strip(), url.strip()
 
-            if url.endswith("/skaha/capabilities") and uri.endswith("/skaha"):
-                url = url.replace("/capabilities", "")
+            leaf = uri.rpartition("/")[2]
+            if leaf in {"skaha", self.config.preferred_storage_leaf}:
+                url = _without_terminal_capabilities(url)
+                if url is None:
+                    continue
                 # Apply exclusion filters
                 if not dev and any(
                     word in uri.lower() or word in url.lower()
@@ -105,7 +109,7 @@ class Discover:
                     registry=registry.name,
                     uri=uri,
                     url=url,
-                    name=self.config.names.get(uri),
+                    name=self.config.names.get(uri) if leaf == "skaha" else None,
                 )
                 endpoints.append(endpoint)
 
@@ -119,3 +123,11 @@ class Discover:
         except httpx.HTTPError:
             endpoint.status = None
         return endpoint
+
+
+def _without_terminal_capabilities(url: str) -> str | None:
+    """Remove only a terminal ``/capabilities`` path component."""
+    parsed = urlsplit(url)
+    if not parsed.path.endswith("/capabilities"):
+        return None
+    return urlunsplit(parsed._replace(path=parsed.path.removesuffix("/capabilities")))

--- a/canfar/utils/vosi.py
+++ b/canfar/utils/vosi.py
@@ -9,6 +9,8 @@ from defusedxml import ElementTree
 
 LEGACY_SESSIONS_STDID = "vos://cadc.nrc.ca~vospace/CADC/std/Proc#sessions-1.0"
 PLATFORM_PREFIX = "http://www.opencadc.org/std/platform#session-"
+VOSPACE_NODES_STDID = "ivo://ivoa.net/std/VOSpace/v2.0#nodes"
+_XSI_TYPE = "{http://www.w3.org/2001/XMLSchema-instance}type"
 
 # Auth mode rename map
 AUTH_RENAME = {
@@ -199,3 +201,23 @@ def capabilities(  # noqa: PLR0912 too many branches (clarity)
         reverse=True,
     )
     return items
+
+
+def is_vospace_service(xml: str) -> bool:
+    """Return whether VOSI XML exposes the OpenCADC VOSpace node binding."""
+    root = ElementTree.fromstring(xml)
+    for capability in root.findall(".//{*}capability"):
+        if capability.get("standardID") != VOSPACE_NODES_STDID:
+            continue
+        for interface in capability.findall("{*}interface"):
+            if interface.get("role") != "std":
+                continue
+            if interface.get(_XSI_TYPE, "").rsplit(":", 1)[-1] != "ParamHTTP":
+                continue
+            if any(
+                (access.get("use") in {None, "base"})
+                and bool((access.text or "").strip())
+                for access in interface.findall("{*}accessURL")
+            ):
+                return True
+    return False

--- a/tests/test_idp.py
+++ b/tests/test_idp.py
@@ -23,6 +23,13 @@ class TestListIdps:
         assert len(idps) == 2
         assert all(isinstance(idp, IdpInfo) for idp in idps)
 
+    def test_builtin_primary_storage_preferences(self) -> None:
+        """Each built-in IDP declares its primary VOSpace resource leaf."""
+        assert {idp.key: idp.preferred_storage_leaf for idp in list_idps()} == {
+            "cadc": "arc",
+            "srcnet": "cavern",
+        }
+
 
 class TestGetIdpCadc:
     """Tests for get_idp() with the cadc entry."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -391,7 +391,7 @@ class TestServerDiscovery:
         self,
         tmp_path: Path,
     ) -> None:
-        """Rediscovery updates only the generated Server Name storage entry."""
+        """Rediscovery updates only the generated Storage Name entry."""
         manual = VOSpaceService(
             uri="ivo://cadc.nrc.ca/custom",
             url="https://manual.example/custom",
@@ -472,7 +472,9 @@ class TestServerDiscovery:
         )
 
     @pytest.mark.parametrize("mode", ["missing", "malformed", "unreachable"])
-    def test_storage_inspection_fail_or_keep_outcomes(self, mode: str) -> None:
+    def test_storage_inspection_fail_or_keep_outcomes(
+        self, mode: str, tmp_path: Path
+    ) -> None:
         """Storage failures are kept non-strict and actionable when strict."""
         storage_resource = (
             None
@@ -492,27 +494,35 @@ class TestServerDiscovery:
 
         server = _cadc_server()
         transport = httpx.MockTransport(response)
-        with patch("canfar.client.Client", side_effect=_http_client_factory(transport)):
-            assert (
+        config_path = tmp_path / "config.yaml"
+        with patch("canfar.models.config.CONFIG_PATH", config_path):
+            config = _anonymous_config()
+            with patch(
+                "canfar.client.Client", side_effect=_http_client_factory(transport)
+            ):
+                assert (
+                    enrich(
+                        server,
+                        config=config,
+                        storage_resource=storage_resource,
+                        strict=False,
+                    )
+                    == server
+                )
+
+            with (
+                patch(
+                    "canfar.client.Client",
+                    side_effect=_http_client_factory(transport),
+                ),
+                pytest.raises(ServerFetchError, match="VOSpace Service") as exc_info,
+            ):
                 enrich(
                     server,
-                    config=_anonymous_config(),
+                    config=config,
                     storage_resource=storage_resource,
-                    strict=False,
+                    strict=True,
                 )
-                == server
-            )
-
-        with (
-            patch("canfar.client.Client", side_effect=_http_client_factory(transport)),
-            pytest.raises(ServerFetchError, match="VOSpace Service") as exc_info,
-        ):
-            enrich(
-                server,
-                config=_anonymous_config(),
-                storage_resource=storage_resource,
-                strict=True,
-            )
 
         if mode == "malformed":
             assert isinstance(exc_info.value.__cause__, ValueError)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -15,7 +15,8 @@ from canfar.errors import ErrorCode
 from canfar.models.active import ActiveConfig
 from canfar.models.auth import OIDCCredential, X509Credential
 from canfar.models.config import Configuration
-from canfar.models.http import Server
+from canfar.models.http import Server, VOSpaceService
+from canfar.models.registry import IVOARegistry, IVOARegistrySearch
 from canfar.models.registry import Server as DiscoveredServer
 from canfar.server import (
     ServerDiscoveryError,
@@ -25,11 +26,13 @@ from canfar.server import (
     _discovered_to_server,
     activate,
     discover,
+    enrich,
     use,
 )
 from canfar.server import (
     list_servers as server_list,
 )
+from canfar.utils.discover import Discover
 from tests.helpers.config import assign_servers
 
 if TYPE_CHECKING:
@@ -37,6 +40,16 @@ if TYPE_CHECKING:
 
 _CADC_URI = "ivo://cadc.nrc.ca/skaha"
 _CADC_URL = "https://ws-uv.canfar.net/skaha"
+
+_VOSPACE_CAPABILITIES = """
+    <capabilities xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <capability standardID="ivo://ivoa.net/std/VOSpace/v2.0#nodes">
+        <interface xsi:type="ParamHTTP" role="std">
+          <accessURL use="base">https://storage.example/arc/nodes</accessURL>
+        </interface>
+      </capability>
+    </capabilities>
+"""
 
 
 def _http_client_factory(
@@ -344,6 +357,234 @@ class TestServerDiscovery:
         assert str(saved.get_server_by_uri("ivo://cadc.example/skaha").url) == (
             "https://cadc.example/skaha"
         )
+
+    @pytest.mark.asyncio
+    async def test_registry_retains_only_skaha_and_preferred_storage_records(
+        self,
+    ) -> None:
+        """CADC discovery retains ARC despite Vault and preserves registry URLs."""
+        registry = IVOARegistry(
+            name="CADC",
+            content=(
+                "ivo://cadc.nrc.ca/skaha="
+                "https://platform.example/skaha/capabilities\n"
+                "ivo://cadc.nrc.ca/arc="
+                "https://storage.example/custom/capabilities\n"
+                "ivo://cadc.nrc.ca/vault="
+                "https://storage.example/vault/capabilities\n"
+                "ivo://other.example/arc="
+                "https://platform.example/skaha-arc/capabilities"
+            ),
+        )
+        search = IVOARegistrySearch(preferred_storage_leaf="arc")
+
+        async with Discover(search) as discovery:
+            resources = discovery.extract(registry)
+
+        assert [(resource.uri, resource.url) for resource in resources] == [
+            ("ivo://cadc.nrc.ca/skaha", "https://platform.example/skaha"),
+            ("ivo://cadc.nrc.ca/arc", "https://storage.example/custom"),
+            ("ivo://other.example/arc", "https://platform.example/skaha-arc"),
+        ]
+
+    def test_discover_refreshes_primary_storage_and_preserves_manual_entries(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Rediscovery updates only the generated Server Name storage entry."""
+        manual = VOSpaceService(
+            uri="ivo://cadc.nrc.ca/custom",
+            url="https://manual.example/custom",
+        )
+        old_primary = VOSpaceService(
+            uri="ivo://cadc.nrc.ca/arc",
+            url="https://old.example/arc",
+        )
+        known = _cadc_server(
+            name="canfar",
+            storage={"canfar": old_primary, "archive": manual},
+        )
+        registry_body = "\n".join(
+            (
+                f"{_CADC_URI}={_CADC_URL}/capabilities",
+                "ivo://cadc.nrc.ca/arc=https://storage.example/arc/capabilities",
+                "ivo://cadc.nrc.ca/vault=https://storage.example/vault/capabilities",
+            )
+        )
+
+        def registry_response(request: httpx.Request) -> httpx.Response:
+            if request.method == "GET":
+                return httpx.Response(200, text=registry_body, request=request)
+            return httpx.Response(200, request=request)
+
+        session_capabilities = """
+            <capabilities>
+              <capability standardID="http://www.opencadc.org/std/platform#session-1">
+                <interface>
+                  <accessURL use="base">https://ws-uv.canfar.net/skaha/v1</accessURL>
+                  <securityMethod
+                    standardID="ivo://ivoa.net/sso#tls-with-certificate" />
+                </interface>
+              </capability>
+            </capabilities>
+        """
+
+        def capabilities_response(request: httpx.Request) -> httpx.Response:
+            content = (
+                _VOSPACE_CAPABILITIES
+                if str(request.url) == "https://storage.example/arc/capabilities"
+                else session_capabilities
+            )
+            return httpx.Response(200, text=content, request=request)
+
+        real_async_client = httpx.AsyncClient
+        config_path = tmp_path / "config.yaml"
+        with patch("canfar.models.config.CONFIG_PATH", config_path):
+            config = _anonymous_config(known)
+            with (
+                patch(
+                    "canfar.utils.discover.httpx.AsyncClient",
+                    side_effect=lambda **_kwargs: real_async_client(
+                        transport=httpx.MockTransport(registry_response)
+                    ),
+                ),
+                patch(
+                    "canfar.client.Client",
+                    side_effect=_http_client_factory(
+                        httpx.MockTransport(capabilities_response)
+                    ),
+                ),
+            ):
+                [discovered] = discover("cadc", config=config)
+
+            persisted = Configuration().servers["canfar"]
+
+        assert (
+            discovered.storage
+            == persisted.storage
+            == {
+                "canfar": VOSpaceService(
+                    uri="ivo://cadc.nrc.ca/arc",
+                    url="https://storage.example/arc",
+                ),
+                "archive": manual,
+            }
+        )
+
+    @pytest.mark.parametrize("mode", ["missing", "malformed", "unreachable"])
+    def test_storage_inspection_fail_or_keep_outcomes(self, mode: str) -> None:
+        """Storage failures are kept non-strict and actionable when strict."""
+        storage_resource = (
+            None
+            if mode == "missing"
+            else DiscoveredServer(
+                registry="CADC",
+                uri="ivo://cadc.nrc.ca/arc",
+                url="https://storage.example/arc",
+            )
+        )
+
+        def response(request: httpx.Request) -> httpx.Response:
+            if mode == "unreachable":
+                message = "storage unavailable"
+                raise httpx.ConnectError(message, request=request)
+            return httpx.Response(200, text="<capabilities />", request=request)
+
+        server = _cadc_server()
+        transport = httpx.MockTransport(response)
+        with patch("canfar.client.Client", side_effect=_http_client_factory(transport)):
+            assert (
+                enrich(
+                    server,
+                    config=_anonymous_config(),
+                    storage_resource=storage_resource,
+                    strict=False,
+                )
+                == server
+            )
+
+        with (
+            patch("canfar.client.Client", side_effect=_http_client_factory(transport)),
+            pytest.raises(ServerFetchError, match="VOSpace Service") as exc_info,
+        ):
+            enrich(
+                server,
+                config=_anonymous_config(),
+                storage_resource=storage_resource,
+                strict=True,
+            )
+
+        if mode == "malformed":
+            assert isinstance(exc_info.value.__cause__, ValueError)
+
+    @pytest.mark.asyncio
+    async def test_srcnet_pairs_each_server_with_same_namespace_cavern(self) -> None:
+        """SRCNet Cavern records pair by IVOA namespace, not list position."""
+        resources = [
+            DiscoveredServer(
+                registry="SRCNet",
+                uri="ivo://canfar.net/src/skaha",
+                url="https://one.example/skaha",
+                status=200,
+                name="canSRC",
+            ),
+            DiscoveredServer(
+                registry="SRCNet",
+                uri="ivo://swesrc.chalmers.se/skaha",
+                url="https://two.example/skaha",
+                status=200,
+                name="sweSRC",
+            ),
+            DiscoveredServer(
+                registry="SRCNet",
+                uri="ivo://swesrc.chalmers.se/cavern",
+                url="https://storage.example/two",
+            ),
+            DiscoveredServer(
+                registry="SRCNet",
+                uri="ivo://canfar.net/src/cavern",
+                url="https://storage.example/one",
+            ),
+        ]
+        mock_discovery = AsyncMock()
+        mock_discovery.fetch.return_value = MagicMock(success=True, content="line")
+        mock_discovery.extract = MagicMock(return_value=resources)
+        mock_discovery.check = AsyncMock(side_effect=lambda item: item)
+        mock_discovery.__aenter__ = AsyncMock(return_value=mock_discovery)
+        mock_discovery.__aexit__ = AsyncMock(return_value=None)
+
+        def enriched(
+            server: Server,
+            *,
+            storage_resource: DiscoveredServer,
+            **_kwargs: object,
+        ) -> Server:
+            return server.model_copy(
+                update={
+                    "version": "v1",
+                    "auths": ["oidc"],
+                    "storage": {
+                        server.name: VOSpaceService(
+                            uri=storage_resource.uri,
+                            url=storage_resource.url,
+                        )
+                    },
+                },
+                deep=True,
+            )
+
+        with (
+            patch("canfar.server.Discover", return_value=mock_discovery),
+            patch("canfar.server.enrich", side_effect=enriched),
+        ):
+            servers = await _discover_for_idp("srcnet")
+
+        assert {
+            server.name: str(server.storage[server.name].uri) for server in servers
+        } == {
+            "canSRC": "ivo://canfar.net/src/cavern",
+            "sweSRC": "ivo://swesrc.chalmers.se/cavern",
+        }
 
     @pytest.mark.parametrize(
         "capabilities_case",


### PR DESCRIPTION
Closes #152

## Summary
- retain preferred VOSpace registry records alongside Science Platform Server records
- pair CADC ARC and SRCNet Cavern by IVOA namespace, validate OpenCADC node capabilities, and persist the exact registry base URL
- refresh the generated primary Storage Name while preserving manual storage entries and non-strict server usability

## Validation
- Ruff check and format: pass
- deterministic tests: 775 passed before rebase
- post-rebase focused tests: 175 passed
- ty: accepted baseline of exactly 22 pre-existing unused-ignore diagnostics
- MkDocs: completed; git-committers reported a non-fatal GitHub API 403 rate-limit warning
- fixed-base standards/spec review: no blocking findings