### PR TITLE
fix(ci): support pinned ty checks

### DIFF
--- a/canfar/_discovery.py
+++ b/canfar/_discovery.py
@@ -201,7 +201,7 @@ async def prepare_enrichment_workers(
     """Materialize credentials once, then isolate worker configuration state."""
     from canfar.client import HTTPClient  # noqa: PLC0415
 
-    base_config = config or Configuration()
+    base_config = config or Configuration()  # ty: ignore[missing-argument]
     client = HTTPClient(
         config=base_config,
         authentication_idp=idp,

--- a/canfar/_storage.py
+++ b/canfar/_storage.py
@@ -28,7 +28,7 @@ def _vospace_source(
 
     @asynccontextmanager
     async def source() -> AsyncIterator[AbstractFileSystem]:
-        config = Configuration()
+        config = Configuration()  # ty: ignore[missing-argument]
         endpoint, idp = config._resolve_storage(storage_name)  # noqa: SLF001
         try:
             client_kwargs: dict[str, Any] = {

--- a/canfar/cli/data.py
+++ b/canfar/cli/data.py
@@ -36,7 +36,7 @@ async def _local_source() -> AsyncIterator[AbstractFileSystem]:
 
 def _sources() -> dict[str, AsyncFilesystemSource]:
     """Build the mapped sources for one data command invocation."""
-    config = Configuration()
+    config = Configuration()  # ty: ignore[missing-argument]
     sources = {
         storage_name: _vospace_source(storage_name)
         for server in config.servers.values()

--- a/canfar/server.py
+++ b/canfar/server.py
@@ -775,7 +775,9 @@ def _enrich_storage(
         )
     assert storage_resource is not None
     assert server.name is not None
-    service = VOSpaceService(uri=storage_resource.uri, url=storage_resource.url)
+    service = VOSpaceService.model_validate(
+        {"uri": storage_resource.uri, "url": storage_resource.url}
+    )
 
     return server.model_copy(
         update={"storage": {**server.storage, server.name: service}},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,6 +233,9 @@ docstring-code-line-length = "dynamic"
 # ty configuration (replaces mypy)
 [tool.ty]
 
+[tool.ty.rules]
+unused-ignore-comment = "ignore"
+
 [tool.ty.environment]
 python-version = "3.10"
 


### PR DESCRIPTION
## Summary
- suppress ty 0.0.51 BaseSettings constructor false positives at the three new call sites without changing runtime configuration loading
- validate discovered VOSpace registry strings through `VOSpaceService.model_validate`
- disable only the `unused-ignore-comment` rule so the repository-authorized pre-existing suppressions remain compatible with ty 0.0.61

## Validation
- `uv run --no-sync pre-commit run --all-files`
- `uv run --no-sync ruff check . --no-cache`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ty check canfar`
- `uv run --no-sync pytest tests -m "not slow" --no-cov -q -o cache_dir=/tmp/canfar-ci-gate-fix-pytest-cache` (811 passed)

Fixes the pre-commit/type-check failure observed on #217.