### PR TITLE
fix(server): harden VOSpace discovery and inspection

### DIFF
--- a/canfar/_discovery.py
+++ b/canfar/_discovery.py
@@ -209,7 +209,7 @@ async def prepare_enrichment_workers(
     )
     token: str | None = None
     certificate: Path | None = None
-    if client.authentication_record is not None:
+    if client.uses_runtime_credentials or client.authentication_record is not None:
         try:
             token, certfile = await client._materialize_credentials()  # noqa: SLF001
         except (

--- a/canfar/_discovery.py
+++ b/canfar/_discovery.py
@@ -1,0 +1,230 @@
+"""Private registry evidence and discovery-worker preparation."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+
+from pydantic import AnyHttpUrl
+
+from canfar import get_logger
+from canfar.auth.x509 import CertificateError
+from canfar.exceptions.context import AuthContextError, AuthExpiredError
+from canfar.idp import get_idp, registry_sources
+from canfar.models.config import Configuration
+from canfar.models.registry import IVOARegistrySearch
+from canfar.models.registry import Server as RegistryResource
+from canfar.utils.discover import Discover
+
+log = get_logger(__name__)
+
+
+class RegistryEvidenceError(RuntimeError):
+    """Raised when strict registry evidence is missing or ambiguous."""
+
+
+@dataclass(frozen=True)
+class RegistryEvidence:
+    """Registry resources plus acquisition outcome for one IDP inspection."""
+
+    preferred_storage_leaf: str | None
+    resources: tuple[RegistryResource, ...]
+    errors: tuple[str, ...]
+    available: bool
+
+
+@dataclass(frozen=True)
+class EnrichmentWorkers:
+    """Isolated worker configs with one pre-materialized runtime credential."""
+
+    configs: tuple[Configuration, ...]
+    token: str | None = None
+    certificate: Path | None = None
+
+
+async def load_registry_evidence(
+    idp: str,
+    *,
+    dev: bool,
+    timeout: int,
+    check_platforms: bool,
+) -> RegistryEvidence:
+    """Acquire and extract registry records through one shared pipeline."""
+    idp_info = get_idp(idp)
+    sources = registry_sources(idp, include_dev=dev)
+    development_sources = set(idp_info.dev_registries)
+    search = IVOARegistrySearch(
+        registries=sources,
+        preferred_storage_leaf=idp_info.preferred_storage_leaf,
+    )
+    async with Discover(search, timeout=timeout) as discovery:
+        registries = await asyncio.gather(
+            *(
+                discovery.fetch(
+                    url,
+                    name,
+                    development=url in development_sources,
+                )
+                for url, name in sources.items()
+            )
+        )
+        successful = [registry for registry in registries if registry.success]
+        resources = [
+            resource
+            for registry in successful
+            for resource in discovery.extract(registry, dev=dev)
+        ]
+        if check_platforms:
+            endpoints = [
+                resource for resource in resources if resource.uri.endswith("/skaha")
+            ]
+            await asyncio.gather(*(discovery.check(endpoint) for endpoint in endpoints))
+
+    return RegistryEvidence(
+        preferred_storage_leaf=idp_info.preferred_storage_leaf,
+        resources=tuple(resources),
+        errors=tuple(
+            f"{registry.name}: {registry.error}"
+            for registry in registries
+            if not registry.success
+        ),
+        available=bool(successful),
+    )
+
+
+def _registry_namespace(uri: str) -> str:
+    """Return the IVOA registry URI namespace before its resource leaf."""
+    return uri.rpartition("/")[0]
+
+
+def select_storage_resource(
+    endpoint: RegistryResource,
+    resources: list[RegistryResource],
+    *,
+    strict: bool,
+) -> RegistryResource | None:
+    """Pair an endpoint with one unambiguous same-environment VOSpace record."""
+    candidates = [
+        resource
+        for resource in resources
+        if _registry_namespace(resource.uri) == _registry_namespace(endpoint.uri)
+        and resource.development == endpoint.development
+    ]
+    same_registry = [
+        resource for resource in candidates if resource.registry == endpoint.registry
+    ]
+    preferred = same_registry or candidates
+    if len(preferred) == 1:
+        return preferred[0]
+    if len(preferred) > 1:
+        message = (
+            "Multiple preferred VOSpace registry records found for Science "
+            f"Platform Server '{endpoint.name or endpoint.uri}' in namespace "
+            f"'{_registry_namespace(endpoint.uri)}'."
+        )
+        if strict:
+            raise RegistryEvidenceError(message)
+        log.debug("%s Omitting generated storage configuration.", message)
+    return None
+
+
+async def discover_storage_resource(
+    server_uri: str | None,
+    server_url: str | None,
+    server_name: str | None,
+    idp: str,
+    *,
+    dev: bool,
+    timeout: int,
+) -> RegistryResource | None:
+    """Return fresh registry evidence for a server's primary VOSpace service."""
+    if server_uri is None:
+        message = "Server URI is required to inspect its VOSpace Service."
+        raise RegistryEvidenceError(message)
+
+    evidence = await load_registry_evidence(
+        idp,
+        dev=dev,
+        timeout=timeout,
+        check_platforms=False,
+    )
+    if not evidence.available:
+        errors = "; ".join(evidence.errors)
+        message = (
+            f"Failed to inspect VOSpace registry records for IDP '{idp}': {errors}"
+        )
+        raise RegistryEvidenceError(message)
+
+    endpoints = [
+        resource
+        for resource in evidence.resources
+        if resource.uri == server_uri and resource.uri.endswith("/skaha")
+    ]
+    matching_urls = [
+        endpoint
+        for endpoint in endpoints
+        if server_url is not None and endpoint.url == server_url
+    ]
+    if len(matching_urls) == 1:
+        endpoint = matching_urls[0]
+    elif len(endpoints) == 1:
+        endpoint = endpoints[0]
+    elif not endpoints:
+        message = (
+            f"No Science Platform registry record found for Server '{server_name}' "
+            f"with URI '{server_uri}'."
+        )
+        raise RegistryEvidenceError(message)
+    else:
+        message = (
+            f"Multiple Science Platform registry records found for Server "
+            f"'{server_name}' with URI '{server_uri}'."
+        )
+        raise RegistryEvidenceError(message)
+
+    storage_resources = [
+        resource
+        for resource in evidence.resources
+        if resource.uri.endswith(f"/{evidence.preferred_storage_leaf}")
+    ]
+    return select_storage_resource(endpoint, storage_resources, strict=True)
+
+
+async def prepare_enrichment_workers(
+    config: Configuration | None,
+    idp: str,
+    *,
+    endpoint: RegistryResource,
+    count: int,
+) -> EnrichmentWorkers | None:
+    """Materialize credentials once, then isolate worker configuration state."""
+    from canfar.client import HTTPClient  # noqa: PLC0415
+
+    base_config = config or Configuration()
+    client = HTTPClient(
+        config=base_config,
+        authentication_idp=idp,
+        url=AnyHttpUrl(endpoint.url),
+    )
+    token: str | None = None
+    certificate: Path | None = None
+    if client.authentication_record is not None:
+        try:
+            token, certfile = await client._materialize_credentials()  # noqa: SLF001
+        except (
+            KeyError,
+            OSError,
+            AuthContextError,
+            AuthExpiredError,
+            CertificateError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            log.debug("Skipping capability enrichment for IDP %s: %s", idp, exc)
+            return None
+        certificate = Path(certfile) if certfile is not None else None
+
+    values = base_config.model_dump(mode="python")
+    configs = tuple(Configuration.model_validate(values) for _ in range(count))
+    return EnrichmentWorkers(configs, token=token, certificate=certificate)

--- a/canfar/_storage.py
+++ b/canfar/_storage.py
@@ -12,7 +12,6 @@ from canfar.models.config import Configuration
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
     from pathlib import Path
-    from typing import NoReturn
 
     from fsspec.spec import AbstractFileSystem
     from fsspec_cli import AsyncFilesystemSource
@@ -46,7 +45,8 @@ def _vospace_source(
             )
             token_value, certfile = await client._materialize_credentials()  # noqa: SLF001
         except (KeyError, OSError, TypeError, ValueError):
-            _fail_authentication(idp)
+            reason = "Credential cannot be used. Run 'canfar login' for this IDP."
+            raise AuthContextError(idp, reason) from None
 
         from vosfs import VOSpaceFileSystem  # noqa: PLC0415
 
@@ -71,9 +71,3 @@ def _vospace_source(
             await filesystem.aclose()
 
     return source
-
-
-def _fail_authentication(idp: str) -> NoReturn:
-    """Raise the fixed secret-safe authentication failure."""
-    reason = "Credential cannot be used. Run 'canfar login' for this IDP."
-    raise AuthContextError(idp, reason) from None

--- a/canfar/models/config.py
+++ b/canfar/models/config.py
@@ -12,7 +12,6 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
-    PrivateAttr,
     model_validator,
 )
 
@@ -114,8 +113,6 @@ class Configuration(BaseSettings):
         json_schema_mode_override="serialization",
         str_strip_whitespace=True,
     )
-
-    _storage_discovery_errors: dict[str, str] = PrivateAttr(default_factory=dict)
 
     version: Literal[1] = Field(
         default=1,

--- a/canfar/models/registry.py
+++ b/canfar/models/registry.py
@@ -69,6 +69,8 @@ class IVOARegistry(BaseModel):
 
     name: str
     content: str
+    source: str | None = None
+    development: bool = False
     success: bool = True
     error: str | None = None
 
@@ -77,6 +79,7 @@ class Server(BaseModel):
     """Model to store Canfar Server endpoint information."""
 
     registry: str
+    development: bool = False
     uri: str
     url: str
     status: int | None = None

--- a/canfar/server.py
+++ b/canfar/server.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 from xml.etree.ElementTree import ParseError
 
 import httpx
@@ -12,11 +12,18 @@ from defusedxml.common import DefusedXmlException
 from pydantic import AnyHttpUrl, AnyUrl, ValidationError
 
 from canfar import get_logger
+from canfar._discovery import (
+    RegistryEvidenceError,
+    discover_storage_resource,
+    load_registry_evidence,
+    prepare_enrichment_workers,
+    select_storage_resource,
+)
 from canfar.auth.x509 import CertificateError
 from canfar.errors import ErrorCode, StructuredError
 from canfar.exceptions.context import AuthContextError, AuthExpiredError
 from canfar.hooks.httpx.auth import AuthenticationError as HTTPAuthenticationError
-from canfar.idp import get_idp, registry_sources
+from canfar.idp import get_idp
 from canfar.models.config import Configuration
 from canfar.models.http import (
     DEFAULT_SERVER_CORES,
@@ -25,10 +32,11 @@ from canfar.models.http import (
     Server,
     VOSpaceService,
 )
-from canfar.models.registry import IVOARegistrySearch
 from canfar.models.registry import Server as RegistryResource
 from canfar.utils import vosi
-from canfar.utils.discover import Discover
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 log = get_logger(__name__)
 
@@ -86,16 +94,6 @@ class ServerActivation:
 
     server: Server
     reason: Literal["active", "remembered", "single", "selected"]
-
-
-@dataclass(frozen=True)
-class _RegistryEvidence:
-    """Registry resources plus acquisition outcome for one IDP inspection."""
-
-    preferred_storage_leaf: str | None
-    resources: tuple[RegistryResource, ...]
-    errors: tuple[str, ...]
-    available: bool
 
 
 def discover(
@@ -394,91 +392,6 @@ def _resolve_selector(
     return None
 
 
-async def _load_registry_evidence(
-    idp: str,
-    *,
-    dev: bool,
-    timeout: int,
-    check_platforms: bool,
-) -> _RegistryEvidence:
-    """Acquire and extract registry records through one shared pipeline."""
-    idp_info = get_idp(idp)
-    sources = registry_sources(idp, include_dev=dev)
-    development_sources = set(idp_info.dev_registries)
-    search = IVOARegistrySearch(
-        registries=sources,
-        preferred_storage_leaf=idp_info.preferred_storage_leaf,
-    )
-    async with Discover(search, timeout=timeout) as discovery:
-        registries = await asyncio.gather(
-            *(
-                discovery.fetch(
-                    url,
-                    name,
-                    development=url in development_sources,
-                )
-                for url, name in sources.items()
-            )
-        )
-        successful = [registry for registry in registries if registry.success]
-        resources = [
-            resource
-            for registry in successful
-            for resource in discovery.extract(registry, dev=dev)
-        ]
-        if check_platforms:
-            endpoints = [
-                resource for resource in resources if resource.uri.endswith("/skaha")
-            ]
-            await asyncio.gather(*(discovery.check(endpoint) for endpoint in endpoints))
-
-    return _RegistryEvidence(
-        preferred_storage_leaf=idp_info.preferred_storage_leaf,
-        resources=tuple(resources),
-        errors=tuple(
-            f"{registry.name}: {registry.error}"
-            for registry in registries
-            if not registry.success
-        ),
-        available=bool(successful),
-    )
-
-
-async def _enrichment_config_copies(
-    config: Configuration | None,
-    idp: str,
-    *,
-    endpoint: RegistryResource,
-    count: int,
-) -> list[Configuration] | None:
-    """Materialize credentials once, then isolate worker configuration state."""
-    from canfar.client import HTTPClient  # noqa: PLC0415
-
-    base_config = config or Configuration()
-    client = HTTPClient(
-        config=base_config,
-        authentication_idp=idp,
-        url=AnyHttpUrl(endpoint.url),
-    )
-    if client.authentication_record is not None:
-        try:
-            await client._materialize_credentials()  # noqa: SLF001
-        except (
-            KeyError,
-            OSError,
-            AuthContextError,
-            AuthExpiredError,
-            CertificateError,
-            TypeError,
-            ValueError,
-        ) as exc:
-            log.debug("Skipping capability enrichment for IDP %s: %s", idp, exc)
-            return None
-
-    values = base_config.model_dump(mode="python")
-    return [Configuration.model_validate(values) for _ in range(count)]
-
-
 async def _discover_for_idp(
     idp: str,
     *,
@@ -500,7 +413,7 @@ async def _discover_for_idp(
     Raises:
         ServerDiscoveryError: If registry retrieval fails.
     """
-    evidence = await _load_registry_evidence(
+    evidence = await load_registry_evidence(
         idp,
         dev=dev,
         timeout=timeout,
@@ -524,13 +437,13 @@ async def _discover_for_idp(
         for resource in evidence.resources
         if resource.uri.endswith(f"/{evidence.preferred_storage_leaf}")
     ]
-    worker_configs = await _enrichment_config_copies(
+    workers = await prepare_enrichment_workers(
         config,
         idp,
         endpoint=endpoints[0],
         count=len(endpoints),
     )
-    if worker_configs is None:
+    if workers is None:
         return [_registry_resource_to_server(endpoint, idp) for endpoint in endpoints]
 
     return list(
@@ -541,6 +454,8 @@ async def _discover_for_idp(
                     endpoint,
                     idp,
                     config=worker_config,
+                    token=workers.token,
+                    certificate=workers.certificate,
                     timeout=timeout,
                     storage_resource=_select_storage_resource(
                         endpoint,
@@ -550,7 +465,7 @@ async def _discover_for_idp(
                 )
                 for endpoint, worker_config in zip(
                     endpoints,
-                    worker_configs,
+                    workers.configs,
                     strict=True,
                 )
             )
@@ -565,40 +480,17 @@ def _host_slug(uri: AnyUrl) -> str | None:
     return uri.host.replace(".", "-")
 
 
-def _registry_namespace(uri: str) -> str:
-    """Return the IVOA registry URI namespace before its resource leaf."""
-    return uri.rpartition("/")[0]
-
-
 def _select_storage_resource(
     endpoint: RegistryResource,
     resources: list[RegistryResource],
     *,
     strict: bool,
 ) -> RegistryResource | None:
-    """Pair an endpoint with one unambiguous same-environment VOSpace record."""
-    candidates = [
-        resource
-        for resource in resources
-        if _registry_namespace(resource.uri) == _registry_namespace(endpoint.uri)
-        and resource.development == endpoint.development
-    ]
-    same_registry = [
-        resource for resource in candidates if resource.registry == endpoint.registry
-    ]
-    preferred = same_registry or candidates
-    if len(preferred) == 1:
-        return preferred[0]
-    if len(preferred) > 1:
-        message = (
-            "Multiple preferred VOSpace registry records found for Science "
-            f"Platform Server '{endpoint.name or endpoint.uri}' in namespace "
-            f"'{_registry_namespace(endpoint.uri)}'."
-        )
-        if strict:
-            raise ServerFetchError(message)
-        log.debug("%s Omitting generated storage configuration.", message)
-    return None
+    """Map private registry ambiguity to the public server fetch error."""
+    try:
+        return select_storage_resource(endpoint, resources, strict=strict)
+    except RegistryEvidenceError as exc:
+        raise ServerFetchError(str(exc)) from exc
 
 
 async def _discover_storage_resource(
@@ -609,54 +501,17 @@ async def _discover_storage_resource(
     timeout: int,
 ) -> RegistryResource | None:
     """Return fresh registry evidence for a server's primary VOSpace service."""
-    if server.uri is None:
-        msg = "Server URI is required to inspect its VOSpace Service."
-        raise ServerFetchError(msg)
-
-    evidence = await _load_registry_evidence(
-        idp,
-        dev=dev,
-        timeout=timeout,
-        check_platforms=False,
-    )
-    if not evidence.available:
-        errors = "; ".join(evidence.errors)
-        msg = f"Failed to inspect VOSpace registry records for IDP '{idp}': {errors}"
-        raise ServerFetchError(msg)
-
-    endpoints = [
-        resource
-        for resource in evidence.resources
-        if resource.uri == str(server.uri) and resource.uri.endswith("/skaha")
-    ]
-    matching_urls = [
-        endpoint
-        for endpoint in endpoints
-        if server.url is not None and endpoint.url == str(server.url)
-    ]
-    if len(matching_urls) == 1:
-        endpoint = matching_urls[0]
-    elif len(endpoints) == 1:
-        endpoint = endpoints[0]
-    elif not endpoints:
-        msg = (
-            f"No Science Platform registry record found for Server '{server.name}' "
-            f"with URI '{server.uri}'."
+    try:
+        return await discover_storage_resource(
+            str(server.uri) if server.uri is not None else None,
+            str(server.url) if server.url is not None else None,
+            server.name,
+            idp,
+            dev=dev,
+            timeout=timeout,
         )
-        raise ServerFetchError(msg)
-    else:
-        msg = (
-            f"Multiple Science Platform registry records found for Server "
-            f"'{server.name}' with URI '{server.uri}'."
-        )
-        raise ServerFetchError(msg)
-
-    storage_resources = [
-        resource
-        for resource in evidence.resources
-        if resource.uri.endswith(f"/{evidence.preferred_storage_leaf}")
-    ]
-    return _select_storage_resource(endpoint, storage_resources, strict=True)
+    except RegistryEvidenceError as exc:
+        raise ServerFetchError(str(exc)) from exc
 
 
 def _configured_storage_resource(server: Server) -> RegistryResource | None:
@@ -689,6 +544,8 @@ def _discovered_to_server(
     idp: str,
     *,
     config: Configuration | None = None,
+    token: str | None = None,
+    certificate: Path | None = None,
     timeout: int = 2,
     storage_resource: RegistryResource | None = None,
 ) -> Server:
@@ -701,6 +558,8 @@ def _discovered_to_server(
         endpoint: Discovered registry endpoint.
         idp: Canonical IDP key.
         config: Configuration whose Authentication Record authorizes enrichment.
+        token: Pre-materialized runtime bearer token for worker isolation.
+        certificate: Pre-materialized runtime certificate for worker isolation.
         timeout: HTTP timeout in seconds for VOSI capabilities requests.
         storage_resource: Same-namespace preferred VOSpace registry record, if any.
 
@@ -711,6 +570,8 @@ def _discovered_to_server(
     return enrich(
         server,
         config=config,
+        token=token,
+        certificate=certificate,
         strict=False,
         timeout=timeout,
         storage_resource=storage_resource,
@@ -722,6 +583,8 @@ def enrich(
     *,
     config: Configuration | None = None,
     authentication_idp: str | None = None,
+    token: str | None = None,
+    certificate: Path | None = None,
     strict: bool = True,
     timeout: int = 2,
     storage_resource: RegistryResource | None | object = _STORAGE_RESOURCE_UNSET,
@@ -735,6 +598,8 @@ def enrich(
             Authentication or Server Selection.
         authentication_idp: Optional Authentication Record selector. Defaults to
             the Server IDP, then the active Authentication.
+        token: Optional runtime bearer token for capability requests.
+        certificate: Optional runtime certificate for capability requests.
         strict: When ``False``, keep usable registry and existing storage data
             when session or storage capabilities cannot be retrieved or parsed.
             Other successful enrichment may still be returned, so the result can
@@ -764,6 +629,8 @@ def enrich(
             ),
             config=base_config,
             authentication_idp=active_idp,
+            token=token,
+            certificate=certificate,
             strict=strict,
             timeout=timeout,
         )
@@ -776,6 +643,8 @@ def enrich(
                 server.url,
                 config=base_config,
                 authentication_idp=active_idp,
+                token=token,
+                certificate=certificate,
                 timeout=timeout,
             )
         )
@@ -846,6 +715,8 @@ def _enrich_storage(
     storage_resource: RegistryResource | None,
     config: Configuration,
     authentication_idp: str,
+    token: str | None,
+    certificate: Path | None,
     strict: bool,
     timeout: int,
 ) -> Server:
@@ -864,6 +735,8 @@ def _enrich_storage(
                 AnyHttpUrl(storage_resource.url),
                 config=config,
                 authentication_idp=authentication_idp,
+                token=token,
+                certificate=certificate,
                 timeout=timeout,
             )
             valid = vosi.is_vospace_service(xml)
@@ -915,6 +788,8 @@ def _fetch_capabilities(
     *,
     config: Configuration,
     authentication_idp: str,
+    token: str | None = None,
+    certificate: Path | None = None,
     timeout: int,
 ) -> str:
     """Fetch one VOSI capabilities document through the existing HTTP seam."""
@@ -923,6 +798,8 @@ def _fetch_capabilities(
     with HTTPClient(
         config=config,
         authentication_idp=authentication_idp,
+        token=token,
+        certificate=certificate,
         url=url,
         timeout=timeout,
         raise_http_errors=False,

--- a/canfar/server.py
+++ b/canfar/server.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 from xml.etree.ElementTree import ParseError
 
 import httpx
@@ -795,15 +795,18 @@ def _fetch_capabilities(
     """Fetch one VOSI capabilities document through the existing HTTP seam."""
     from canfar.client import HTTPClient  # noqa: PLC0415
 
-    with HTTPClient(
-        config=config,
-        authentication_idp=authentication_idp,
-        token=token,
-        certificate=certificate,
-        url=url,
-        timeout=timeout,
-        raise_http_errors=False,
-    ) as client:
+    client_kwargs: dict[str, Any] = {
+        "config": config,
+        "authentication_idp": authentication_idp,
+        "url": url,
+        "timeout": timeout,
+        "raise_http_errors": False,
+    }
+    if token is not None:
+        client_kwargs["token"] = token
+    if certificate is not None:
+        client_kwargs["certificate"] = certificate
+    with HTTPClient(**client_kwargs) as client:
         request_client = client.client
         request_client.headers["Accept"] = "application/xml"
         request_client.headers.pop("Content-Type", None)

--- a/canfar/server.py
+++ b/canfar/server.py
@@ -254,6 +254,7 @@ def activate(
         resolved,
         config=target_config,
         idp=idp,
+        dev=dev,
         timeout=timeout,
     )
     target_config.set_active_selection(idp, validated)
@@ -404,14 +405,23 @@ async def _discover_for_idp(
     Raises:
         ServerDiscoveryError: If registry retrieval fails.
     """
+    idp_info = get_idp(idp)
     sources = registry_sources(idp, include_dev=dev)
+    development_sources = set(idp_info.dev_registries)
     search = IVOARegistrySearch(
         registries=sources,
-        preferred_storage_leaf=get_idp(idp).preferred_storage_leaf,
+        preferred_storage_leaf=idp_info.preferred_storage_leaf,
     )
     async with Discover(search, timeout=timeout) as discovery:
         registries = await asyncio.gather(
-            *(discovery.fetch(url, name) for url, name in sources.items())
+            *(
+                discovery.fetch(
+                    url,
+                    name,
+                    development=url in development_sources,
+                )
+                for url, name in sources.items()
+            )
         )
         successful_registries = [
             registry for registry in registries if registry.success
@@ -432,28 +442,35 @@ async def _discover_for_idp(
         if not endpoints:
             return []
 
-        storage_by_namespace = {
-            _registry_namespace(resource.uri): resource
+        storage_resources = [
+            resource
             for resource in resources
             if resource.uri.endswith(f"/{search.preferred_storage_leaf}")
-        }
+        ]
 
         checked = await asyncio.gather(
             *(discovery.check(endpoint) for endpoint in endpoints)
         )
-        return [
-            _discovered_to_server(
-                endpoint,
-                idp,
-                config=config,
-                timeout=timeout,
-                storage_resource=storage_by_namespace.get(
-                    _registry_namespace(endpoint.uri)
-                ),
+        reachable = [endpoint for endpoint in checked if endpoint.status == 200]
+        return list(
+            await asyncio.gather(
+                *(
+                    asyncio.to_thread(
+                        _discovered_to_server,
+                        endpoint,
+                        idp,
+                        config=config,
+                        timeout=timeout,
+                        storage_resource=_select_storage_resource(
+                            endpoint,
+                            storage_resources,
+                            strict=False,
+                        ),
+                    )
+                    for endpoint in reachable
+                )
             )
-            for endpoint in checked
-            if endpoint.status == 200
-        ]
+        )
 
 
 def _host_slug(uri: AnyUrl) -> str | None:
@@ -466,6 +483,132 @@ def _host_slug(uri: AnyUrl) -> str | None:
 def _registry_namespace(uri: str) -> str:
     """Return the IVOA registry URI namespace before its resource leaf."""
     return uri.rpartition("/")[0]
+
+
+def _select_storage_resource(
+    endpoint: RegistryResource,
+    resources: list[RegistryResource],
+    *,
+    strict: bool,
+) -> RegistryResource | None:
+    """Pair an endpoint with one unambiguous same-environment VOSpace record."""
+    candidates = [
+        resource
+        for resource in resources
+        if _registry_namespace(resource.uri) == _registry_namespace(endpoint.uri)
+        and resource.development == endpoint.development
+    ]
+    same_registry = [
+        resource for resource in candidates if resource.registry == endpoint.registry
+    ]
+    preferred = same_registry or candidates
+    if len(preferred) == 1:
+        return preferred[0]
+    if len(preferred) > 1:
+        message = (
+            "Multiple preferred VOSpace registry records found for Science "
+            f"Platform Server '{endpoint.name or endpoint.uri}' in namespace "
+            f"'{_registry_namespace(endpoint.uri)}'."
+        )
+        if strict:
+            raise ServerFetchError(message)
+        log.debug("%s Omitting generated storage configuration.", message)
+    return None
+
+
+async def _discover_storage_resource(
+    server: Server,
+    idp: str,
+    *,
+    dev: bool,
+    timeout: int,
+) -> RegistryResource | None:
+    """Return fresh registry evidence for a server's primary VOSpace service."""
+    if server.uri is None:
+        msg = "Server URI is required to inspect its VOSpace Service."
+        raise ServerFetchError(msg)
+
+    idp_info = get_idp(idp)
+    sources = registry_sources(idp, include_dev=dev)
+    development_sources = set(idp_info.dev_registries)
+    search = IVOARegistrySearch(
+        registries=sources,
+        preferred_storage_leaf=idp_info.preferred_storage_leaf,
+    )
+    async with Discover(search, timeout=timeout) as discovery:
+        registries = await asyncio.gather(
+            *(
+                discovery.fetch(
+                    url,
+                    name,
+                    development=url in development_sources,
+                )
+                for url, name in sources.items()
+            )
+        )
+        successful = [registry for registry in registries if registry.success]
+        if not successful:
+            errors = "; ".join(
+                f"{registry.name}: {registry.error}" for registry in registries
+            )
+            msg = (
+                f"Failed to inspect VOSpace registry records for IDP '{idp}': {errors}"
+            )
+            raise ServerFetchError(msg)
+
+        resources = [
+            resource
+            for registry in successful
+            for resource in discovery.extract(registry, dev=dev)
+        ]
+
+    endpoints = [
+        resource
+        for resource in resources
+        if resource.uri == str(server.uri) and resource.uri.endswith("/skaha")
+    ]
+    matching_urls = [
+        endpoint
+        for endpoint in endpoints
+        if server.url is not None and endpoint.url == str(server.url)
+    ]
+    if len(matching_urls) == 1:
+        endpoint = matching_urls[0]
+    elif len(endpoints) == 1:
+        endpoint = endpoints[0]
+    elif not endpoints:
+        msg = (
+            f"No Science Platform registry record found for Server '{server.name}' "
+            f"with URI '{server.uri}'."
+        )
+        raise ServerFetchError(msg)
+    else:
+        msg = (
+            f"Multiple Science Platform registry records found for Server "
+            f"'{server.name}' with URI '{server.uri}'."
+        )
+        raise ServerFetchError(msg)
+
+    storage_resources = [
+        resource
+        for resource in resources
+        if resource.uri.endswith(f"/{search.preferred_storage_leaf}")
+    ]
+    return _select_storage_resource(endpoint, storage_resources, strict=True)
+
+
+def _configured_storage_resource(server: Server) -> RegistryResource | None:
+    """Convert the persisted primary VOSpace service to inspection evidence."""
+    if server.name is None:
+        return None
+    service = server.storage.get(server.name)
+    if service is None:
+        return None
+    return RegistryResource(
+        registry="configuration",
+        uri=str(service.uri),
+        url=str(service.url),
+    )
 
 
 def _discovered_to_server(
@@ -544,14 +687,6 @@ def enrich(
     """
     base_config = config or Configuration()  # ty: ignore[missing-argument]
     active_idp = authentication_idp or server.idp or base_config.active.authentication
-    if (
-        strict
-        and storage_resource is _STORAGE_RESOURCE_UNSET
-        and server.name in base_config._storage_discovery_errors  # noqa: SLF001
-    ):
-        raise ServerFetchError(
-            base_config._storage_discovery_errors[server.name]  # noqa: SLF001
-        )
     if storage_resource is not _STORAGE_RESOURCE_UNSET:
         server = _enrich_storage(
             server,
@@ -617,7 +752,7 @@ def enrich(
         )
 
     try:
-        enriched = Server.model_validate(
+        return Server.model_validate(
             {
                 **server.model_dump(mode="python"),
                 "url": primary["baseurl"],
@@ -636,8 +771,6 @@ def enrich(
             ),
             args=(server.url, exc),
         )
-    else:
-        return enriched
 
 
 def _enrich_storage(
@@ -692,7 +825,7 @@ def _enrich_storage(
             f"Failed to inspect VOSpace Service '{subject}' for Science "
             f"Platform Server '{server.name}': {error}"
         )
-        kept = _keep_or_raise(
+        return _keep_or_raise(
             server,
             strict=strict,
             error=message,
@@ -700,20 +833,14 @@ def _enrich_storage(
             debug="Skipping VOSpace Service %s during discovery: %s",
             args=(subject, error),
         )
-        if server.name is not None:
-            config._storage_discovery_errors[server.name] = message  # noqa: SLF001
-        return kept
-
     assert storage_resource is not None
     assert server.name is not None
     service = VOSpaceService(uri=storage_resource.uri, url=storage_resource.url)
 
-    enriched = server.model_copy(
+    return server.model_copy(
         update={"storage": {**server.storage, server.name: service}},
         deep=True,
     )
-    config._storage_discovery_errors.pop(server.name, None)  # noqa: SLF001
-    return enriched
 
 
 def _fetch_capabilities(
@@ -763,6 +890,7 @@ def _validate_server(
     *,
     config: Configuration | None = None,
     idp: str | None = None,
+    dev: bool = False,
     timeout: int = 2,
 ) -> Server:
     """Fetch and validate a server before persisting it as active.
@@ -771,6 +899,7 @@ def _validate_server(
         server: Candidate server record.
         config: Configuration to use while validating the candidate selection.
         idp: Authentication IDP to pair with the candidate server.
+        dev: Include development registry evidence during validation.
         timeout: HTTP timeout in seconds for validation requests.
 
     Returns:
@@ -781,12 +910,23 @@ def _validate_server(
     """
     base_config = config or Configuration()  # ty: ignore[missing-argument]
     active_idp = idp or server.idp or base_config.active.authentication
+    storage_resource = _configured_storage_resource(server)
+    if storage_resource is None:
+        storage_resource = asyncio.run(
+            _discover_storage_resource(
+                server,
+                active_idp,
+                dev=dev,
+                timeout=timeout,
+            )
+        )
     enriched = enrich(
         server,
         config=base_config,
         authentication_idp=active_idp,
         strict=True,
         timeout=timeout,
+        storage_resource=storage_resource,
     )
     if enriched.url is None or enriched.version is None:
         msg = "Server URL and version are required before activation."

--- a/canfar/server.py
+++ b/canfar/server.py
@@ -88,6 +88,16 @@ class ServerActivation:
     reason: Literal["active", "remembered", "single", "selected"]
 
 
+@dataclass(frozen=True)
+class _RegistryEvidence:
+    """Registry resources plus acquisition outcome for one IDP inspection."""
+
+    preferred_storage_leaf: str | None
+    resources: tuple[RegistryResource, ...]
+    errors: tuple[str, ...]
+    available: bool
+
+
 def discover(
     idp: str,
     *,
@@ -384,6 +394,91 @@ def _resolve_selector(
     return None
 
 
+async def _load_registry_evidence(
+    idp: str,
+    *,
+    dev: bool,
+    timeout: int,
+    check_platforms: bool,
+) -> _RegistryEvidence:
+    """Acquire and extract registry records through one shared pipeline."""
+    idp_info = get_idp(idp)
+    sources = registry_sources(idp, include_dev=dev)
+    development_sources = set(idp_info.dev_registries)
+    search = IVOARegistrySearch(
+        registries=sources,
+        preferred_storage_leaf=idp_info.preferred_storage_leaf,
+    )
+    async with Discover(search, timeout=timeout) as discovery:
+        registries = await asyncio.gather(
+            *(
+                discovery.fetch(
+                    url,
+                    name,
+                    development=url in development_sources,
+                )
+                for url, name in sources.items()
+            )
+        )
+        successful = [registry for registry in registries if registry.success]
+        resources = [
+            resource
+            for registry in successful
+            for resource in discovery.extract(registry, dev=dev)
+        ]
+        if check_platforms:
+            endpoints = [
+                resource for resource in resources if resource.uri.endswith("/skaha")
+            ]
+            await asyncio.gather(*(discovery.check(endpoint) for endpoint in endpoints))
+
+    return _RegistryEvidence(
+        preferred_storage_leaf=idp_info.preferred_storage_leaf,
+        resources=tuple(resources),
+        errors=tuple(
+            f"{registry.name}: {registry.error}"
+            for registry in registries
+            if not registry.success
+        ),
+        available=bool(successful),
+    )
+
+
+async def _enrichment_config_copies(
+    config: Configuration | None,
+    idp: str,
+    *,
+    endpoint: RegistryResource,
+    count: int,
+) -> list[Configuration] | None:
+    """Materialize credentials once, then isolate worker configuration state."""
+    from canfar.client import HTTPClient  # noqa: PLC0415
+
+    base_config = config or Configuration()
+    client = HTTPClient(
+        config=base_config,
+        authentication_idp=idp,
+        url=AnyHttpUrl(endpoint.url),
+    )
+    if client.authentication_record is not None:
+        try:
+            await client._materialize_credentials()  # noqa: SLF001
+        except (
+            KeyError,
+            OSError,
+            AuthContextError,
+            AuthExpiredError,
+            CertificateError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            log.debug("Skipping capability enrichment for IDP %s: %s", idp, exc)
+            return None
+
+    values = base_config.model_dump(mode="python")
+    return [Configuration.model_validate(values) for _ in range(count)]
+
+
 async def _discover_for_idp(
     idp: str,
     *,
@@ -405,72 +500,62 @@ async def _discover_for_idp(
     Raises:
         ServerDiscoveryError: If registry retrieval fails.
     """
-    idp_info = get_idp(idp)
-    sources = registry_sources(idp, include_dev=dev)
-    development_sources = set(idp_info.dev_registries)
-    search = IVOARegistrySearch(
-        registries=sources,
-        preferred_storage_leaf=idp_info.preferred_storage_leaf,
+    evidence = await _load_registry_evidence(
+        idp,
+        dev=dev,
+        timeout=timeout,
+        check_platforms=True,
     )
-    async with Discover(search, timeout=timeout) as discovery:
-        registries = await asyncio.gather(
+    if not evidence.available:
+        errors = "; ".join(evidence.errors)
+        msg = f"Failed to discover servers for IDP '{idp}': {errors}"
+        raise ServerDiscoveryError(msg)
+
+    endpoints = [
+        resource
+        for resource in evidence.resources
+        if resource.uri.endswith("/skaha") and resource.status == 200
+    ]
+    if not endpoints:
+        return []
+
+    storage_resources = [
+        resource
+        for resource in evidence.resources
+        if resource.uri.endswith(f"/{evidence.preferred_storage_leaf}")
+    ]
+    worker_configs = await _enrichment_config_copies(
+        config,
+        idp,
+        endpoint=endpoints[0],
+        count=len(endpoints),
+    )
+    if worker_configs is None:
+        return [_registry_resource_to_server(endpoint, idp) for endpoint in endpoints]
+
+    return list(
+        await asyncio.gather(
             *(
-                discovery.fetch(
-                    url,
-                    name,
-                    development=url in development_sources,
-                )
-                for url, name in sources.items()
-            )
-        )
-        successful_registries = [
-            registry for registry in registries if registry.success
-        ]
-        if not successful_registries:
-            errors = "; ".join(
-                f"{registry.name}: {registry.error}" for registry in registries
-            )
-            msg = f"Failed to discover servers for IDP '{idp}': {errors}"
-            raise ServerDiscoveryError(msg)
-
-        resources = []
-        for registry in successful_registries:
-            resources.extend(discovery.extract(registry, dev=dev))
-        endpoints = [
-            resource for resource in resources if resource.uri.endswith("/skaha")
-        ]
-        if not endpoints:
-            return []
-
-        storage_resources = [
-            resource
-            for resource in resources
-            if resource.uri.endswith(f"/{search.preferred_storage_leaf}")
-        ]
-
-        checked = await asyncio.gather(
-            *(discovery.check(endpoint) for endpoint in endpoints)
-        )
-        reachable = [endpoint for endpoint in checked if endpoint.status == 200]
-        return list(
-            await asyncio.gather(
-                *(
-                    asyncio.to_thread(
-                        _discovered_to_server,
+                asyncio.to_thread(
+                    _discovered_to_server,
+                    endpoint,
+                    idp,
+                    config=worker_config,
+                    timeout=timeout,
+                    storage_resource=_select_storage_resource(
                         endpoint,
-                        idp,
-                        config=config,
-                        timeout=timeout,
-                        storage_resource=_select_storage_resource(
-                            endpoint,
-                            storage_resources,
-                            strict=False,
-                        ),
-                    )
-                    for endpoint in reachable
+                        storage_resources,
+                        strict=False,
+                    ),
+                )
+                for endpoint, worker_config in zip(
+                    endpoints,
+                    worker_configs,
+                    strict=True,
                 )
             )
         )
+    )
 
 
 def _host_slug(uri: AnyUrl) -> str | None:
@@ -528,43 +613,20 @@ async def _discover_storage_resource(
         msg = "Server URI is required to inspect its VOSpace Service."
         raise ServerFetchError(msg)
 
-    idp_info = get_idp(idp)
-    sources = registry_sources(idp, include_dev=dev)
-    development_sources = set(idp_info.dev_registries)
-    search = IVOARegistrySearch(
-        registries=sources,
-        preferred_storage_leaf=idp_info.preferred_storage_leaf,
+    evidence = await _load_registry_evidence(
+        idp,
+        dev=dev,
+        timeout=timeout,
+        check_platforms=False,
     )
-    async with Discover(search, timeout=timeout) as discovery:
-        registries = await asyncio.gather(
-            *(
-                discovery.fetch(
-                    url,
-                    name,
-                    development=url in development_sources,
-                )
-                for url, name in sources.items()
-            )
-        )
-        successful = [registry for registry in registries if registry.success]
-        if not successful:
-            errors = "; ".join(
-                f"{registry.name}: {registry.error}" for registry in registries
-            )
-            msg = (
-                f"Failed to inspect VOSpace registry records for IDP '{idp}': {errors}"
-            )
-            raise ServerFetchError(msg)
-
-        resources = [
-            resource
-            for registry in successful
-            for resource in discovery.extract(registry, dev=dev)
-        ]
+    if not evidence.available:
+        errors = "; ".join(evidence.errors)
+        msg = f"Failed to inspect VOSpace registry records for IDP '{idp}': {errors}"
+        raise ServerFetchError(msg)
 
     endpoints = [
         resource
-        for resource in resources
+        for resource in evidence.resources
         if resource.uri == str(server.uri) and resource.uri.endswith("/skaha")
     ]
     matching_urls = [
@@ -591,8 +653,8 @@ async def _discover_storage_resource(
 
     storage_resources = [
         resource
-        for resource in resources
-        if resource.uri.endswith(f"/{search.preferred_storage_leaf}")
+        for resource in evidence.resources
+        if resource.uri.endswith(f"/{evidence.preferred_storage_leaf}")
     ]
     return _select_storage_resource(endpoint, storage_resources, strict=True)
 
@@ -608,6 +670,17 @@ def _configured_storage_resource(server: Server) -> RegistryResource | None:
         registry="configuration",
         uri=str(service.uri),
         url=str(service.url),
+    )
+
+
+def _registry_resource_to_server(endpoint: RegistryResource, idp: str) -> Server:
+    """Convert registry endpoint identity without performing capability I/O."""
+    uri = AnyUrl(endpoint.uri)
+    return Server(
+        idp=idp,
+        name=endpoint.name or _host_slug(uri),
+        uri=uri,
+        url=AnyHttpUrl(endpoint.url),
     )
 
 
@@ -634,13 +707,7 @@ def _discovered_to_server(
     Returns:
         Server: Persisted server model with capabilities metadata when available.
     """
-    uri = AnyUrl(endpoint.uri)
-    server = Server(
-        idp=idp,
-        name=endpoint.name or _host_slug(uri),
-        uri=uri,
-        url=AnyHttpUrl(endpoint.url),
-    )
+    server = _registry_resource_to_server(endpoint, idp)
     return enrich(
         server,
         config=config,

--- a/canfar/utils/discover.py
+++ b/canfar/utils/discover.py
@@ -115,11 +115,12 @@ class Discover:
                 url = _without_terminal_capabilities(url)
                 if url is None:
                     continue
-                # Apply exclusion filters
-                if not dev and any(
+                record_development = any(
                     word in uri.lower() or word in url.lower()
                     for word in self.config.excluded
-                ):
+                )
+                # Apply exclusion filters
+                if not dev and record_development:
                     continue
 
                 # Apply omit filters
@@ -127,7 +128,7 @@ class Discover:
                     continue
                 endpoint = Server(
                     registry=registry.source or registry.name,
-                    development=registry.development,
+                    development=registry.development or record_development,
                     uri=uri,
                     url=url,
                     name=self.config.names.get(uri) if leaf == "skaha" else None,

--- a/canfar/utils/discover.py
+++ b/canfar/utils/discover.py
@@ -51,12 +51,19 @@ class Discover:
         """
         await self.client.aclose()
 
-    async def fetch(self, url: str, name: str) -> IVOARegistry:
+    async def fetch(
+        self,
+        url: str,
+        name: str,
+        *,
+        development: bool = False,
+    ) -> IVOARegistry:
         """Fetch registry contents.
 
         Args:
             url (str): Registry URL.
             name (str): Common name for the registry.
+            development: Whether this source contains development records.
 
         Returns:
             RegistryInfo: Registry information.
@@ -70,10 +77,23 @@ class Discover:
                 f"[dim]Fetched {name} in {elapsed:.2f}s[/dim]"
             )
 
-            return IVOARegistry(name=name, content=response.text, success=True)
+            return IVOARegistry(
+                name=name,
+                source=url,
+                development=development,
+                content=response.text,
+                success=True,
+            )
         except httpx.HTTPError as error:
             error_msg = str(error)
-            return IVOARegistry(name=name, content="", success=False, error=error_msg)
+            return IVOARegistry(
+                name=name,
+                source=url,
+                development=development,
+                content="",
+                success=False,
+                error=error_msg,
+            )
 
     def extract(self, registry: IVOARegistry, dev: bool = False) -> list[Server]:
         """Extract Science Platform and preferred VOSpace registry records."""
@@ -106,7 +126,8 @@ class Discover:
                 if (registry.name, uri) in self.config.omit:
                     continue
                 endpoint = Server(
-                    registry=registry.name,
+                    registry=registry.source or registry.name,
+                    development=registry.development,
                     uri=uri,
                     url=url,
                     name=self.config.names.get(uri) if leaf == "skaha" else None,

--- a/tests/test_platform_enrichment.py
+++ b/tests/test_platform_enrichment.py
@@ -23,7 +23,7 @@ from canfar.models.auth import (
     X509Credential,
 )
 from canfar.models.config import Configuration
-from canfar.models.http import Server
+from canfar.models.http import Server, VOSpaceService
 from canfar.models.registry import ContainerRegistry
 from tests.test_auth_x509 import generate_cert
 
@@ -39,6 +39,25 @@ _CONTEXT_PAYLOAD = {
     "memoryGB": {"defaultLimit": 192},
     "gpus": {"options": [0, 1, 2, 4]},
 }
+_VOSPACE_CAPABILITIES = """
+    <capabilities xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <capability standardID="ivo://ivoa.net/std/VOSpace/v2.0#nodes">
+        <interface xsi:type="ParamHTTP" role="std">
+          <accessURL use="base">https://storage.example/arc/nodes</accessURL>
+        </interface>
+      </capability>
+    </capabilities>
+"""
+
+
+def _primary_storage(name: str, *, leaf: str = "arc") -> dict[str, VOSpaceService]:
+    """Return persisted primary storage evidence for activation tests."""
+    return {
+        name: VOSpaceService(
+            uri=AnyUrl(f"ivo://storage.example/{leaf}"),
+            url=AnyHttpUrl(f"https://storage.example/{leaf}"),
+        )
+    }
 
 
 def _http_client_factory(
@@ -149,6 +168,7 @@ class TestPlatformEnrichment:
         """Activation owns HTTP enrichment while Server remains persisted data."""
         known = _server(
             name="Stable-Name",
+            storage=_primary_storage("Stable-Name"),
             cores=8,
             ram=64,
             gpus=1,
@@ -159,6 +179,8 @@ class TestPlatformEnrichment:
         def response(request: httpx.Request) -> httpx.Response:
             """Serve capabilities and context for activation enrichment."""
             requests.append(request)
+            if request.url.host == "storage.example":
+                return httpx.Response(200, text=_VOSPACE_CAPABILITIES, request=request)
             if request.url.path.endswith("/capabilities"):
                 return httpx.Response(
                     200, text=_capabilities(_CADC_URL), request=request
@@ -189,10 +211,12 @@ class TestPlatformEnrichment:
         assert persisted.active.server == "Stable-Name"
         assert persisted.servers["Stable-Name"] == activated.server
         assert [request.url.path for request in requests] == [
+            "/arc/capabilities",
             "/skaha/capabilities",
             "/skaha/v2/context",
         ]
         assert [request.extensions["timeout"] for request in requests] == [
+            {"connect": 7, "read": 7, "write": 7, "pool": 7},
             {"connect": 7, "read": 7, "write": 7, "pool": 7},
             {"connect": 7, "read": 7, "write": 7, "pool": 7},
         ]
@@ -204,10 +228,19 @@ class TestPlatformEnrichment:
         failure: str,
     ) -> None:
         """Expected context failures keep server identity and safe defaults."""
-        known = _server(name="Stable-Name", cores=8, ram=64, gpus=1, status="reachable")
+        known = _server(
+            name="Stable-Name",
+            storage=_primary_storage("Stable-Name"),
+            cores=8,
+            ram=64,
+            gpus=1,
+            status="reachable",
+        )
 
         def response(request: httpx.Request) -> httpx.Response:
             """Serve capabilities and a parametrized unusable context reply."""
+            if request.url.host == "storage.example":
+                return httpx.Response(200, text=_VOSPACE_CAPABILITIES, request=request)
             if request.url.path.endswith("/capabilities"):
                 return httpx.Response(
                     200, text=_capabilities(_CADC_URL), request=request
@@ -445,6 +478,7 @@ class TestPlatformEnrichment:
             name="SRCNet",
             uri=AnyUrl("ivo://srcnet.example/skaha"),
             url=AnyHttpUrl("https://srcnet.example/skaha"),
+            storage=_primary_storage("SRCNet", leaf="cavern"),
             version=None,
             auths=None,
         )
@@ -455,6 +489,8 @@ class TestPlatformEnrichment:
         def platform_response(request: httpx.Request) -> httpx.Response:
             """Serve capabilities then a failed context fetch during refresh."""
             platform_requests.append(request)
+            if request.url.host == "storage.example":
+                return httpx.Response(200, text=_VOSPACE_CAPABILITIES, request=request)
             if request.url.path.endswith("/capabilities"):
                 return httpx.Response(200, text=capabilities, request=request)
             if request.url.path.endswith("/v2/context"):
@@ -518,6 +554,7 @@ class TestPlatformEnrichment:
         assert validated.version == "v2"
         assert len(token_requests) == 1
         assert [request.headers["Authorization"] for request in platform_requests] == [
+            f"Bearer {_REFRESHED_TOKEN}",
             f"Bearer {_REFRESHED_TOKEN}",
             f"Bearer {_REFRESHED_TOKEN}",
         ]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -840,6 +840,133 @@ class TestServerDiscovery:
             "Bearer runtime-token"
         ]
 
+    @pytest.mark.asyncio
+    async def test_environment_token_materializes_without_saved_credential(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Environment bearer auth survives preparation and worker fan-out."""
+        endpoint = DiscoveredServer(
+            registry="SRCNet",
+            uri="ivo://site.example/skaha",
+            url="https://site.example/skaha",
+            status=200,
+            name="site",
+        )
+        mock_discovery = AsyncMock()
+        mock_discovery.fetch.return_value = MagicMock(success=True, content="line")
+        mock_discovery.extract = MagicMock(return_value=[endpoint])
+        mock_discovery.check = AsyncMock(side_effect=lambda item: item)
+        mock_discovery.__aenter__ = AsyncMock(return_value=mock_discovery)
+        mock_discovery.__aexit__ = AsyncMock(return_value=None)
+        requests: list[httpx.Request] = []
+        session_capabilities = """
+            <capabilities>
+              <capability standardID="http://www.opencadc.org/std/platform#session-1">
+                <interface>
+                  <accessURL use="base">https://site.example/skaha/v1</accessURL>
+                  <securityMethod standardID="ivo://ivoa.net/sso#token" />
+                </interface>
+              </capability>
+            </capabilities>
+        """
+
+        def response(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            return httpx.Response(200, text=session_capabilities, request=request)
+
+        monkeypatch.delenv("CANFAR_CERTIFICATE", raising=False)
+        monkeypatch.setenv("CANFAR_TOKEN", "environment-token")
+        with (
+            patch("canfar._discovery.Discover", return_value=mock_discovery),
+            patch(
+                "canfar.client.Client",
+                side_effect=_http_client_factory(httpx.MockTransport(response)),
+            ),
+        ):
+            [server] = await _discover_for_idp(
+                "srcnet",
+                config=_anonymous_config(idp="srcnet"),
+            )
+
+        assert server.version == "v1"
+        assert [request.headers["Authorization"] for request in requests] == [
+            "Bearer environment-token"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_environment_certificate_materializes_without_saved_credential(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Environment certificate auth survives preparation and worker fan-out."""
+        endpoint = DiscoveredServer(
+            registry="SRCNet",
+            uri="ivo://site.example/skaha",
+            url="https://site.example/skaha",
+            status=200,
+            name="site",
+        )
+        mock_discovery = AsyncMock()
+        mock_discovery.fetch.return_value = MagicMock(success=True, content="line")
+        mock_discovery.extract = MagicMock(return_value=[endpoint])
+        mock_discovery.check = AsyncMock(side_effect=lambda item: item)
+        mock_discovery.__aenter__ = AsyncMock(return_value=mock_discovery)
+        mock_discovery.__aexit__ = AsyncMock(return_value=None)
+        session_capabilities = """
+            <capabilities>
+              <capability standardID="http://www.opencadc.org/std/platform#session-1">
+                <interface>
+                  <accessURL use="base">https://site.example/skaha/v1</accessURL>
+                  <securityMethod
+                    standardID="ivo://ivoa.net/sso#tls-with-certificate" />
+                </interface>
+              </capability>
+            </capabilities>
+        """
+        certificate = tmp_path / "environment.pem"
+        valid = MagicMock(return_value=certificate.as_posix())
+        ssl_context = MagicMock()
+
+        monkeypatch.delenv("CANFAR_TOKEN", raising=False)
+        monkeypatch.setenv("CANFAR_CERTIFICATE", certificate.as_posix())
+        with (
+            patch("canfar._discovery.Discover", return_value=mock_discovery),
+            patch(
+                "canfar.client.x509.inspect",
+                return_value={
+                    "path": certificate.as_posix(),
+                    "expiry": 9_999_999_999.0,
+                },
+            ),
+            patch("canfar.client.x509.valid", new=valid),
+            patch(
+                "canfar.client.HTTPClient._get_ssl_context",
+                return_value=ssl_context,
+            ) as get_ssl_context,
+            patch(
+                "canfar.client.Client",
+                side_effect=_http_client_factory(
+                    httpx.MockTransport(
+                        lambda request: httpx.Response(
+                            200,
+                            text=session_capabilities,
+                            request=request,
+                        )
+                    )
+                ),
+            ),
+        ):
+            [server] = await _discover_for_idp(
+                "srcnet",
+                config=_anonymous_config(idp="srcnet"),
+            )
+
+        assert server.version == "v1"
+        valid.assert_called_once_with(certificate)
+        get_ssl_context.assert_called_once_with(certificate)
+
     @pytest.mark.parametrize(
         "capabilities_case",
         [

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from threading import Barrier
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -24,6 +25,7 @@ from canfar.server import (
     ServerSelectionRequiredError,
     _discover_for_idp,
     _discovered_to_server,
+    _select_storage_resource,
     activate,
     discover,
     enrich,
@@ -527,8 +529,8 @@ class TestServerDiscovery:
         if mode == "malformed":
             assert isinstance(exc_info.value.__cause__, ValueError)
 
-    def test_activation_surfaces_storage_failure_retained_by_discovery(self) -> None:
-        """Real non-strict discovery carries its storage error into activation."""
+    def test_activation_freshly_inspects_storage_missing_during_discovery(self) -> None:
+        """Activation obtains fresh evidence without transient Configuration state."""
         endpoint = DiscoveredServer(
             registry="CADC source",
             uri=_CADC_URI,
@@ -570,18 +572,20 @@ class TestServerDiscovery:
             ),
         ):
             [discovered] = discover("cadc", config=config, save=False)
+            reloaded = Configuration.model_validate(config.model_dump(mode="python"))
             with pytest.raises(
                 ServerFetchError,
                 match="same-namespace 'arc' registry record",
             ):
-                activate("cadc", _CADC_URI, config=config)
+                activate("cadc", _CADC_URI, config=reloaded)
 
         assert discovered.version == "v1"
         assert discovered.storage == {}
+        assert "_storage_discovery_errors" not in Configuration.__private_attributes__
 
     @pytest.mark.asyncio
-    async def test_srcnet_pairs_each_server_with_same_namespace_cavern(self) -> None:
-        """SRCNet Cavern records pair by IVOA namespace, not list position."""
+    async def test_cross_registry_singletons_pair_by_namespace(self) -> None:
+        """A lone same-environment fallback may cross registry provenance."""
         resources = [
             DiscoveredServer(
                 registry="SRCNet",
@@ -647,6 +651,94 @@ class TestServerDiscovery:
             "canSRC": "ivo://canfar.net/src/cavern",
             "sweSRC": "ivo://swesrc.chalmers.se/cavern",
         }
+
+    def test_storage_pairing_never_crosses_prod_and_dev_sources(self) -> None:
+        """A same-namespace record from another environment is not a fallback."""
+        endpoint = DiscoveredServer(
+            registry="https://registry.example/prod",
+            development=False,
+            uri="ivo://cadc.nrc.ca/skaha",
+            url="https://platform.example/skaha",
+            name="canfar",
+        )
+        dev_storage = DiscoveredServer(
+            registry="https://registry.example/dev",
+            development=True,
+            uri="ivo://cadc.nrc.ca/arc",
+            url="https://storage.example/arc",
+        )
+
+        assert _select_storage_resource(endpoint, [dev_storage], strict=False) is None
+
+    def test_ambiguous_cross_registry_storage_is_not_last_write_wins(self) -> None:
+        """Multiple namespace fallbacks are omitted or actionable, never arbitrary."""
+        endpoint = DiscoveredServer(
+            registry="https://registry.example/platform",
+            uri="ivo://example.org/skaha",
+            url="https://platform.example/skaha",
+            name="example",
+        )
+        storage = [
+            DiscoveredServer(
+                registry=f"https://registry.example/storage-{index}",
+                uri="ivo://example.org/cavern",
+                url=f"https://storage-{index}.example/cavern",
+            )
+            for index in (1, 2)
+        ]
+
+        assert _select_storage_resource(endpoint, storage, strict=False) is None
+        with pytest.raises(ServerFetchError, match="Multiple preferred VOSpace"):
+            _select_storage_resource(endpoint, storage, strict=True)
+
+    @pytest.mark.asyncio
+    async def test_capability_enrichment_runs_concurrently_off_event_loop(
+        self,
+    ) -> None:
+        """Blocking authenticated capability clients run in concurrent workers."""
+        endpoints = [
+            DiscoveredServer(
+                registry="SRCNet",
+                uri=f"ivo://site-{index}.example/skaha",
+                url=f"https://site-{index}.example/skaha",
+                status=200,
+                name=f"site-{index}",
+            )
+            for index in (1, 2)
+        ]
+        mock_discovery = AsyncMock()
+        mock_discovery.fetch.return_value = MagicMock(
+            success=True,
+            content="line",
+        )
+        mock_discovery.extract = MagicMock(return_value=endpoints)
+        mock_discovery.check = AsyncMock(side_effect=lambda item: item)
+        mock_discovery.__aenter__ = AsyncMock(return_value=mock_discovery)
+        mock_discovery.__aexit__ = AsyncMock(return_value=None)
+        concurrent = Barrier(2, timeout=2)
+
+        def convert(
+            endpoint: DiscoveredServer,
+            idp: str,
+            **_kwargs: object,
+        ) -> Server:
+            concurrent.wait()
+            return Server(
+                idp=idp,
+                name=endpoint.name,
+                uri=AnyUrl(endpoint.uri),
+                url=AnyHttpUrl(endpoint.url),
+                version="v1",
+                auths=["oidc"],
+            )
+
+        with (
+            patch("canfar.server.Discover", return_value=mock_discovery),
+            patch("canfar.server._discovered_to_server", side_effect=convert),
+        ):
+            servers = await _discover_for_idp("srcnet")
+
+        assert [server.name for server in servers] == ["site-1", "site-2"]
 
     @pytest.mark.parametrize(
         "capabilities_case",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -670,6 +670,28 @@ class TestServerDiscovery:
 
         assert _select_storage_resource(endpoint, [dev_storage], strict=False) is None
 
+    @pytest.mark.asyncio
+    async def test_mixed_registry_records_keep_per_record_environment(self) -> None:
+        """Development-looking records stay isolated within a production source."""
+        registry = IVOARegistry(
+            name="SRCNet",
+            source="https://registry.example/resources",
+            content=(
+                "ivo://example.org/skaha="
+                "https://platform.example/skaha/capabilities\n"
+                "ivo://example.org/cavern="
+                "https://storage.example/dev/capabilities"
+            ),
+        )
+        search = IVOARegistrySearch(preferred_storage_leaf="cavern")
+
+        async with Discover(search) as discovery:
+            endpoint, storage = discovery.extract(registry, dev=True)
+
+        assert endpoint.development is False
+        assert storage.development is True
+        assert _select_storage_resource(endpoint, [storage], strict=False) is None
+
     def test_ambiguous_cross_registry_storage_is_not_last_write_wins(self) -> None:
         """Multiple namespace fallbacks are omitted or actionable, never arbitrary."""
         endpoint = DiscoveredServer(
@@ -695,7 +717,7 @@ class TestServerDiscovery:
     async def test_capability_enrichment_runs_concurrently_off_event_loop(
         self,
     ) -> None:
-        """Blocking authenticated capability clients run in concurrent workers."""
+        """Workers run concurrently with isolated, pre-materialized config copies."""
         endpoints = [
             DiscoveredServer(
                 registry="SRCNet",
@@ -716,12 +738,21 @@ class TestServerDiscovery:
         mock_discovery.__aenter__ = AsyncMock(return_value=mock_discovery)
         mock_discovery.__aexit__ = AsyncMock(return_value=None)
         concurrent = Barrier(2, timeout=2)
+        worker_configs: list[Configuration] = []
+        config = Configuration(
+            active=ActiveConfig(authentication="srcnet", server=None),
+            authentication={"srcnet": OIDCCredential(idp="srcnet")},
+            servers={},
+        )
 
         def convert(
             endpoint: DiscoveredServer,
             idp: str,
-            **_kwargs: object,
+            **kwargs: object,
         ) -> Server:
+            worker_config = kwargs["config"]
+            assert isinstance(worker_config, Configuration)
+            worker_configs.append(worker_config)
             concurrent.wait()
             return Server(
                 idp=idp,
@@ -732,13 +763,21 @@ class TestServerDiscovery:
                 auths=["oidc"],
             )
 
+        materialize = AsyncMock(return_value=("current-token", None))
         with (
             patch("canfar.server.Discover", return_value=mock_discovery),
             patch("canfar.server._discovered_to_server", side_effect=convert),
+            patch(
+                "canfar.client.HTTPClient._materialize_credentials",
+                new=materialize,
+            ),
         ):
-            servers = await _discover_for_idp("srcnet")
+            servers = await _discover_for_idp("srcnet", config=config)
 
         assert [server.name for server in servers] == ["site-1", "site-2"]
+        materialize.assert_awaited_once_with()
+        assert len({id(worker_config) for worker_config in worker_configs}) == 2
+        assert all(worker_config is not config for worker_config in worker_configs)
 
     @pytest.mark.parametrize(
         "capabilities_case",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -565,7 +565,7 @@ class TestServerDiscovery:
         config = _anonymous_config()
 
         with (
-            patch("canfar.server.Discover", return_value=mock_discovery),
+            patch("canfar._discovery.Discover", return_value=mock_discovery),
             patch(
                 "canfar.client.Client",
                 side_effect=_http_client_factory(transport),
@@ -640,7 +640,7 @@ class TestServerDiscovery:
             )
 
         with (
-            patch("canfar.server.Discover", return_value=mock_discovery),
+            patch("canfar._discovery.Discover", return_value=mock_discovery),
             patch("canfar.server.enrich", side_effect=enriched),
         ):
             servers = await _discover_for_idp("srcnet")
@@ -753,6 +753,8 @@ class TestServerDiscovery:
             worker_config = kwargs["config"]
             assert isinstance(worker_config, Configuration)
             worker_configs.append(worker_config)
+            assert kwargs["token"] == "current-token"
+            assert kwargs["certificate"] is None
             concurrent.wait()
             return Server(
                 idp=idp,
@@ -765,7 +767,7 @@ class TestServerDiscovery:
 
         materialize = AsyncMock(return_value=("current-token", None))
         with (
-            patch("canfar.server.Discover", return_value=mock_discovery),
+            patch("canfar._discovery.Discover", return_value=mock_discovery),
             patch("canfar.server._discovered_to_server", side_effect=convert),
             patch(
                 "canfar.client.HTTPClient._materialize_credentials",
@@ -778,6 +780,65 @@ class TestServerDiscovery:
         materialize.assert_awaited_once_with()
         assert len({id(worker_config) for worker_config in worker_configs}) == 2
         assert all(worker_config is not config for worker_config in worker_configs)
+
+    @pytest.mark.asyncio
+    async def test_worker_requests_use_pre_materialized_runtime_token(self) -> None:
+        """Fan-out requests cannot invoke saved-record refresh or persistence."""
+        endpoint = DiscoveredServer(
+            registry="SRCNet",
+            uri="ivo://site.example/skaha",
+            url="https://site.example/skaha",
+            status=200,
+            name="site",
+        )
+        mock_discovery = AsyncMock()
+        mock_discovery.fetch.return_value = MagicMock(success=True, content="line")
+        mock_discovery.extract = MagicMock(return_value=[endpoint])
+        mock_discovery.check = AsyncMock(side_effect=lambda item: item)
+        mock_discovery.__aenter__ = AsyncMock(return_value=mock_discovery)
+        mock_discovery.__aexit__ = AsyncMock(return_value=None)
+        config = Configuration(
+            active=ActiveConfig(authentication="srcnet", server=None),
+            authentication={"srcnet": OIDCCredential(idp="srcnet")},
+            servers={},
+        )
+        requests: list[httpx.Request] = []
+        session_capabilities = """
+            <capabilities>
+              <capability standardID="http://www.opencadc.org/std/platform#session-1">
+                <interface>
+                  <accessURL use="base">https://site.example/skaha/v1</accessURL>
+                  <securityMethod standardID="ivo://ivoa.net/sso#token" />
+                </interface>
+              </capability>
+            </capabilities>
+        """
+
+        def response(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            return httpx.Response(200, text=session_capabilities, request=request)
+
+        materialize = AsyncMock(return_value=("runtime-token", None))
+        with (
+            patch("canfar._discovery.Discover", return_value=mock_discovery),
+            patch(
+                "canfar.client.HTTPClient._materialize_credentials",
+                new=materialize,
+            ),
+            patch(
+                "canfar.client.Client",
+                side_effect=_http_client_factory(httpx.MockTransport(response)),
+            ),
+            patch("canfar.auth.oidc.sync_refresh") as refresh,
+        ):
+            [server] = await _discover_for_idp("srcnet", config=config)
+
+        assert server.version == "v1"
+        materialize.assert_awaited_once_with()
+        refresh.assert_not_called()
+        assert [request.headers["Authorization"] for request in requests] == [
+            "Bearer runtime-token"
+        ]
 
     @pytest.mark.parametrize(
         "capabilities_case",
@@ -1020,7 +1081,7 @@ class TestServerDiscovery:
 
         with (
             patch("canfar.models.config.CONFIG_PATH", config_path),
-            patch("canfar.server.Discover", return_value=mock_discovery),
+            patch("canfar._discovery.Discover", return_value=mock_discovery),
             patch(
                 "canfar.server.enrich",
                 side_effect=lambda item, **_kwargs: item.model_copy(
@@ -1058,7 +1119,7 @@ class TestServerDiscovery:
         mock_discovery.__aexit__ = AsyncMock(return_value=None)
 
         with (
-            patch("canfar.server.Discover", return_value=mock_discovery),
+            patch("canfar._discovery.Discover", return_value=mock_discovery),
             patch(
                 "canfar.server.enrich",
                 side_effect=lambda item, **_kwargs: item.model_copy(
@@ -1147,7 +1208,7 @@ class TestServerDiscovery:
         mock_discovery.__aexit__ = AsyncMock(return_value=None)
 
         with (
-            patch("canfar.server.Discover", return_value=mock_discovery),
+            patch("canfar._discovery.Discover", return_value=mock_discovery),
             pytest.raises(ServerDiscoveryError, match="Failed to discover"),
         ):
             await _discover_for_idp("cadc")
@@ -1164,7 +1225,9 @@ class TestServerDiscovery:
         mock_discovery.__aenter__ = AsyncMock(return_value=mock_discovery)
         mock_discovery.__aexit__ = AsyncMock(return_value=None)
 
-        with patch("canfar.server.Discover", return_value=mock_discovery) as factory:
+        with patch(
+            "canfar._discovery.Discover", return_value=mock_discovery
+        ) as factory:
             servers = await _discover_for_idp("cadc", dev=True, timeout=11)
 
         assert servers == []

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -24,8 +24,6 @@ if TYPE_CHECKING:
 class _Filesystem:
     """Record construction and cleanup without VOSpace I/O."""
 
-    async_impl = True
-
     def __init__(self, endpoint: str, **kwargs: Any) -> None:
         self.endpoint = endpoint
         self.kwargs = kwargs
@@ -97,7 +95,6 @@ async def test_source_reloads_config_and_runtime_token_wins(
             "asynchronous": True,
             "skip_instance_cache": True,
         }
-        assert filesystem.async_impl is True
         assert filesystem.asynchronous is True
         assert filesystem.closed is False
 


### PR DESCRIPTION
## Summary

- remove transient storage-discovery errors from `Configuration`
- make strict activation inspect persisted or freshly discovered VOSpace evidence
- pair storage by registry provenance and environment, with deterministic ambiguity handling
- classify mixed-source records individually, materialize one immutable runtime credential snapshot, and run blocking capability enrichment concurrently with isolated configuration copies
- keep registry evidence, pairing, and worker preparation in a focused private discovery module
- preserve `CANFAR_TOKEN` and `CANFAR_CERTIFICATE` precedence when no usable saved record exists
- apply the agreed low-risk authenticated-source cleanup

## Validation

- `uv run --no-sync ruff check . --no-cache`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync pytest tests -m "not slow" --no-cov -q -o cache_dir=/tmp/canfar-mega-pytest-cache` (811 passed)
- `uv run ty check canfar` (exactly 22 accepted pre-existing unused-ignore warnings; no new diagnostics)
- `uv run --group docs mkdocs build` (built successfully; GitHub contributor lookup reported the pre-existing API rate-limit warning)
- `uv build`

Refs #150
Refs #152
Refs #153
Refs #155
