### PR TITLE
docs(data): validate VOSpace integration

### DIFF
--- a/docs/cli/cli-help.md
+++ b/docs/cli/cli-help.md
@@ -184,6 +184,18 @@ canfar stats
 Use `canfar image --help` and `canfar stats --help` for command-specific
 options.
 
+## Data
+
+```bash
+canfar data ls -lh canfar:/
+canfar data cp local:/absolute/path/file.fits canfar:/folder/file.fits
+```
+
+Data operands use explicit `Storage-Name:/absolute/path` or
+`local:/absolute/path` syntax. See [Data commands](data.md) for recursive copy,
+cross-source copy and verification, recursive-removal policy, and the exact
+supported boundary.
+
 ## Client configuration
 
 ```bash

--- a/docs/cli/data.md
+++ b/docs/cli/data.md
@@ -13,7 +13,7 @@ canfar login cadc
 ```
 
 CANFAR installs the audited upstream releases as normal dependencies through
-immutable Git references:
+tagged Git references:
 
 - `vosfs @ git+https://github.com/shinybrar/vosfs@v0.6.0`
 - `fsspec-cli @ git+https://github.com/shinybrar/vosfs@fsspec-cli-v0.5.0#subdirectory=src/fsspec-cli`
@@ -84,8 +84,8 @@ Recursive removal is disabled by application policy. `rm -R` exits with status
 rm: recursive removal disabled by application
 ```
 
-Because directory removal is disabled, directory movement is not a supported
-workflow in this release. Any future one-command relocation would be a
+Because recursive directory removal is disabled, directory movement is not a
+supported workflow in this release. Any future one-command relocation would be a
 separately named, opt-in orchestration feature with stronger destination
 verification and residual-state semantics—not portable `mv`.
 

--- a/docs/cli/data.md
+++ b/docs/cli/data.md
@@ -26,6 +26,12 @@ Every remote source uses its configured Storage Name. The reserved `local`
 source addresses the machine where the command runs. Operands always use an
 explicit mapped name and absolute path:
 
+On each CLI invocation, CANFAR rebuilds the source mapping from every Storage
+Name on every configured Science Platform Server and always adds `local`.
+Active Server Selection does not filter data sources. Each mapped source is a
+factory that creates a fresh asynchronous filesystem when the command acquires
+it.
+
 ```text
 Storage-Name:/absolute/path
 local:/absolute/path

