### PR TITLE
test: support Python 3.10 TOML parsing

### DIFF
--- a/tests/test_data_dependencies.py
+++ b/tests/test_data_dependencies.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import tomllib
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
 
 
 def test_tagged_data_dependencies_are_standard_dependencies() -> None:


### PR DESCRIPTION
## Summary
- use the repository's tomllib/tomli compatibility pattern in the data dependency metadata test
- restore Python 3.10 CI without changing runtime code

## Validation
- Python 3.10 focused test: 1 passed
- pre-commit: passed
- deterministic non-slow suite: 811 passed