### PR TITLE
docs(data): use default CADC storage name

### DIFF
--- a/docs/cli/quick-start.md
+++ b/docs/cli/quick-start.md
@@ -33,17 +33,19 @@ The standard installation includes data commands. Use a configured Storage Name
 or the reserved `local` name with an absolute path:
 
 ```bash
-canfar data ls -lh canSRC:/
-canfar data cp local:/absolute/path/file.fits canSRC:/folder/file.fits
+canfar data ls -lh canfar:/
+canfar data cp local:/absolute/path/file.fits canfar:/folder/file.fits
 ```
 
 Cross-source `mv` is unsupported. Copy the file, verify the destination, and
-then remove the source with a separate command:
+then remove the source with a separate command. In this example, `archive` is
+a placeholder for a second Storage Name that you configured; replace it with
+that Storage Name:
 
 ```bash
-canfar data cp canSRC:/folder/file.fits other:/folder/file.fits
-canfar data ls -lh other:/folder/file.fits
-canfar data rm canSRC:/folder/file.fits
+canfar data cp canfar:/folder/file.fits archive:/folder/file.fits
+canfar data ls -lh archive:/folder/file.fits
+canfar data rm canfar:/folder/file.fits
 ```
 
 ## 4. Create a notebook


### PR DESCRIPTION
Fixes the single Wave 3 High-review finding after #221.

## Change

- use the default CADC primary Storage Name `canfar` in examples following `canfar login cadc`
- identify `archive` explicitly as a placeholder for a second user-configured Storage Name
- preserve the explicit cross-source workflow: `cp`, verify the destination, then separate `rm`
- continue to avoid advertising same-source `mv` or recursive removal

## Validation

- docs-only diff; `git diff --check` passed
- stale `canSRC`, `other:/`, and `canfar[data]` examples are absent from the quick start
- MkDocs build completed successfully; the unchanged git-committers plugin eventually reported its known GitHub API 403 warning while saving its cache