--- a/docs/cli/data.md
+++ b/docs/cli/data.md
@@ -1,0 +1,114 @@
+# Data commands
+
+Use `canfar data` to work with configured VOSpace Services and the local
+filesystem through the embedded `fsspec-cli` command application.
+
+## Install and authenticate
+
+Data commands are included in the standard installation:
+
+```bash
+pip install canfar
+canfar login cadc
+```
+
+CANFAR installs the audited upstream releases as normal dependencies through
+immutable Git references:
+
+- `vosfs @ git+https://github.com/shinybrar/vosfs@v0.6.0`
+- `fsspec-cli @ git+https://github.com/shinybrar/vosfs@fsspec-cli-v0.5.0#subdirectory=src/fsspec-cli`
+
+There is no separate data extra.
+
+## Address mapped sources
+
+Every remote source uses its configured Storage Name. The reserved `local`
+source addresses the machine where the command runs. Operands always use an
+explicit mapped name and absolute path:
+
+```text
+Storage-Name:/absolute/path
+local:/absolute/path
+```
+
+For a default CADC login, the discovered primary Storage Name is `canfar`:
+
+```bash
+canfar data ls -lh canfar:/
+canfar data ls -lh canfar:/folder
+```
+
+Use `ls -lh` (or `ll -h`) for a human-readable long listing. Standalone
+`ls -h` is not supported. Empty `:/path`, bare local paths, `active:/path`, and
+the retired `canfar storage` command are not aliases.
+
+## Copy files and directories
+
+Copy one file between local and remote sources:
+
+```bash
+canfar data cp local:/absolute/path/file.fits canfar:/folder/file.fits
+canfar data cp canfar:/folder/file.fits local:/absolute/path/file.fits
+```
+
+Recursive copy is enabled for admitted local and remote source pairs:
+
+```bash
+canfar data cp -R local:/absolute/path/dataset canfar:/folder/dataset
+```
+
+The tagged upstream implementation builds a bounded manifest, copies files
+through host-local staging when sources differ, and verifies destination
+metadata. Recursive copy is not atomic and does not create a snapshot; inspect
+the destination before removing any source data.
+
+## Move data between sources
+
+Cross-source `mv` is unsupported. Move a file explicitly by copying it,
+verifying the destination, and only then issuing a separate source removal. In
+this example, `archive` stands for a second Storage Name that you configured:
+
+```bash
+canfar data cp canfar:/folder/file.fits archive:/folder/file.fits
+canfar data ls -lh archive:/folder/file.fits
+canfar data rm canfar:/folder/file.fits
+```
+
+Do not use this sequence as a one-command or atomic move. CANFAR does not
+advertise same-source `mv` for current VOSpace sources either.
+
+Recursive removal is disabled by application policy. `rm -R` exits with status
+2 and reports:
+
+```text
+rm: recursive removal disabled by application
+```
+
+Because directory removal is disabled, directory movement is not a supported
+workflow in this release. Any future one-command relocation would be a
+separately named, opt-in orchestration feature with stronger destination
+verification and residual-state semantics—not portable `mv`.
+
+## Output and accepted omissions
+
+Data command stdout belongs to the embedded command; CANFAR does not prepend
+the active-Server banner or add JSON/YAML envelopes. Diagnostics are written to
+stderr.
+
+This release intentionally provides no public CANFAR storage Python API, FUSE
+mount, signed-URL extension, progress display, confirmation prompt, `:/path` or
+bare-path shorthand, `active` alias, `canfar storage` alias, recursive removal,
+or cross-source/current-VOSpace `mv` workflow.
+
+## Audited upstream releases
+
+CANFAR's integration is based on
+[`shinybrar/vosfs` PR #294](https://github.com/shinybrar/vosfs/pull/294),
+audited at commit
+[`9e5314db4706894d31d54d245392f43b9556cfbb`](https://github.com/shinybrar/vosfs/commit/9e5314db4706894d31d54d245392f43b9556cfbb).
+The installed pair is the tagged
+[`vosfs` v0.6.0](https://github.com/shinybrar/vosfs/releases/tag/v0.6.0) and
+[`fsspec-cli-v0.5.0`](https://github.com/shinybrar/vosfs/releases/tag/fsspec-cli-v0.5.0)
+releases. CANFAR tests its composition, configuration, authentication, and
+output seams; exhaustive filesystem-command and backend matrices remain in the
+upstream project.

--- a/docs/presentations/srcnet-june-2026-demo.typ
+++ b/docs/presentations/srcnet-june-2026-demo.typ
@@ -90,17 +90,16 @@ for node in ["canSRC", "sweSRC"]:
     await session.create(image="skaha/base-notebook:latest", cmd="env")
 ```
 
-== Next: storage, same front door
+== Data, same front door
 
-Coming in #link("https://github.com/opencadc/canfar/pull/83")[#raw("#83")] — file management over VOSpace, no second login:
+File management over named VOSpace Services, using the saved identity:
 
 ```bash
-canfar server use sweSRC
-canfar storage ls
-canfar storage mv /data/filename @canSRC:/data/ # Syntax TBD
+canfar data ls -lh canSRC:/
+canfar data cp local:/absolute/path/filename canSRC:/data/filename
 ```
 
-- Familiar verbs: `ls` · `cp` · `mkdir` · `mv` · `rm`
+- Cross-source movement is explicit `cp`, verify, then separate `rm`
 - Reuses your active identity — *no extra auth*
 
 #align(center)[_Your files, your compute, your platform — one door, one login._]

--- a/docs/presentations/srcnet-june-2026-demo.typ
+++ b/docs/presentations/srcnet-june-2026-demo.typ
@@ -92,7 +92,7 @@ for node in ["canSRC", "sweSRC"]:
 
 == Data, same front door
 
-File management over named VOSpace Services, using the saved identity:
+File management over named VOSpace Services, using the parent server's saved Authentication Record:
 
 ```bash
 canfar data ls -lh canSRC:/
@@ -100,6 +100,6 @@ canfar data cp local:/absolute/path/filename canSRC:/data/filename
 ```
 
 - Cross-source movement is explicit `cp`, verify, then separate `rm`
-- Reuses your active identity — *no extra auth*
+- Uses the named Storage Service's parent-server IDP, even when that server is inactive
 
 #align(center)[_Your files, your compute, your platform — one door, one login._]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -259,6 +259,7 @@ nav:
               - Helpers: client/helpers.md
       - CLI:
           - 5-Minute Tutorial: cli/quick-start.md
+          - Data Commands: cli/data.md
           - Authentication and Servers: cli/authentication-contexts.md
           - Logging: cli/logging.md
           - Reference: cli/cli-help.md

--- a/tests/test_cli_data.py
+++ b/tests/test_cli_data.py
@@ -200,6 +200,28 @@ def test_data_deprecated_operand_grammar_is_unsupported(
     assert result.exit_code != 0
 
 
+@pytest.mark.parametrize(
+    ("arguments", "diagnostic"),
+    [
+        (["storage", "ls"], "No such command 'storage'"),
+        (["data", "ls", "active:/"], "unknown filesystem"),
+        (["data", "ls", "-h", "local:/"], "-h: unsupported option"),
+    ],
+)
+def test_data_retired_aliases_and_standalone_h_are_unsupported(
+    monkeypatch,
+    arguments: list[str],
+    diagnostic: str,
+) -> None:
+    """Retired host aliases do not widen the upstream mapped grammar."""
+    monkeypatch.setattr(data_cli, "Configuration", _configuration)
+
+    result = runner.invoke(cli, arguments)
+
+    assert result.exit_code == 2
+    assert diagnostic in result.stderr
+
+
 def test_importing_data_module_does_not_load_configuration() -> None:
     """Registering the command performs no configuration filesystem I/O."""
     package = sys.modules["canfar.cli"]

--- a/tests/test_data_smoke.py
+++ b/tests/test_data_smoke.py
@@ -1,0 +1,64 @@
+"""Optional authenticated smoke test for the configured CADC VOSpace Service."""
+
+from __future__ import annotations
+
+from typing import NoReturn
+
+import pytest
+from typer.testing import CliRunner
+
+from canfar.auth import x509
+from canfar.cli.main import cli
+from canfar.models.config import Configuration
+
+
+def _skip(reason: str) -> NoReturn:
+    pytest.skip(
+        "live data smoke requires Storage Name 'canfar' and a valid saved "
+        f"Authentication Record/certificate: {reason}"
+    )
+
+
+def _require_live_credentials() -> None:
+    """Skip unless persisted configuration can authenticate the live source."""
+    try:
+        config = Configuration()  # ty: ignore[missing-argument]
+    except Exception:  # noqa: BLE001 - optional environment preflight.
+        _skip("configuration is unavailable")
+
+    try:
+        _endpoint, idp = config._resolve_storage("canfar")  # noqa: SLF001
+        credential = config.get_credential(idp)
+    except (KeyError, ValueError):
+        _skip("the named service or its Authentication Record is unavailable")
+
+    if credential.mode == "x509":
+        if credential.path is None:
+            _skip("the saved X.509 certificate path is missing")
+        try:
+            x509.valid(credential.path)
+            x509.expiry(credential.path)
+        except (OSError, ValueError):
+            _skip("the saved X.509 certificate is unavailable or invalid")
+        return
+
+    access = credential.token.access
+    has_current_access = (
+        access is not None
+        and bool(access.get_secret_value())
+        and not credential.expired
+    )
+    if not has_current_access and not credential.refreshable:
+        _skip("the saved OIDC credential cannot authenticate or refresh")
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_canfar_data_lists_live_primary_storage() -> None:
+    """List the configured live CADC primary VOSpace Service when available."""
+    _require_live_credentials()
+
+    result = CliRunner().invoke(cli, ["data", "ls", "-lh", "canfar:/"])
+
+    assert result.exit_code == 0, result.output
+    assert not result.stdout.startswith("@")


### PR DESCRIPTION
Implements #155 and completes the documentation/validation wave of #150.

## Summary

- add the end-user `canfar data` guide for standard installation, mapped operands, `local`, long listings, verified recursive copy, cross-source copy/verify/remove, recursive-removal policy, omissions, and audited upstream releases
- state explicitly that every CLI invocation maps all configured Storage Names plus `local`, independent of active Server Selection, through fresh async filesystem factories
- reconcile CLI reference/navigation and retire obsolete `canfar storage` / speculative `mv` presentation guidance
- add only missing CANFAR-owned seam assertions for retired aliases and standalone `ls -h`
- add an isolated optional slow authenticated `canfar data ls -lh canfar:/` smoke with clear credential preflight skips

## Validation

- Ruff check and format: passed
- deterministic non-slow tests: 803 passed
- `ty check canfar`: exactly the accepted 22 pre-existing unused-ignore warnings; no new diagnostics
- MkDocs build: passed (unchanged git-committers contributor lookup reported the known GitHub API 403 warning)
- sdist and wheel build: passed
- optional authenticated smoke: skipped before live I/O because Storage Name `canfar` or its saved Authentication Record was unavailable
- fixed-base Standards and Spec reviews: clean after docs-only wording fixes