### PR TITLE
feat(config): establish bound Configuration editor

### DIFF
--- a/canfar/cli/config.py
+++ b/canfar/cli/config.py
@@ -124,7 +124,7 @@ def get(
         raise typer.Exit(1) from err
 
     try:
-        value = cfg.get_value(key)
+        value = cfg.editor.get(key)
     except (AttributeError, KeyError, IndexError, TypeError, ValueError) as err:
         failure = StructuredError(
             code=ErrorCode.COMMAND_VALIDATION_FAILED,
@@ -159,8 +159,8 @@ def set_value(
     cfg = Configuration()  # ty: ignore[missing-argument]
     try:
         parsed = yaml.safe_load(value)
-        updated = cfg.set_value(key, parsed)
-        updated.save()
+        cfg.editor.set(key, parsed)
+        cfg.editor.save()
     except (AttributeError, KeyError, IndexError, TypeError, ValueError) as err:
         get_console(stderr=True).print(f"[bold red]Error:[/bold red] {err}")
         raise typer.Exit(1) from err

--- a/canfar/config/editor.py
+++ b/canfar/config/editor.py
@@ -2,29 +2,27 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from canfar.models.config import Configuration
 
 
-def _parse_dotted_path(path: str) -> list[str | int]:
-    segments: list[str | int] = []
+def _parse_dotted_path(path: str) -> list[str]:
+    segments: list[str] = []
     for raw in path.split("."):
         if not raw:
             msg = f"Invalid path {path!r}: empty segment"
             raise ValueError(msg)
-        segments.append(int(raw) if raw.isdigit() else raw)
+        if raw.isdigit():
+            msg = "List indices are not supported in configuration paths"
+            raise ValueError(msg)
+        segments.append(raw)
     return segments
 
 
-def _get_from_container(container: Any, key: str | int) -> Any:
-    if isinstance(key, int):
-        if not isinstance(container, list):
-            msg = f"Expected list for index {key}"
-            raise TypeError(msg)
-        return container[key]
-
+def _get_from_container(container: Any, key: str) -> Any:
     if isinstance(container, dict):
         return container[key]
 
@@ -32,14 +30,7 @@ def _get_from_container(container: Any, key: str | int) -> Any:
     raise KeyError(msg)
 
 
-def _set_in_container(container: Any, key: str | int, value: Any) -> None:
-    if isinstance(key, int):
-        if not isinstance(container, list):
-            msg = f"Expected list for index {key}"
-            raise TypeError(msg)
-        container[key] = value
-        return
-
+def _set_in_container(container: Any, key: str, value: Any) -> None:
     if isinstance(container, dict):
         container[key] = value
         return
@@ -48,11 +39,7 @@ def _set_in_container(container: Any, key: str | int, value: Any) -> None:
     raise TypeError(msg)
 
 
-def _ensure_child_container(parent: Any, key: str | int) -> Any:
-    if isinstance(key, int):
-        msg = "List indices are not supported for intermediate path segments"
-        raise TypeError(msg)
-
+def _ensure_child_container(parent: Any, key: str) -> Any:
     if not isinstance(parent, dict):
         msg = f"Expected mapping for key {key!r}"
         raise TypeError(msg)
@@ -85,3 +72,27 @@ def set_value(config: Configuration, path: str, value: Any) -> Configuration:
 
     _set_in_container(cursor, segments[-1], value)
     return config.__class__.model_validate(data)
+
+
+@dataclass(slots=True)
+class ConfigurationEditor:
+    """Bound editing and persistence boundary for a Configuration."""
+
+    _config: Configuration
+
+    def get(self, key: str) -> Any:
+        """Read a scalar, mapping, or whole-list value by dotted path."""
+        return get_value(self._config, key)
+
+    def set(self, key: str, value: Any) -> Configuration:
+        """Validate and install a dotted-path update on the bound config."""
+        updated = set_value(self._config, key, value)
+        self._config.__dict__.update(updated.__dict__)
+        self._config.__pydantic_fields_set__ = updated.__pydantic_fields_set__.copy()
+        return self._config
+
+    def save(self) -> None:
+        """Atomically persist the bound Configuration."""
+        from canfar.config.store import save_config  # noqa: PLC0415
+
+        save_config(self._config)

--- a/canfar/models/config.py
+++ b/canfar/models/config.py
@@ -29,6 +29,7 @@ from pydantic_settings import (
 from pydantic_settings.sources import EnvSettingsSource
 
 from canfar import CONFIG_PATH, get_logger
+from canfar.config.editor import ConfigurationEditor as _ConfigurationEditor
 from canfar.config.editor import get_value as _get_value
 from canfar.config.editor import set_value as _set_value
 from canfar.models.active import ActiveConfig
@@ -317,6 +318,11 @@ class Configuration(BaseSettings):
         from canfar.config.store import save_config  # noqa: PLC0415
 
         save_config(self)
+
+    @property
+    def editor(self) -> _ConfigurationEditor:
+        """Return the bound editing and persistence boundary."""
+        return _ConfigurationEditor(self)
 
     def _validated_copy(self, **updates: Any) -> Configuration:
         """Validate a source-isolated copy of this complete Configuration."""

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -190,14 +190,14 @@ def test_config_show_path_format_and_errors(tmp_path: Path) -> None:
     assert isinstance(result.exception, RuntimeError)
 
     with patch("canfar.cli.config.Configuration") as cfg:
-        cfg.return_value.get_value.side_effect = KeyError("missing")
+        cfg.return_value.editor.get.side_effect = KeyError("missing")
         result = runner.invoke(config, ["get", "missing"])
 
     assert result.exit_code == 1
     assert "missing" in result.stderr
 
     with patch("canfar.cli.config.Configuration") as cfg:
-        cfg.return_value.set_value.side_effect = TypeError("wrong")
+        cfg.return_value.editor.set.side_effect = TypeError("wrong")
         result = runner.invoke(config, ["set", "console.width", "120"])
 
     assert result.exit_code == 1

--- a/tests/test_config_editor.py
+++ b/tests/test_config_editor.py
@@ -1,0 +1,98 @@
+"""Tests for the bound persisted Configuration editor."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from canfar.models.config import Configuration
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_editor_reads_scalars_mappings_and_whole_lists(tmp_path: Path) -> None:
+    """The editor resolves dotted paths without exposing list indexing."""
+    config_path = tmp_path / "config.yaml"
+    with patch("canfar.models.config.CONFIG_PATH", config_path):
+        config = Configuration()
+
+        assert config.editor.get("console.width") == 120
+        server = config.editor.get("servers.canfar")
+        assert server["name"] == "canfar"
+        assert config.editor.get("servers.canfar.auths") == ["x509"]
+
+    assert "editor" not in config.model_dump(mode="python")
+
+
+def test_editor_set_mutates_validated_configuration(tmp_path: Path) -> None:
+    """Setting a dotted path updates the bound Configuration in memory."""
+    config_path = tmp_path / "config.yaml"
+    with patch("canfar.models.config.CONFIG_PATH", config_path):
+        config = Configuration()
+
+        assert config.editor.set("console.width", 132) is config
+        assert config.console.width == 132
+        config.editor.set("servers.canfar.auths", ["x509", "oidc"])
+
+        assert config.editor.get("console.width") == 132
+        assert config.editor.get("servers.canfar.auths") == ["x509", "oidc"]
+
+
+def test_editor_rejects_list_indexing(tmp_path: Path) -> None:
+    """Dotted paths may retrieve a whole list but cannot address its items."""
+    config_path = tmp_path / "config.yaml"
+    with patch("canfar.models.config.CONFIG_PATH", config_path):
+        config = Configuration()
+
+        with pytest.raises(ValueError, match="List indices are not supported"):
+            config.editor.get("servers.canfar.auths.0")
+        with pytest.raises(ValueError, match="List indices are not supported"):
+            config.editor.set("servers.canfar.auths.0", "oidc")
+
+
+def test_editor_save_persists_bound_configuration(tmp_path: Path) -> None:
+    """Editor save writes its validated in-memory state to the config file."""
+    config_path = tmp_path / "config.yaml"
+    with patch("canfar.models.config.CONFIG_PATH", config_path):
+        config = Configuration()
+        config.editor.set("console.width", 133)
+        config.editor.save()
+        loaded = Configuration()
+
+    assert loaded.console.width == 133
+
+
+def test_editor_failed_set_preserves_configuration(tmp_path: Path) -> None:
+    """Invalid editor updates do not partially mutate the bound config."""
+    config_path = tmp_path / "config.yaml"
+    with patch("canfar.models.config.CONFIG_PATH", config_path):
+        config = Configuration()
+        original = config.model_dump(mode="python")
+
+        with pytest.raises(ValidationError):
+            config.editor.set("console.width", "not-an-int")
+
+    assert config.model_dump(mode="python") == original
+
+
+def test_editor_save_failure_preserves_existing_file(tmp_path: Path) -> None:
+    """A failed editor save leaves the existing YAML untouched."""
+    config_path = tmp_path / "config.yaml"
+    with patch("canfar.models.config.CONFIG_PATH", config_path):
+        config = Configuration()
+        config.editor.save()
+        original = config_path.read_bytes()
+        config.editor.set("console.width", 134)
+
+        with (
+            patch("canfar.config.store.os.fsync", side_effect=OSError("disk full")),
+            pytest.raises(OSError, match="Failed to save configuration"),
+        ):
+            config.editor.save()
+
+    assert config_path.read_bytes() == original
+    assert list(tmp_path.iterdir()) == [config_path]


### PR DESCRIPTION
## Summary\n\n- establish Configuration.editor with bound get, validated in-place set, and atomic save operations\n- reject dotted list-index paths while preserving whole-list reads and the released Configuration/file shape\n- route canfar config get/set through the editor boundary; retain legacy Configuration service methods\n\n## Validation\n\n- RED: new tests/test_config_editor.py initially failed because Configuration.editor was absent\n- GREEN: focused editor tests: 6 passed\n- config/CLI tests: 33 passed\n- adjacent model/import/machine-output tests: 71 passed\n- deterministic non-slow suite: 834 passed\n- Ruff check and format check: passed\n- ty check canfar: passed\n\nRefs #245