### PR TITLE
fix(storage): address wave 2 review findings

### DIFF
--- a/canfar/_storage.py
+++ b/canfar/_storage.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from canfar.client import HTTPClient
 from canfar.exceptions.context import AuthContextError
@@ -32,12 +32,17 @@ def _vospace_source(
         config = Configuration()
         endpoint, idp = config._resolve_storage(storage_name)  # noqa: SLF001
         try:
+            client_kwargs: dict[str, Any] = {
+                "config": config,
+                "authentication_idp": idp,
+                "url": endpoint,
+            }
+            if token is not None:
+                client_kwargs["token"] = token
+            if certificate is not None:
+                client_kwargs["certificate"] = certificate
             client = HTTPClient(
-                config=config,
-                authentication_idp=idp,
-                url=endpoint,
-                token=token,
-                certificate=certificate,
+                **client_kwargs,
             )
             token_value, certfile = await client._materialize_credentials()  # noqa: SLF001
         except (KeyError, OSError, TypeError, ValueError):

--- a/canfar/models/config.py
+++ b/canfar/models/config.py
@@ -12,6 +12,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    PrivateAttr,
     model_validator,
 )
 
@@ -113,6 +114,8 @@ class Configuration(BaseSettings):
         json_schema_mode_override="serialization",
         str_strip_whitespace=True,
     )
