### PR TITLE
test(data): prove source lifecycle contracts

### DIFF
--- a/docs/presentations/srcnet-june-2026-demo.typ
+++ b/docs/presentations/srcnet-june-2026-demo.typ
@@ -92,7 +92,7 @@ for node in ["canSRC", "sweSRC"]:
 
 == Data, same front door
 
-File management over named VOSpace Services, using the parent server's saved Authentication Record:
+File management over named VOSpace Services, using their configured Authentication Records:
 
 ```bash
 canfar data ls -lh canSRC:/
@@ -100,6 +100,7 @@ canfar data cp local:/absolute/path/filename canSRC:/data/filename
 ```
 
 - Cross-source movement is explicit `cp`, verify, then separate `rm`
-- Uses the named Storage Service's parent-server IDP, even when that server is inactive
+- Each VOSpace Service uses its parent Science Platform Server's IDP
+- CANFAR uses that IDP's saved Authentication Record, even when the Science Platform Server is inactive
 
 #align(center)[_Your files, your compute, your platform — one door, one login._]

--- a/tests/test_cli_data.py
+++ b/tests/test_cli_data.py
@@ -41,14 +41,36 @@ def test_root_help_advertises_data() -> None:
 
 
 def test_upstream_app_receives_configured_sources_and_policy(monkeypatch) -> None:
-    """CANFAR supplies named sources and policy without extending commands."""
-    captured: dict[str, object] = {}
-    factories: dict[str, object] = {}
+    """Every app build maps all configured Servers plus local, not only active."""
+    captured_sources: list[dict[str, object]] = []
+    captured_capabilities: list[object] = []
 
-    def source_factory(name: str) -> object:
-        factory = object()
-        factories[name] = factory
-        return factory
+    def source_factory(_name: str) -> object:
+        return object()
+
+    configurations = iter(
+        [
+            SimpleNamespace(
+                active=SimpleNamespace(server="first"),
+                servers={
+                    "first": SimpleNamespace(storage={"arc": object()}),
+                    "second": SimpleNamespace(storage={"cavern": object()}),
+                },
+            ),
+            SimpleNamespace(
+                active=SimpleNamespace(server="second"),
+                servers={
+                    "first": SimpleNamespace(storage={"arc": object()}),
+                    "second": SimpleNamespace(
+                        storage={"cavern": object(), "vault": object()}
+                    ),
+                },
+            ),
+        ]
+    )
+
+    def configuration() -> SimpleNamespace:
+        return next(configurations)
 
     class FakeApp:
         def __init__(
@@ -57,25 +79,29 @@ def test_upstream_app_receives_configured_sources_and_policy(monkeypatch) -> Non
             *,
             capabilities: object,
         ) -> None:
-            captured["sources"] = sources
-            captured["capabilities"] = capabilities
+            captured_sources.append(dict(sources))
+            captured_capabilities.append(capabilities)
             self.typer_app = typer.Typer()
 
-    monkeypatch.setattr(
-        data_cli,
-        "Configuration",
-        partial(_configuration, "arc", "cavern"),
-    )
+    monkeypatch.setattr(data_cli, "Configuration", configuration)
     monkeypatch.setattr(data_cli, "_vospace_source", source_factory)
     monkeypatch.setattr(data_cli, "App", FakeApp)
 
     data_cli._upstream_group()  # noqa: SLF001
+    data_cli._upstream_group()  # noqa: SLF001
 
-    assert captured["sources"] == {
-        **factories,
-        "local": data_cli._local_source,  # noqa: SLF001
-    }
-    assert captured["capabilities"] == {"recursion": {"copy": True, "remove": False}}
+    assert [set(sources) for sources in captured_sources] == [
+        {"arc", "cavern", "local"},
+        {"arc", "cavern", "vault", "local"},
+    ]
+    assert all(
+        sources["local"] is data_cli._local_source  # noqa: SLF001
+        for sources in captured_sources
+    )
+    assert captured_capabilities == [
+        {"recursion": {"copy": True, "remove": False}},
+        {"recursion": {"copy": True, "remove": False}},
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -105,6 +105,34 @@ async def test_source_reloads_config_and_runtime_token_wins(
 
 
 @pytest.mark.asyncio
+async def test_source_factory_constructs_fresh_filesystem_per_acquisition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated acquisition constructs and closes distinct VOSpace filesystems."""
+    _config(credential=oidc_credential("inactive", access="current-token")).save()
+    filesystems: list[_Filesystem] = []
+
+    def build(endpoint: str, **kwargs: Any) -> _Filesystem:
+        filesystem = _Filesystem(endpoint, **kwargs)
+        filesystems.append(filesystem)
+        return filesystem
+
+    monkeypatch.setattr(vosfs, "VOSpaceFileSystem", build)
+    source = _vospace_source("archive")
+
+    async with source() as first:
+        assert first.closed is False
+    assert first.closed is True
+
+    async with source() as second:
+        assert second.closed is False
+    assert second.closed is True
+
+    assert first is not second
+    assert filesystems == [first, second]
+
+
+@pytest.mark.asyncio
 async def test_environment_token_preserves_runtime_precedence(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Fixes all three Wave 4 High-review findings after #223.

## Changes

- use exact glossary ownership in the SRCNet presentation: a VOSpace Service uses its parent Science Platform Server IDP; CANFAR uses that IDP saved Authentication Record
- prove each upstream app build rebuilds mappings from multiple configured servers, includes every Storage Name plus `local`, and is independent of active Server Selection
- prove repeated acquisition of one remote source factory creates distinct fake `VOSpaceFileSystem` instances and closes each, without backend I/O
- intentionally add no positive `rmdir` test because that would duplicate the upstream matrix

## Validation

- focused data/storage tests: 27 passed
- Ruff check and format: passed
- deterministic non-slow tests: 804 passed
- `ty check canfar`: exactly the accepted 22 pre-existing unused-ignore warnings; no new diagnostics
- MkDocs build: passed (unchanged git-committers contributor lookup reported the known GitHub API 403 warning)
- package metadata was untouched, so package build was not repeated
- same High reviewer re-review: clean, no remaining blocker