### PR TITLE
feat(data): embed upstream fsspec commands

### DIFF
--- a/canfar/cli/data.py
+++ b/canfar/cli/data.py
@@ -1,0 +1,85 @@
+"""Mount the upstream data command application."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+
+import typer
+from fsspec.implementations.asyn_wrapper import AsyncFileSystemWrapper
+from fsspec.implementations.local import LocalFileSystem
+from fsspec_cli import App
+from typer.core import TyperGroup
+from typer.main import get_group
+
+from canfar._storage import _vospace_source
+from canfar.models.config import Configuration
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from fsspec.spec import AbstractFileSystem
+    from fsspec_cli import AsyncFilesystemSource
+    from typer._click.core import Command, Context
+
+_DATA_GROUP_META_KEY = "canfar.data_group"
+
+
+@asynccontextmanager
+async def _local_source() -> AsyncIterator[AbstractFileSystem]:
+    """Yield a fresh asynchronous wrapper around the local filesystem."""
+    yield AsyncFileSystemWrapper(
+        LocalFileSystem(skip_instance_cache=True),
+        asynchronous=True,
+    )
+
+
+def _sources() -> dict[str, AsyncFilesystemSource]:
+    """Build the mapped sources for one data command invocation."""
+    config = Configuration()
+    sources = {
+        storage_name: _vospace_source(storage_name)
+        for server in config.servers.values()
+        for storage_name in server.storage
+    }
+    sources["local"] = _local_source
+    return sources
+
+
+def _upstream_group() -> TyperGroup:
+    """Build the released upstream application with CANFAR policy."""
+    return get_group(
+        App(
+            _sources(),
+            capabilities={"recursion": {"copy": True, "remove": False}},
+        ).typer_app
+    )
+
+
+class _DataGroup(TyperGroup):
+    """Resolve the embedded app lazily so imports perform no configuration I/O."""
+
+    @staticmethod
+    def _delegate(ctx: Context) -> TyperGroup:
+        group = ctx.meta.get(_DATA_GROUP_META_KEY)
+        if group is None:
+            group = _upstream_group()
+            ctx.meta[_DATA_GROUP_META_KEY] = group
+        assert isinstance(group, TyperGroup)
+        return group
+
+    def list_commands(self, ctx: Context) -> list[str]:
+        """List the unchanged upstream commands."""
+        return self._delegate(ctx).list_commands(ctx)
+
+    def get_command(self, ctx: Context, cmd_name: str) -> Command | None:
+        """Resolve an unchanged upstream command."""
+        return self._delegate(ctx).get_command(ctx, cmd_name)
+
+
+data = typer.Typer(
+    cls=_DataGroup,
+    help="Operate on configured data sources.",
+    add_completion=False,
+    no_args_is_help=True,
+)

--- a/canfar/cli/main.py
+++ b/canfar/cli/main.py
@@ -11,6 +11,7 @@ from canfar.cli import output
 from canfar.cli.auth import auth
 from canfar.cli.config import config
 from canfar.cli.create import create
+from canfar.cli.data import data
 from canfar.cli.delete import delete
 from canfar.cli.events import events
 from canfar.cli.image import image
@@ -115,7 +116,8 @@ def callback(
     if ctx.invoked_subcommand is None:
         get_console().print(ctx.get_help())
         raise typer.Exit(0)
-    set_before_command(ctx, _emit_banner_for_command)
+    if ctx.invoked_subcommand != "data":
+        set_before_command(ctx, _emit_banner_for_command)
 
 
 cli: typer.Typer = typer.Typer(
@@ -159,6 +161,12 @@ cli.add_typer(
     help="Manage science platform servers.",
     no_args_is_help=True,
     rich_help_panel="Auth Management",
+)
+
+cli.add_typer(
+    data,
+    name="data",
+    rich_help_panel="Data Management",
 )
 
 cli.add_typer(

--- a/docs/cli/quick-start.md
+++ b/docs/cli/quick-start.md
@@ -8,12 +8,6 @@ Create a notebook Session from a terminal, open it, inspect it, and clean it up.
 pip install canfar --upgrade
 ```
 
-Install the pinned optional storage dependencies when you need data support:
-
-```bash
-pip install "canfar[data]" --upgrade
-```
-
 ## 2. Log in
 
 ```bash

--- a/docs/cli/quick-start.md
+++ b/docs/cli/quick-start.md
@@ -27,7 +27,26 @@ canfar auth show
 canfar server ls
 ```
 
-## 3. Create a notebook
+## 3. Work with data
+
+The standard installation includes data commands. Use a configured Storage Name
+or the reserved `local` name with an absolute path:
+
+```bash
+canfar data ls -lh canSRC:/
+canfar data cp local:/absolute/path/file.fits canSRC:/folder/file.fits
+```
+
+Cross-source `mv` is unsupported. Copy the file, verify the destination, and
+then remove the source with a separate command:
+
+```bash
+canfar data cp canSRC:/folder/file.fits other:/folder/file.fits
+canfar data ls -lh other:/folder/file.fits
+canfar data rm canSRC:/folder/file.fits
+```
+
+## 4. Create a notebook
 
 ```bash
 canfar create notebook skaha/astroml:latest
@@ -40,7 +59,7 @@ registry. Use the full image name when you want to be explicit:
 canfar create notebook images.canfar.net/skaha/astroml:latest
 ```
 
-## 4. Check status
+## 5. Check status
 
 ```bash
 canfar ps
@@ -53,7 +72,7 @@ Use machine output in scripts:
 canfar ps --json
 ```
 
-## 5. Open the notebook
+## 6. Open the notebook
 
 ```bash
 canfar open $(canfar ps -q)
@@ -61,14 +80,14 @@ canfar open $(canfar ps -q)
 
 Notebook Sessions usually take 60-120 seconds to become reachable.
 
-## 6. Inspect startup events
+## 7. Inspect startup events
 
 ```bash
 canfar events $(canfar ps -q)
 canfar logs $(canfar ps -q)
 ```
 
-## 7. Clean up
+## 8. Clean up
 
 ```bash
 canfar delete $(canfar ps -q)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,10 +59,6 @@ dependencies = [
     "rich>=13.9.4",
     "segno>=1.6.6",
     "typer>=0.16.0",
-]
-
-[project.optional-dependencies]
-data = [
     "vosfs @ git+https://github.com/shinybrar/vosfs@v0.6.0",
     "fsspec-cli @ git+https://github.com/shinybrar/vosfs@fsspec-cli-v0.5.0#subdirectory=src/fsspec-cli",
 ]

--- a/tests/test_cli_data.py
+++ b/tests/test_cli_data.py
@@ -1,0 +1,181 @@
+"""Tests for the embedded upstream data command group."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from contextlib import asynccontextmanager
+from functools import partial
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+import canfar.cli.data as data_cli
+from canfar.cli.main import cli
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Mapping
+    from pathlib import Path
+
+    from fsspec.spec import AbstractFileSystem
+    from fsspec_cli import AsyncFilesystemSource
+
+runner = CliRunner()
+
+
+def _configuration(*storage_names: str) -> SimpleNamespace:
+    storage = dict.fromkeys(storage_names, object())
+    return SimpleNamespace(servers={"server": SimpleNamespace(storage=storage)})
+
+
+def test_root_help_advertises_data() -> None:
+    """The standard CANFAR command surface contains the data group."""
+    result = runner.invoke(cli, ["--help"])
+
+    assert result.exit_code == 0
+    assert "data" in result.output
+
+
+def test_upstream_app_receives_configured_sources_and_policy(monkeypatch) -> None:
+    """CANFAR supplies named sources and policy without extending commands."""
+    captured: dict[str, object] = {}
+    factories: dict[str, object] = {}
+
+    def source_factory(name: str) -> object:
+        factory = object()
+        factories[name] = factory
+        return factory
+
+    class FakeApp:
+        def __init__(
+            self,
+            sources: Mapping[str, AsyncFilesystemSource],
+            *,
+            capabilities: object,
+        ) -> None:
+            captured["sources"] = sources
+            captured["capabilities"] = capabilities
+            self.typer_app = typer.Typer()
+
+    monkeypatch.setattr(
+        data_cli,
+        "Configuration",
+        partial(_configuration, "arc", "cavern"),
+    )
+    monkeypatch.setattr(data_cli, "_vospace_source", source_factory)
+    monkeypatch.setattr(data_cli, "App", FakeApp)
+
+    data_cli._upstream_group()  # noqa: SLF001
+
+    assert captured["sources"] == {
+        **factories,
+        "local": data_cli._local_source,  # noqa: SLF001
+    }
+    assert captured["capabilities"] == {"recursion": {"copy": True, "remove": False}}
+
+
+@pytest.mark.asyncio
+async def test_local_source_returns_fresh_async_wrappers() -> None:
+    """Each local source entry owns a fresh asynchronous wrapper."""
+    async with data_cli._local_source() as first:  # noqa: SLF001
+        assert first.asynchronous is True
+    async with data_cli._local_source() as second:  # noqa: SLF001
+        assert second.asynchronous is True
+
+    assert first is not second
+    assert first.sync_fs is not second.sync_fs
+
+
+def test_data_cat_delegates_without_active_server_banner(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Data stdout belongs byte-for-byte to the upstream command."""
+    payload = tmp_path / "payload.txt"
+    payload.write_text("upstream output\n", encoding="utf-8")
+    monkeypatch.setattr(data_cli, "Configuration", _configuration)
+
+    result = runner.invoke(cli, ["data", "cat", f"local:{payload}"])
+
+    assert result.exit_code == 0, result.output
+    assert result.stdout == "upstream output\n"
+
+
+def test_data_recursive_copy_delegates_to_released_contract(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """The embedded app retains its enabled recursive-copy behavior."""
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "payload.txt").write_text("copied", encoding="utf-8")
+    destination = tmp_path / "destination"
+    monkeypatch.setattr(data_cli, "Configuration", _configuration)
+
+    result = runner.invoke(
+        cli,
+        ["data", "cp", "-R", f"local:{source}", f"local:{destination}"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (destination / "payload.txt").read_text(encoding="utf-8") == "copied"
+
+
+def test_data_recursive_remove_is_disabled(monkeypatch, tmp_path: Path) -> None:
+    """CANFAR keeps upstream recursive removal source-free and disabled."""
+    monkeypatch.setattr(data_cli, "Configuration", _configuration)
+
+    result = runner.invoke(cli, ["data", "rm", "-R", f"local:{tmp_path}"])
+
+    assert result.exit_code == 2
+    assert result.stdout == ""
+    assert result.stderr == "rm: recursive removal disabled by application\n"
+
+
+def test_data_cross_source_move_retains_upstream_rejection(monkeypatch) -> None:
+    """CANFAR does not reinterpret or implement cross-source move."""
+
+    @asynccontextmanager
+    async def unused_source() -> AsyncIterator[AbstractFileSystem]:
+        msg = "source-free rejection must not acquire filesystems"
+        raise AssertionError(msg)
+        yield
+
+    monkeypatch.setattr(data_cli, "Configuration", partial(_configuration, "arc"))
+    monkeypatch.setattr(data_cli, "_vospace_source", lambda _name: unused_source)
+
+    result = runner.invoke(cli, ["data", "mv", "arc:/a", "local:/b"])
+
+    assert result.exit_code == 2
+    assert result.stdout == ""
+    assert result.stderr == "mv: cross-source move unsupported\n"
+
+
+@pytest.mark.parametrize("operand", [":/path", "/bare/local/path"])
+def test_data_deprecated_operand_grammar_is_unsupported(
+    monkeypatch,
+    operand: str,
+) -> None:
+    """Only the upstream explicit ``name:/absolute/path`` grammar is accepted."""
+    monkeypatch.setattr(data_cli, "Configuration", _configuration)
+
+    result = runner.invoke(cli, ["data", "ls", operand])
+
+    assert result.exit_code != 0
+
+
+def test_importing_data_module_does_not_load_configuration() -> None:
+    """Registering the command performs no configuration filesystem I/O."""
+    original = sys.modules.pop("canfar.cli.data")
+    try:
+        with patch(
+            "canfar.models.config.Configuration",
+            side_effect=AssertionError("configuration loaded during import"),
+        ):
+            importlib.import_module("canfar.cli.data")
+    finally:
+        sys.modules["canfar.cli.data"] = original

--- a/tests/test_cli_data.py
+++ b/tests/test_cli_data.py
@@ -105,6 +105,29 @@ def test_data_cat_delegates_without_active_server_banner(
     assert result.stdout == "upstream output\n"
 
 
+def test_data_long_listing_delegates_unchanged(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """The documented ``ls -lh name:/path`` form reaches upstream unchanged."""
+    (tmp_path / "payload.txt").write_text("listed", encoding="utf-8")
+    monkeypatch.setattr(
+        data_cli,
+        "Configuration",
+        partial(_configuration, "canSRC"),
+    )
+    monkeypatch.setattr(
+        data_cli,
+        "_vospace_source",
+        lambda _name: data_cli._local_source,  # noqa: SLF001
+    )
+
+    result = runner.invoke(cli, ["data", "ls", "-lh", f"canSRC:{tmp_path}"])
+
+    assert result.exit_code == 0, result.output
+    assert "payload.txt" in result.stdout
+
+
 def test_data_recursive_copy_delegates_to_released_contract(
     monkeypatch,
     tmp_path: Path,
@@ -114,11 +137,20 @@ def test_data_recursive_copy_delegates_to_released_contract(
     source.mkdir()
     (source / "payload.txt").write_text("copied", encoding="utf-8")
     destination = tmp_path / "destination"
-    monkeypatch.setattr(data_cli, "Configuration", _configuration)
+    monkeypatch.setattr(
+        data_cli,
+        "Configuration",
+        partial(_configuration, "canSRC"),
+    )
+    monkeypatch.setattr(
+        data_cli,
+        "_vospace_source",
+        lambda _name: data_cli._local_source,  # noqa: SLF001
+    )
 
     result = runner.invoke(
         cli,
-        ["data", "cp", "-R", f"local:{source}", f"local:{destination}"],
+        ["data", "cp", "-R", f"local:{source}", f"canSRC:{destination}"],
     )
 
     assert result.exit_code == 0, result.output
@@ -170,6 +202,8 @@ def test_data_deprecated_operand_grammar_is_unsupported(
 
 def test_importing_data_module_does_not_load_configuration() -> None:
     """Registering the command performs no configuration filesystem I/O."""
+    package = sys.modules["canfar.cli"]
+    original_attribute = package.data
     original = sys.modules.pop("canfar.cli.data")
     try:
         with patch(
@@ -179,3 +213,4 @@ def test_importing_data_module_does_not_load_configuration() -> None:
             importlib.import_module("canfar.cli.data")
     finally:
         sys.modules["canfar.cli.data"] = original
+        package.data = original_attribute

--- a/tests/test_data_dependencies.py
+++ b/tests/test_data_dependencies.py
@@ -1,0 +1,22 @@
+"""Package metadata tests for the standard data dependencies."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import tomllib
+
+
+def test_tagged_data_dependencies_are_standard_dependencies() -> None:
+    """A standard CANFAR install includes both immutable upstream releases."""
+    metadata = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+
+    assert (
+        "vosfs @ git+https://github.com/shinybrar/vosfs@v0.6.0"
+        in metadata["project"]["dependencies"]
+    )
+    assert (
+        "fsspec-cli @ git+https://github.com/shinybrar/vosfs@fsspec-cli-v0.5.0"
+        "#subdirectory=src/fsspec-cli" in metadata["project"]["dependencies"]
+    )
+    assert "data" not in metadata["project"].get("optional-dependencies", {})

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -118,6 +118,7 @@ dependencies = [
     { name = "cadcutils" },
     { name = "click" },
     { name = "defusedxml" },
+    { name = "fsspec-cli" },
     { name = "httpx", extra = ["http2"] },
     { name = "humanize" },
     { name = "pydantic" },
@@ -127,11 +128,6 @@ dependencies = [
     { name = "rich" },
     { name = "segno" },
     { name = "typer" },
-]
-
-[package.optional-dependencies]
-data = [
-    { name = "fsspec-cli" },
     { name = "vosfs" },
 ]
 
@@ -164,7 +160,7 @@ requires-dist = [
     { name = "cadcutils", specifier = ">=1.5.4" },
     { name = "click", specifier = ">=8.4.1" },
     { name = "defusedxml", specifier = ">=0.7.1" },
-    { name = "fsspec-cli", marker = "extra == 'data'", git = "https://github.com/shinybrar/vosfs?subdirectory=src%2Ffsspec-cli&rev=fsspec-cli-v0.5.0" },
+    { name = "fsspec-cli", git = "https://github.com/shinybrar/vosfs?subdirectory=src%2Ffsspec-cli&rev=fsspec-cli-v0.5.0" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.28.1" },
     { name = "humanize", specifier = ">=4.12.3" },
     { name = "pydantic", specifier = ">=2.9.2" },
@@ -174,9 +170,8 @@ requires-dist = [
     { name = "rich", specifier = ">=13.9.4" },
     { name = "segno", specifier = ">=1.6.6" },
     { name = "typer", specifier = ">=0.16.0" },
-    { name = "vosfs", marker = "extra == 'data'", git = "https://github.com/shinybrar/vosfs?rev=v0.6.0" },
+    { name = "vosfs", git = "https://github.com/shinybrar/vosfs?rev=v0.6.0" },
 ]
-provides-extras = ["data"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Implements #154 as the data-command wave of #150.

## Summary

- promote tagged `vosfs` v0.6.0 and `fsspec-cli` v0.5.0 Git references to normal CANFAR dependencies and remove the superseded `data` extra
- mount the unchanged upstream `App(sources, capabilities=...).typer_app` at `canfar data` with configured Storage Names plus fresh `local` wrappers
- keep recursive copy enabled, recursive removal disabled, explicit `name:/absolute/path` grammar, and upstream cross-source `mv` rejection
- suppress the active-server banner for every data leaf and defer configuration loading until data command resolution
- document the standard-install data workflow and explicit cross-source `cp`, verification, then separate `rm`

## Validation

- Ruff check: passed
- Ruff format: passed
- deterministic non-slow tests: 800 passed
- `ty check canfar`: exactly the accepted 22 pre-existing unused-ignore warnings; no new diagnostics
- MkDocs build: passed (git-committers contributor lookup reported the known GitHub 403 warning)
- sdist and wheel build: passed; wheel metadata contains both normal immutable Git `Requires-Dist` entries and no `Provides-Extra: data`
- fixed-base Standards review: no hard findings
- fixed-base Spec review: clean after documentation follow-up