+
+    _storage_discovery_errors: dict[str, str] = PrivateAttr(default_factory=dict)
 
     version: Literal[1] = Field(
         default=1,

--- a/canfar/server.py
+++ b/canfar/server.py
@@ -433,7 +433,7 @@ async def _discover_for_idp(
             return []
 
         storage_by_namespace = {
-            (resource.registry, _registry_namespace(resource.uri)): resource
+            _registry_namespace(resource.uri): resource
             for resource in resources
             if resource.uri.endswith(f"/{search.preferred_storage_leaf}")
         }
@@ -448,7 +448,7 @@ async def _discover_for_idp(
                 config=config,
                 timeout=timeout,
                 storage_resource=storage_by_namespace.get(
-                    (endpoint.registry, _registry_namespace(endpoint.uri))
+                    _registry_namespace(endpoint.uri)
                 ),
             )
             for endpoint in checked
@@ -525,9 +525,11 @@ def enrich(
             Authentication or Server Selection.
         authentication_idp: Optional Authentication Record selector. Defaults to
             the Server IDP, then the active Authentication.
-        strict: When ``False``, return the original server if capabilities
-            cannot be retrieved or parsed. Discovery uses non-strict mode so
-            one malformed endpoint does not abort listing for an IDP.
+        strict: When ``False``, keep usable registry and existing storage data
+            when session or storage capabilities cannot be retrieved or parsed.
+            Other successful enrichment may still be returned, so the result can
+            be partial. Discovery uses non-strict mode so one malformed endpoint
+            does not abort listing for an IDP.
         timeout: HTTP timeout in seconds for VOSI capabilities requests.
         storage_resource: Retained same-namespace VOSpace registry record. Passing
             ``None`` records that the preferred resource was absent; omitting the
@@ -542,6 +544,14 @@ def enrich(
     """
     base_config = config or Configuration()  # ty: ignore[missing-argument]
     active_idp = authentication_idp or server.idp or base_config.active.authentication
+    if (
+        strict
+        and storage_resource is _STORAGE_RESOURCE_UNSET
+        and server.name in base_config._storage_discovery_errors  # noqa: SLF001
+    ):
+        raise ServerFetchError(
+            base_config._storage_discovery_errors[server.name]  # noqa: SLF001
+        )
     if storage_resource is not _STORAGE_RESOURCE_UNSET:
         server = _enrich_storage(
             server,
@@ -607,7 +617,7 @@ def enrich(
         )
 
     try:
-        return Server.model_validate(
+        enriched = Server.model_validate(
             {
                 **server.model_dump(mode="python"),
                 "url": primary["baseurl"],
@@ -626,6 +636,8 @@ def enrich(
             ),
             args=(server.url, exc),
         )
+    else:
+        return enriched
 
 
 def _enrich_storage(
@@ -676,26 +688,32 @@ def _enrich_storage(
                 error = ValueError("Science Platform Server has no Server Name")
 
     if error is not None:
-        return _keep_or_raise(
+        message = (
+            f"Failed to inspect VOSpace Service '{subject}' for Science "
+            f"Platform Server '{server.name}': {error}"
+        )
+        kept = _keep_or_raise(
             server,
             strict=strict,
-            error=(
-                f"Failed to inspect VOSpace Service '{subject}' for Science "
-                f"Platform Server '{server.name}': {error}"
-            ),
+            error=message,
             cause=error,
             debug="Skipping VOSpace Service %s during discovery: %s",
             args=(subject, error),
         )
+        if server.name is not None:
+            config._storage_discovery_errors[server.name] = message  # noqa: SLF001
+        return kept
 
     assert storage_resource is not None
     assert server.name is not None
     service = VOSpaceService(uri=storage_resource.uri, url=storage_resource.url)
 
-    return server.model_copy(
+    enriched = server.model_copy(
         update={"storage": {**server.storage, server.name: service}},
         deep=True,
     )
+    config._storage_discovery_errors.pop(server.name, None)  # noqa: SLF001
+    return enriched
 
 
 def _fetch_capabilities(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -527,6 +527,58 @@ class TestServerDiscovery:
         if mode == "malformed":
             assert isinstance(exc_info.value.__cause__, ValueError)
 
+    def test_activation_surfaces_storage_failure_retained_by_discovery(self) -> None:
+        """Real non-strict discovery carries its storage error into activation."""
+        endpoint = DiscoveredServer(
+            registry="CADC source",
+            uri=_CADC_URI,
+            url=_CADC_URL,
+            status=200,
+            name="CADC-CANFAR",
+        )
+        mock_discovery = AsyncMock()
+        mock_discovery.fetch.return_value = MagicMock(success=True, content="line")
+        mock_discovery.extract = MagicMock(return_value=[endpoint])
+        mock_discovery.check = AsyncMock(side_effect=lambda item: item)
+        mock_discovery.__aenter__ = AsyncMock(return_value=mock_discovery)
+        mock_discovery.__aexit__ = AsyncMock(return_value=None)
+        session_capabilities = """
+            <capabilities>
+              <capability standardID="http://www.opencadc.org/std/platform#session-1">
+                <interface>
+                  <accessURL use="base">https://ws-uv.canfar.net/skaha/v1</accessURL>
+                  <securityMethod
+                    standardID="ivo://ivoa.net/sso#tls-with-certificate" />
+                </interface>
+              </capability>
+            </capabilities>
+        """
+        transport = httpx.MockTransport(
+            lambda request: httpx.Response(
+                200,
+                text=session_capabilities,
+                request=request,
+            )
+        )
+        config = _anonymous_config()
+
+        with (
+            patch("canfar.server.Discover", return_value=mock_discovery),
+            patch(
+                "canfar.client.Client",
+                side_effect=_http_client_factory(transport),
+            ),
+        ):
+            [discovered] = discover("cadc", config=config, save=False)
+            with pytest.raises(
+                ServerFetchError,
+                match="same-namespace 'arc' registry record",
+            ):
+                activate("cadc", _CADC_URI, config=config)
+
+        assert discovered.version == "v1"
+        assert discovered.storage == {}
+
     @pytest.mark.asyncio
     async def test_srcnet_pairs_each_server_with_same_namespace_cavern(self) -> None:
         """SRCNet Cavern records pair by IVOA namespace, not list position."""
@@ -546,12 +598,12 @@ class TestServerDiscovery:
                 name="sweSRC",
             ),
             DiscoveredServer(
-                registry="SRCNet",
+                registry="SRCNet mirror B",
                 uri="ivo://swesrc.chalmers.se/cavern",
                 url="https://storage.example/two",
             ),
             DiscoveredServer(
-                registry="SRCNet",
+                registry="SRCNet mirror A",
                 uri="ivo://canfar.net/src/cavern",
                 url="https://storage.example/one",
             ),

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -105,6 +105,52 @@ async def test_source_reloads_config_and_runtime_token_wins(
 
 
 @pytest.mark.asyncio
+async def test_environment_token_preserves_runtime_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The source leaves an omitted token open to HTTPClient environment settings."""
+    _config(credential=x509_credential("inactive")).save()
+    monkeypatch.delenv("CANFAR_CERTIFICATE", raising=False)
+    monkeypatch.setenv("CANFAR_TOKEN", "environment-token")
+    monkeypatch.setattr(vosfs, "VOSpaceFileSystem", _Filesystem)
+
+    async with _vospace_source("archive")() as filesystem:
+        assert filesystem.kwargs == {
+            "token": "environment-token",
+            "asynchronous": True,
+            "skip_instance_cache": True,
+        }
+
+
+@pytest.mark.asyncio
+async def test_environment_certificate_preserves_runtime_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The source leaves an omitted certificate open to settings sources."""
+    certificate = tmp_path / "environment.pem"
+    _config(credential=oidc_credential("inactive")).save()
+    monkeypatch.delenv("CANFAR_TOKEN", raising=False)
+    monkeypatch.setenv("CANFAR_CERTIFICATE", certificate.as_posix())
+    monkeypatch.setattr(
+        "canfar.client.x509.inspect",
+        lambda path: {"path": path.as_posix(), "expiry": 9_999_999_999.0},
+    )
+    valid = Mock(return_value=certificate.as_posix())
+    monkeypatch.setattr("canfar.client.x509.valid", valid)
+    monkeypatch.setattr(vosfs, "VOSpaceFileSystem", _Filesystem)
+
+    async with _vospace_source("archive")() as filesystem:
+        assert filesystem.kwargs == {
+            "certfile": certificate.as_posix(),
+            "asynchronous": True,
+            "skip_instance_cache": True,
+        }
+
+    valid.assert_called_once_with(certificate)
+
+
+@pytest.mark.asyncio
 async def test_expired_inactive_oidc_refreshes_once_and_persists(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- preserve CANFAR_TOKEN and CANFAR_CERTIFICATE settings-source precedence in VOSpace sources
- carry non-strict storage discovery failures into the immediate strict activation path without serializing registry internals
- pair Skaha and storage records by IVOA namespace across registry source identities
- document non-strict partial enrichment accurately

## Validation
- focused tests: 49 passed
- deterministic tests: 788 passed
- Ruff: passed
- ty: exactly 22 accepted pre-existing unused-ignore warnings; no new diagnostics
- docs: build exited 0 and generated the site; git-committers later reported a GitHub API 403 rate-limit warning while fetching contributor metadata

Addresses blocking end-of-wave review findings for #152 and #153.