### PR TITLE
ci: gate full tests on merged code changes

### DIFF
--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -1,44 +1,18 @@
-name: Continous Integration
+name: Full Tests
 
 on:
   pull_request:
-    branches: [ main, feat/interfaces ]
-  push:
+    types: [closed]
     branches: [ main ]
-    paths-ignore:
-      - 'docs/**'
+    paths:
+      - 'canfar/**'
+      - 'tests/**'
 
 permissions: read-all
 
 jobs:
-  pre-commit-checks:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-    - name: Harden Runner
-      timeout-minutes: 10
-      uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-      with:
-        egress-policy: audit
-
-    -
-      name: Setup code repository
-      timeout-minutes: 10
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        fetch-depth: 1
-    - name: Setup Python
-      timeout-minutes: 10
-      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-      with:
-        python-version: 3.12
-    -
-      name: pre-commit
-      timeout-minutes: 10
-      uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-
   tests:
-    needs: pre-commit-checks
+    if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' }}
     strategy:
       fail-fast: false
       matrix:
@@ -88,11 +62,11 @@ jobs:
         rm ~/.netrc
         test -f "${HOME}/.ssl/cadcproxy.pem"
     -
-      name: Run tests
+      name: Run full test suite
       timeout-minutes: 10
       run: |
         set -euo pipefail
-        uv run pytest -m "not slow" tests --cov --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
+        uv run pytest --cov --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
     -
       name: Remove CANFAR Certificate
       timeout-minutes: 10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,16 @@ uv run pytest
 
 Some tests in the Skaha test suite are marked as "slow" because they involve network operations, waiting for session states, or other time-consuming operations. These tests can take several minutes to complete.
 
-**Run all tests (including slow ones):**
+**Run the deterministic pull-request suite:**
+```bash
+uv run pytest -m "not slow" tests
+```
+
+Pull requests targeting `main` or `feat/interfaces` use this non-slow suite in CI.
+The unfiltered suite runs in CI only after a code or test change is merged into
+`main`; documentation- and workflow-only merges do not trigger it.
+
+**Run all tests (including slow ones) locally:**
 ```bash
 uv run pytest
 ```
@@ -101,7 +110,7 @@ The slow tests are primarily integration tests that interact with the CANFAR Sci
 - Authentication timeout tests
 - Session statistics tests
 
-For rapid development and testing, it's recommended to use `-m "not slow"` to skip these time-consuming tests during your development cycle, and run the full test suite before submitting your pull request.
+For rapid development and testing, use `-m "not slow"` to skip these time-consuming tests during your development cycle. Run the full suite locally when you have valid CANFAR credentials and a certificate.
 
 ### 6. Commit Your Changes
 

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).parents[1]
+
+
+def read_workflow(name: str) -> dict:
+    workflow = yaml.safe_load((ROOT / ".github" / "workflows" / name).read_text())
+    return workflow["on"] if "on" in workflow else workflow[True]
+
+
+def run_commands(name: str) -> list[str]:
+    workflow = yaml.safe_load((ROOT / ".github" / "workflows" / name).read_text())
+    return [
+        step["run"]
+        for job in workflow["jobs"].values()
+        for step in job.get("steps", [])
+        if "run" in step
+    ]
+
+
+def test_pull_requests_use_the_fast_suite_for_maintained_branches():
+    events = read_workflow("ci.yml")
+    commands = "\n".join(run_commands("ci.yml"))
+
+    assert set(events["pull_request"]["branches"]) == {"main", "feat/interfaces"}
+    assert "paths-ignore" not in events["pull_request"]
+    assert 'uv run pytest -m "not slow" tests' in commands
+    assert not any(
+        line.strip().startswith("uv run pytest") and '-m "not slow"' not in line
+        for line in commands.splitlines()
+    )
+
+
+def test_full_suite_is_limited_to_merged_code_prs_into_main():
+    events = read_workflow("full-tests.yml")
+    workflow = yaml.safe_load(
+        (ROOT / ".github" / "workflows" / "full-tests.yml").read_text()
+    )
+    commands = "\n".join(run_commands("full-tests.yml"))
+
+    assert events["pull_request"] == {
+        "types": ["closed"],
+        "branches": ["main"],
+        "paths": ["canfar/**", "tests/**"],
+    }
+    assert "github.event.pull_request.merged == true" in workflow["jobs"]["tests"]["if"]
+    assert (
+        "github.event.pull_request.base.ref == 'main'"
+        in workflow["jobs"]["tests"]["if"]
+    )
+    assert "uv run pytest" in commands
+    assert '-m "not slow"' not in commands


### PR DESCRIPTION
## Summary

- make `uv run pytest -m "not slow" tests` the pull-request test command for `main` and `feat/interfaces`
- run the unfiltered suite only when a pull request changing `canfar/**` or `tests/**` is merged into `main`
- document the local and CI test policy and protect it with behavior-level workflow contract tests

## TDD evidence

- Red: the workflow contract tests failed before the event filters and full-suite workflow existed
- Green: `uv run --no-sync pytest tests/test_ci_workflows.py --no-cov -q` — 2 passed

## Verification

- Actionlint — passed
- `uv run --no-sync ruff check . --no-cache` — passed
- `uv run ty check canfar` — passed
- deterministic non-slow suite — 827 passed

No generated files changed.

Refs #262
Parent: #244
