### PR TITLE
fix(ci): address Wave 0 review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     env:
-      CANFAR_BASEURL: ${{ secrets.CANFAR_BASEURL }}
-      CANFAR_USERNAME: ${{ secrets.CANFAR_USERNAME }}
-      CANFAR_PASSWORD: ${{ secrets.CANFAR_PASSWORD }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
     - name: Harden Runner
@@ -78,27 +75,11 @@ jobs:
         uv venv --python ${{ matrix.python-version }}
         uv sync --all-extras --dev
     -
-      name: Login to CANFAR
-      timeout-minutes: 10
-      if: ${{ env.CANFAR_BASEURL != '' && env.CANFAR_USERNAME != '' && env.CANFAR_PASSWORD != '' }}
-      run: |
-        set -euo pipefail
-        printf "machine %s\n  login %s\n  password %s\n" "${CANFAR_BASEURL}" "${CANFAR_USERNAME}" "${CANFAR_PASSWORD}" > ~/.netrc
-        uv run cadc-get-cert --days-valid 1 --netrc-file ~/.netrc
-        rm ~/.netrc
-        test -f "${HOME}/.ssl/cadcproxy.pem"
-    -
       name: Run tests
       timeout-minutes: 10
       run: |
         set -euo pipefail
         uv run pytest -m "not slow" tests --cov --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
-    -
-      name: Remove CANFAR Certificate
-      timeout-minutes: 10
-      if: always()
-      run: |
-        rm -rf ~/.ssl/
     -
       name: Upload coverage to Codecov
       timeout-minutes: 10

--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -1,7 +1,7 @@
 name: Full Tests
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches: [ main ]
     paths:
@@ -66,7 +66,7 @@ jobs:
       timeout-minutes: 10
       run: |
         set -euo pipefail
-        uv run pytest --cov --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
+        CANFAR_TEST_HOME="$HOME" uv run pytest --cov --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
     -
       name: Remove CANFAR Certificate
       timeout-minutes: 10

--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -52,9 +52,17 @@ jobs:
         uv venv --python ${{ matrix.python-version }}
         uv sync --all-extras --dev
     -
+      name: Verify CANFAR credentials
+      timeout-minutes: 10
+      run: |
+        set -euo pipefail
+        if [ -z "${CANFAR_BASEURL}" ] || [ -z "${CANFAR_USERNAME}" ] || [ -z "${CANFAR_PASSWORD}" ]; then
+          echo "CANFAR credentials are required for the full test suite" >&2
+          exit 1
+        fi
+    -
       name: Login to CANFAR
       timeout-minutes: 10
-      if: ${{ env.CANFAR_BASEURL != '' && env.CANFAR_USERNAME != '' && env.CANFAR_PASSWORD != '' }}
       run: |
         set -euo pipefail
         printf "machine %s\n  login %s\n  password %s\n" "${CANFAR_BASEURL}" "${CANFAR_USERNAME}" "${CANFAR_PASSWORD}" > ~/.netrc

--- a/canfar/server.py
+++ b/canfar/server.py
@@ -612,7 +612,7 @@ def enrich(
     certificate: Path | None = None,
     strict: bool = True,
     timeout: int = 2,
-    storage_resource: RegistryResource | object | None = _STORAGE_RESOURCE_UNSET,
+    storage_resource: RegistryResource | None | object = _STORAGE_RESOURCE_UNSET,  # noqa: RUF036
 ) -> Server:
     """Return a validated Server enriched from its VOSI capabilities.
 

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -58,6 +58,17 @@ def test_full_suite_is_limited_to_merged_code_prs_into_main():
         "CANFAR_PASSWORD": "${{ secrets.CANFAR_PASSWORD }}",
         "CODECOV_TOKEN": "${{ secrets.CODECOV_TOKEN }}",
     }
+    assert (
+        'if [ -z "${CANFAR_BASEURL}" ] || [ -z "${CANFAR_USERNAME}" ] '
+        '|| [ -z "${CANFAR_PASSWORD}" ]; then'
+    ) in commands
+    assert "CANFAR credentials are required for the full test suite" in commands
+    login_step = next(
+        step
+        for step in workflow["jobs"]["tests"]["steps"]
+        if step.get("name") == "Login to CANFAR"
+    )
+    assert "if" not in login_step
     assert 'CANFAR_TEST_HOME="$HOME" uv run pytest' in commands
     assert "uv run cadc-get-cert" in commands
     assert "rm -rf ~/.ssl/" in commands

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -5,13 +5,15 @@ import yaml
 ROOT = Path(__file__).parents[1]
 
 
-def read_workflow(name: str) -> dict:
-    workflow = yaml.safe_load((ROOT / ".github" / "workflows" / name).read_text())
+def load_workflow(name: str) -> dict:
+    return yaml.safe_load((ROOT / ".github" / "workflows" / name).read_text())
+
+
+def workflow_events(workflow: dict) -> dict:
     return workflow["on"] if "on" in workflow else workflow[True]
 
 
-def run_commands(name: str) -> list[str]:
-    workflow = yaml.safe_load((ROOT / ".github" / "workflows" / name).read_text())
+def run_commands(workflow: dict) -> list[str]:
     return [
         step["run"]
         for job in workflow["jobs"].values()
@@ -21,8 +23,9 @@ def run_commands(name: str) -> list[str]:
 
 
 def test_pull_requests_use_the_fast_suite_for_maintained_branches():
-    events = read_workflow("ci.yml")
-    commands = "\n".join(run_commands("ci.yml"))
+    workflow = load_workflow("ci.yml")
+    events = workflow_events(workflow)
+    commands = "\n".join(run_commands(workflow))
 
     assert set(events["pull_request"]["branches"]) == {"main", "feat/interfaces"}
     assert "paths-ignore" not in events["pull_request"]
@@ -34,13 +37,12 @@ def test_pull_requests_use_the_fast_suite_for_maintained_branches():
 
 
 def test_full_suite_is_limited_to_merged_code_prs_into_main():
-    events = read_workflow("full-tests.yml")
-    workflow = yaml.safe_load(
-        (ROOT / ".github" / "workflows" / "full-tests.yml").read_text()
-    )
-    commands = "\n".join(run_commands("full-tests.yml"))
+    workflow = load_workflow("full-tests.yml")
+    events = workflow_events(workflow)
+    commands = "\n".join(run_commands(workflow))
 
-    assert events["pull_request"] == {
+    assert set(events) == {"pull_request_target"}
+    assert events["pull_request_target"] == {
         "types": ["closed"],
         "branches": ["main"],
         "paths": ["canfar/**", "tests/**"],
@@ -50,5 +52,13 @@ def test_full_suite_is_limited_to_merged_code_prs_into_main():
         "github.event.pull_request.base.ref == 'main'"
         in workflow["jobs"]["tests"]["if"]
     )
-    assert "uv run pytest" in commands
+    assert workflow["jobs"]["tests"]["env"] == {
+        "CANFAR_BASEURL": "${{ secrets.CANFAR_BASEURL }}",
+        "CANFAR_USERNAME": "${{ secrets.CANFAR_USERNAME }}",
+        "CANFAR_PASSWORD": "${{ secrets.CANFAR_PASSWORD }}",
+        "CODECOV_TOKEN": "${{ secrets.CODECOV_TOKEN }}",
+    }
+    assert 'CANFAR_TEST_HOME="$HOME" uv run pytest' in commands
+    assert "uv run cadc-get-cert" in commands
+    assert "rm -rf ~/.ssl/" in commands
     assert '-m "not slow"' not in commands

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from pathlib import Path
 from threading import Barrier
 from typing import TYPE_CHECKING
@@ -52,6 +53,13 @@ _VOSPACE_CAPABILITIES = """
       </capability>
     </capabilities>
 """
+
+
+def test_enrich_preserves_storage_resource_annotation() -> None:
+    """The public enrichment signature retains its released annotation text."""
+    annotation = inspect.signature(enrich).parameters["storage_resource"].annotation
+
+    assert annotation == "RegistryResource | None | object"
 
 
 def _http_client_factory(


### PR DESCRIPTION
## Summary

- run the merge-only full suite in trusted base-repository context and fail closed when CANFAR credentials are unavailable
- preserve the generated certificate through pytest's isolated-home fixture
- remove live credentials from deterministic pull-request CI
- restore the exact released `server.enrich()` annotation metadata with a narrow Ruff suppression
- simplify workflow loading in the CI contract tests

## Wave 0 review findings addressed

- Standards: unauthenticated full-suite execution — fixed with trusted context and an explicit credential preflight
- Specification: merged fork PRs lacked secrets — fixed with `pull_request_target` plus the merged/main/path guards
- Specification: `server.enrich()` annotation text changed — restored and regression-tested
- Simplify: generated certificate was hidden when pytest replaced `HOME` — fixed with `CANFAR_TEST_HOME="$HOME"`

Broader workflow setup duplication remains deliberately assigned to #248.

## Verification

- focused workflow tests — 2 passed
- full pre-commit, including Actionlint — passed
- Ruff — passed
- `ty` — passed
- deterministic non-slow suite — 828 passed

No generated files changed.

Refs #262
Parent: #244
