### PR TITLE
refactor(ci): consolidate reusable workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,61 +39,8 @@ jobs:
 
   tests:
     needs: pre-commit-checks
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
-    env:
+    uses: ./.github/workflows/reusable-tests.yml
+    with:
+      full-suite: false
+    secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-    steps:
-    - name: Harden Runner
-      timeout-minutes: 10
-      uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-      with:
-        egress-policy: audit
-
-    -
-      name: Setup code repository
-      timeout-minutes: 10
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        fetch-depth: 1
-    -
-      name: Setup uv
-      timeout-minutes: 10
-      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-      with:
-        enable-cache: true
-    -
-      name: Setup Python ${{ matrix.python-version }}
-      timeout-minutes: 10
-      run: |
-        uv python install ${{ matrix.python-version }}
-        uv venv --python ${{ matrix.python-version }}
-        uv sync --all-extras --dev
-    -
-      name: Run tests
-      timeout-minutes: 10
-      run: |
-        set -euo pipefail
-        uv run pytest -m "not slow" tests --cov --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
-    -
-      name: Upload coverage to Codecov
-      timeout-minutes: 10
-      if: ${{ !cancelled() && env.CODECOV_TOKEN != '' }}
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-      with:
-        fail_ci_if_error: true # Fail the CI if an error occurs during the upload
-        token: ${{ env.CODECOV_TOKEN }}
-        flags: ${{ matrix.python-version }}
-        verbose: true # optional (default = false)
-    -
-      name: Upload test results to Codecov
-      timeout-minutes: 10
-      if: ${{ !cancelled() && env.CODECOV_TOKEN != '' }}
-      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-      with:
-        token: ${{ env.CODECOV_TOKEN }}

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -4,80 +4,18 @@ on:
   repository_dispatch:
     types: [edge-build]
 
-env:
-  GHCR_REGISTRY: ghcr.io
-  IMAGE_NAME: opencadc/canfar
-  IMAGE_TAG: edge
-
 permissions:
   contents: read
 
 jobs:
   edge-build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    uses: ./.github/workflows/reusable-container.yml
     permissions:
       packages: write
       attestations: write
       id-token: write
-    steps:
-      - name: Harden Runner
-        timeout-minutes: 10
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: audit
-
-      -
-        name: Client Payload
-        timeout-minutes: 10
-        run: |
-          echo "Client Payload: ${{ toJson(github.event.client_payload) }}"
-      -
-        name: Checkout Code
-        timeout-minutes: 10
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      -
-        name: Setup Docker Buildx
-        timeout-minutes: 10
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-        with:
-          install: true
-      -
-        name: Perform GHCR Login
-        timeout-minutes: 10
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Build & Push Docker Image
-        timeout-minutes: 10
-        id: build
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          target: production
-          file: Dockerfile
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          provenance: mode=max
-          sbom: true
-          push: true
-          labels: |
-            org.opencontainers.image.title=canfar
-            org.opencontainers.image.version=edge
-            org.opencontainers.image.description='Python Client for CANFAR Science Platform'
-            org.opencontainers.image.licenses=AGPL-3.0
-            org.opencontainers.image.source=https://github.com/opencadc/canfar
-          tags: |
-            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
-      -
-        name: Attest GHCR Container Image
-        timeout-minutes: 10
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
-        with:
-          subject-name: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.build.outputs.digest }}
-          push-to-registry: true
+    with:
+      client-payload: ${{ toJson(github.event.client_payload) }}
+      image-description: Python Client for CANFAR Science Platform
+      image-tags: ghcr.io/opencadc/canfar:edge
+      image-version: edge

--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -13,88 +13,11 @@ permissions: read-all
 jobs:
   tests:
     if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
-    env:
+    uses: ./.github/workflows/reusable-tests.yml
+    with:
+      full-suite: true
+    secrets:
       CANFAR_BASEURL: ${{ secrets.CANFAR_BASEURL }}
       CANFAR_USERNAME: ${{ secrets.CANFAR_USERNAME }}
       CANFAR_PASSWORD: ${{ secrets.CANFAR_PASSWORD }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-    steps:
-    - name: Harden Runner
-      timeout-minutes: 10
-      uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-      with:
-        egress-policy: audit
-
-    -
-      name: Setup code repository
-      timeout-minutes: 10
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        fetch-depth: 1
-    -
-      name: Setup uv
-      timeout-minutes: 10
-      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-      with:
-        enable-cache: true
-    -
-      name: Setup Python ${{ matrix.python-version }}
-      timeout-minutes: 10
-      run: |
-        uv python install ${{ matrix.python-version }}
-        uv venv --python ${{ matrix.python-version }}
-        uv sync --all-extras --dev
-    -
-      name: Verify CANFAR credentials
-      timeout-minutes: 10
-      run: |
-        set -euo pipefail
-        if [ -z "${CANFAR_BASEURL}" ] || [ -z "${CANFAR_USERNAME}" ] || [ -z "${CANFAR_PASSWORD}" ]; then
-          echo "CANFAR credentials are required for the full test suite" >&2
-          exit 1
-        fi
-    -
-      name: Login to CANFAR
-      timeout-minutes: 10
-      run: |
-        set -euo pipefail
-        printf "machine %s\n  login %s\n  password %s\n" "${CANFAR_BASEURL}" "${CANFAR_USERNAME}" "${CANFAR_PASSWORD}" > ~/.netrc
-        uv run cadc-get-cert --days-valid 1 --netrc-file ~/.netrc
-        rm ~/.netrc
-        test -f "${HOME}/.ssl/cadcproxy.pem"
-    -
-      name: Run full test suite
-      timeout-minutes: 10
-      run: |
-        set -euo pipefail
-        CANFAR_TEST_HOME="$HOME" uv run pytest --cov --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
-    -
-      name: Remove CANFAR Certificate
-      timeout-minutes: 10
-      if: always()
-      run: |
-        rm -rf ~/.ssl/
-    -
-      name: Upload coverage to Codecov
-      timeout-minutes: 10
-      if: ${{ !cancelled() && env.CODECOV_TOKEN != '' }}
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-      with:
-        fail_ci_if_error: true # Fail the CI if an error occurs during the upload
-        token: ${{ env.CODECOV_TOKEN }}
-        flags: ${{ matrix.python-version }}
-        verbose: true # optional (default = false)
-    -
-      name: Upload test results to Codecov
-      timeout-minutes: 10
-      if: ${{ !cancelled() && env.CODECOV_TOKEN != '' }}
-      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-      with:
-        token: ${{ env.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,84 +4,21 @@ on:
   repository_dispatch:
     types: [release-build]
 
-env:
-  GHCR_REGISTRY: ghcr.io
-  IMAGE_NAME: opencadc/canfar
-  IMAGE_TAG_LATEST: latest
-  IMAGE_TAG_RELEASE: ${{ github.event.client_payload.tag_name }}
-
 permissions:
   contents: read
 
 jobs:
   release-build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    uses: ./.github/workflows/reusable-container.yml
     permissions:
       packages: write # Upload package to ghcr.io
       attestations: write # Attest the build provenance
       id-token: write # Genereate OIDC token for attestations
-    steps:
-      - name: Harden Runner
-        timeout-minutes: 10
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: audit
-
-      -
-        name: Client Payload
-        timeout-minutes: 10
-        run: |
-          echo "Client Payload: ${{ toJson(github.event.client_payload) }}"
-      -
-        name: Checkout Code
-        timeout-minutes: 10
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.event.client_payload.tag_name }}
-      -
-        name: Setup Docker Buildx
-        timeout-minutes: 10
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-        with:
-          install: true
-      -
-        name: Perform GHCR Login
-        timeout-minutes: 10
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Build & Push Docker Image
-        timeout-minutes: 10
-        id: build
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          target: production
-          file: Dockerfile
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          provenance: mode=max
-          sbom: true
-          push: true
-          labels: |
-            org.opencontainers.image.title=canfar
-            org.opencontainers.image.version=${{ env.IMAGE_TAG_RELEASE }}
-            org.opencontainers.image.description='Python Client for CANFAR Science Portal'
-            org.opencontainers.image.licenses=AGPL-3.0
-            org.opencontainers.image.source=https://github.com/opencadc/canfar
-          tags: |
-            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG_RELEASE }}
-            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG_LATEST }}
-      -
-        name: Attest GHCR Container Image
-        timeout-minutes: 10
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
-        with:
-          subject-name: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.build.outputs.digest }}
-          push-to-registry: true
+    with:
+      client-payload: ${{ toJson(github.event.client_payload) }}
+      checkout-ref: ${{ github.event.client_payload.tag_name }}
+      image-description: Python Client for CANFAR Science Portal
+      image-tags: |
+        ghcr.io/opencadc/canfar:${{ github.event.client_payload.tag_name }}
+        ghcr.io/opencadc/canfar:latest
+      image-version: ${{ github.event.client_payload.tag_name }}

--- a/.github/workflows/reusable-container.yml
+++ b/.github/workflows/reusable-container.yml
@@ -1,0 +1,101 @@
+name: Reusable Container Build
+
+on:
+  workflow_call:
+    inputs:
+      checkout-ref:
+        type: string
+        required: false
+        default: ''
+      client-payload:
+        type: string
+        required: true
+      image-description:
+        type: string
+        required: true
+      image-tags:
+        type: string
+        required: true
+      image-version:
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+env:
+  GHCR_REGISTRY: ghcr.io
+  IMAGE_NAME: opencadc/canfar
+
+jobs:
+  container-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+    - name: Harden Runner
+      timeout-minutes: 10
+      uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+      with:
+        egress-policy: audit
+
+    -
+      name: Client Payload
+      timeout-minutes: 10
+      env:
+        CLIENT_PAYLOAD: ${{ inputs.client-payload }}
+      run: |
+        echo "Client Payload: ${CLIENT_PAYLOAD}"
+    -
+      name: Checkout Code
+      timeout-minutes: 10
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        ref: ${{ inputs.checkout-ref }}
+    -
+      name: Setup Docker Buildx
+      timeout-minutes: 10
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      with:
+        install: true
+    -
+      name: Perform GHCR Login
+      timeout-minutes: 10
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    -
+      name: Build & Push Docker Image
+      timeout-minutes: 10
+      id: build
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+      with:
+        context: .
+        target: production
+        file: Dockerfile
+        platforms: linux/amd64,linux/arm64
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        provenance: mode=max
+        sbom: true
+        push: true
+        labels: |
+          org.opencontainers.image.title=canfar
+          org.opencontainers.image.version=${{ inputs.image-version }}
+          org.opencontainers.image.description='${{ inputs.image-description }}'
+          org.opencontainers.image.licenses=AGPL-3.0
+          org.opencontainers.image.source=https://github.com/opencadc/canfar
+        tags: ${{ inputs.image-tags }}
+    -
+      name: Attest GHCR Container Image
+      timeout-minutes: 10
+      uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+      with:
+        subject-name: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
+        subject-digest: ${{ steps.build.outputs.digest }}
+        push-to-registry: true

--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -1,0 +1,118 @@
+name: Reusable Python Tests
+
+on:
+  workflow_call:
+    inputs:
+      full-suite:
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      CANFAR_BASEURL:
+        required: false
+      CANFAR_USERNAME:
+        required: false
+      CANFAR_PASSWORD:
+        required: false
+      CODECOV_TOKEN:
+        required: false
+
+permissions: read-all
+
+jobs:
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    env:
+      CANFAR_BASEURL: ${{ secrets.CANFAR_BASEURL }}
+      CANFAR_USERNAME: ${{ secrets.CANFAR_USERNAME }}
+      CANFAR_PASSWORD: ${{ secrets.CANFAR_PASSWORD }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    steps:
+    - name: Harden Runner
+      timeout-minutes: 10
+      uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+      with:
+        egress-policy: audit
+
+    -
+      name: Setup code repository
+      timeout-minutes: 10
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        fetch-depth: 1
+    -
+      name: Setup uv
+      timeout-minutes: 10
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      with:
+        enable-cache: true
+    -
+      name: Setup Python ${{ matrix.python-version }}
+      timeout-minutes: 10
+      run: |
+        uv python install ${{ matrix.python-version }}
+        uv venv --python ${{ matrix.python-version }}
+        uv sync --all-extras --dev
+    -
+      name: Verify CANFAR credentials
+      timeout-minutes: 10
+      if: ${{ inputs.full-suite }}
+      run: |
+        set -euo pipefail
+        if [ -z "${CANFAR_BASEURL}" ] || [ -z "${CANFAR_USERNAME}" ] || [ -z "${CANFAR_PASSWORD}" ]; then
+          echo "CANFAR credentials are required for the full test suite" >&2
+          exit 1
+        fi
+    -
+      name: Login to CANFAR
+      timeout-minutes: 10
+      if: ${{ inputs.full-suite }}
+      run: |
+        set -euo pipefail
+        printf "machine %s\n  login %s\n  password %s\n" "${CANFAR_BASEURL}" "${CANFAR_USERNAME}" "${CANFAR_PASSWORD}" > ~/.netrc
+        uv run cadc-get-cert --days-valid 1 --netrc-file ~/.netrc
+        rm ~/.netrc
+        test -f "${HOME}/.ssl/cadcproxy.pem"
+    -
+      name: Run fast test suite
+      timeout-minutes: 10
+      if: ${{ !inputs.full-suite }}
+      run: |
+        set -euo pipefail
+        uv run pytest -m "not slow" tests --cov --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
+    -
+      name: Run full test suite
+      timeout-minutes: 10
+      if: ${{ inputs.full-suite }}
+      run: |
+        set -euo pipefail
+        CANFAR_TEST_HOME="$HOME" uv run pytest --cov --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
+    -
+      name: Remove CANFAR Certificate
+      timeout-minutes: 10
+      if: ${{ always() && inputs.full-suite }}
+      run: |
+        rm -rf ~/.ssl/
+    -
+      name: Upload coverage to Codecov
+      timeout-minutes: 10
+      if: ${{ !cancelled() && env.CODECOV_TOKEN != '' }}
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      with:
+        fail_ci_if_error: true # Fail CI if an error occurs during the upload
+        token: ${{ env.CODECOV_TOKEN }}
+        flags: ${{ matrix.python-version }}
+        verbose: true # optional (default = false)
+    -
+      name: Upload test results to Codecov
+      timeout-minutes: 10
+      if: ${{ !cancelled() && env.CODECOV_TOKEN != '' }}
+      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+      with:
+        token: ${{ env.CODECOV_TOKEN }}

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -22,24 +22,174 @@ def run_commands(workflow: dict) -> list[str]:
     ]
 
 
-def test_pull_requests_use_the_fast_suite_for_maintained_branches():
-    workflow = load_workflow("ci.yml")
+def test_fast_and_full_test_workflows_delegate_to_one_explicit_contract():
+    fast = load_workflow("ci.yml")
+    full = load_workflow("full-tests.yml")
+
+    fast_job = fast["jobs"]["tests"]
+    full_job = full["jobs"]["tests"]
+
+    assert fast_job["uses"] == "./.github/workflows/reusable-tests.yml"
+    assert fast_job["with"] == {"full-suite": False}
+    assert fast_job["secrets"] == {
+        "CODECOV_TOKEN": "${{ secrets.CODECOV_TOKEN }}",
+    }
+    assert fast_job["needs"] == "pre-commit-checks"
+
+    assert full_job["uses"] == "./.github/workflows/reusable-tests.yml"
+    assert full_job["with"] == {"full-suite": True}
+    assert full_job["secrets"] == {
+        "CANFAR_BASEURL": "${{ secrets.CANFAR_BASEURL }}",
+        "CANFAR_USERNAME": "${{ secrets.CANFAR_USERNAME }}",
+        "CANFAR_PASSWORD": "${{ secrets.CANFAR_PASSWORD }}",
+        "CODECOV_TOKEN": "${{ secrets.CODECOV_TOKEN }}",
+    }
+
+
+def test_reusable_tests_preserve_fast_and_credentialed_commands():
+    workflow = load_workflow("reusable-tests.yml")
     events = workflow_events(workflow)
     commands = "\n".join(run_commands(workflow))
 
+    assert events["workflow_call"]["inputs"]["full-suite"] == {
+        "default": False,
+        "required": False,
+        "type": "boolean",
+    }
+    assert set(events["workflow_call"]["secrets"]) == {
+        "CANFAR_BASEURL",
+        "CANFAR_USERNAME",
+        "CANFAR_PASSWORD",
+        "CODECOV_TOKEN",
+    }
+    assert 'uv run pytest -m "not slow" tests' in commands
+    assert 'CANFAR_TEST_HOME="$HOME" uv run pytest' in commands
+    assert "uv run cadc-get-cert" in commands
+    assert "CANFAR credentials are required for the full test suite" in commands
+    assert "rm -rf ~/.ssl/" in commands
+
+    fast_step = next(
+        step
+        for step in workflow["jobs"]["tests"]["steps"]
+        if step.get("name") == "Run fast test suite"
+    )
+    full_step = next(
+        step
+        for step in workflow["jobs"]["tests"]["steps"]
+        if step.get("name") == "Run full test suite"
+    )
+    verify_step = next(
+        step
+        for step in workflow["jobs"]["tests"]["steps"]
+        if step.get("name") == "Verify CANFAR credentials"
+    )
+    login_step = next(
+        step
+        for step in workflow["jobs"]["tests"]["steps"]
+        if step.get("name") == "Login to CANFAR"
+    )
+    cleanup_step = next(
+        step
+        for step in workflow["jobs"]["tests"]["steps"]
+        if step.get("name") == "Remove CANFAR Certificate"
+    )
+    assert fast_step["if"] == "${{ !inputs.full-suite }}"
+    assert full_step["if"] == "${{ inputs.full-suite }}"
+    assert verify_step["if"] == "${{ inputs.full-suite }}"
+    assert login_step["if"] == "${{ inputs.full-suite }}"
+    assert cleanup_step["if"] == "${{ always() && inputs.full-suite }}"
+    assert '-m "not slow"' not in full_step["run"]
+
+
+def test_release_and_edge_delegate_to_one_container_build_contract():
+    release = load_workflow("release.yml")
+    edge = load_workflow("edge.yml")
+
+    assert workflow_events(release) == {
+        "repository_dispatch": {"types": ["release-build"]},
+    }
+    assert workflow_events(edge) == {
+        "repository_dispatch": {"types": ["edge-build"]},
+    }
+
+    release_job = release["jobs"]["release-build"]
+    edge_job = edge["jobs"]["edge-build"]
+    assert release_job["uses"] == "./.github/workflows/reusable-container.yml"
+    assert edge_job["uses"] == "./.github/workflows/reusable-container.yml"
+    assert (
+        release_job["permissions"]
+        == edge_job["permissions"]
+        == {
+            "packages": "write",
+            "attestations": "write",
+            "id-token": "write",
+        }
+    )
+    assert release_job["with"]["checkout-ref"] == (
+        "${{ github.event.client_payload.tag_name }}"
+    )
+    assert "checkout-ref" not in edge_job["with"]
+    assert release_job["with"]["image-version"] == (
+        "${{ github.event.client_payload.tag_name }}"
+    )
+    assert edge_job["with"]["image-version"] == "edge"
+    assert release_job["with"]["image-description"] == (
+        "Python Client for CANFAR Science Portal"
+    )
+    assert edge_job["with"]["image-description"] == (
+        "Python Client for CANFAR Science Platform"
+    )
+    assert release_job["with"]["image-tags"].strip().endswith(":latest")
+    assert edge_job["with"]["image-tags"].strip().endswith(":edge")
+
+
+def test_reusable_container_preserves_build_and_attestation_guards():
+    workflow = load_workflow("reusable-container.yml")
+    events = workflow_events(workflow)
+    job = workflow["jobs"]["container-build"]
+    steps = {step["name"]: step for step in job["steps"]}
+
+    assert set(events["workflow_call"]["inputs"]) == {
+        "checkout-ref",
+        "client-payload",
+        "image-description",
+        "image-tags",
+        "image-version",
+    }
+    assert workflow["permissions"] == {"contents": "read"}
+    assert job["permissions"] == {
+        "packages": "write",
+        "attestations": "write",
+        "id-token": "write",
+    }
+    assert steps["Build & Push Docker Image"]["uses"].startswith(
+        "docker/build-push-action@"
+    )
+    build_with = steps["Build & Push Docker Image"]["with"]
+    assert build_with["platforms"] == "linux/amd64,linux/arm64"
+    assert build_with["provenance"] == "mode=max"
+    assert build_with["sbom"] is True
+    assert build_with["push"] is True
+
+    attest = steps["Attest GHCR Container Image"]
+    assert attest["uses"].startswith("actions/attest-build-provenance@")
+    assert attest["with"]["push-to-registry"] is True
+    assert attest["with"]["subject-digest"] == "${{ steps.build.outputs.digest }}"
+
+
+def test_pull_requests_use_the_fast_suite_for_maintained_branches():
+    workflow = load_workflow("ci.yml")
+    events = workflow_events(workflow)
+
     assert set(events["pull_request"]["branches"]) == {"main", "feat/interfaces"}
     assert "paths-ignore" not in events["pull_request"]
-    assert 'uv run pytest -m "not slow" tests' in commands
-    assert not any(
-        line.strip().startswith("uv run pytest") and '-m "not slow"' not in line
-        for line in commands.splitlines()
-    )
+    assert workflow["jobs"]["tests"]["uses"] == "./.github/workflows/reusable-tests.yml"
+    assert workflow["jobs"]["tests"]["with"] == {"full-suite": False}
 
 
 def test_full_suite_is_limited_to_merged_code_prs_into_main():
     workflow = load_workflow("full-tests.yml")
     events = workflow_events(workflow)
-    commands = "\n".join(run_commands(workflow))
 
     assert set(events) == {"pull_request_target"}
     assert events["pull_request_target"] == {
@@ -52,24 +202,11 @@ def test_full_suite_is_limited_to_merged_code_prs_into_main():
         "github.event.pull_request.base.ref == 'main'"
         in workflow["jobs"]["tests"]["if"]
     )
-    assert workflow["jobs"]["tests"]["env"] == {
+    assert workflow["jobs"]["tests"]["uses"] == "./.github/workflows/reusable-tests.yml"
+    assert workflow["jobs"]["tests"]["with"] == {"full-suite": True}
+    assert workflow["jobs"]["tests"]["secrets"] == {
         "CANFAR_BASEURL": "${{ secrets.CANFAR_BASEURL }}",
         "CANFAR_USERNAME": "${{ secrets.CANFAR_USERNAME }}",
         "CANFAR_PASSWORD": "${{ secrets.CANFAR_PASSWORD }}",
         "CODECOV_TOKEN": "${{ secrets.CODECOV_TOKEN }}",
     }
-    assert (
-        'if [ -z "${CANFAR_BASEURL}" ] || [ -z "${CANFAR_USERNAME}" ] '
-        '|| [ -z "${CANFAR_PASSWORD}" ]; then'
-    ) in commands
-    assert "CANFAR credentials are required for the full test suite" in commands
-    login_step = next(
-        step
-        for step in workflow["jobs"]["tests"]["steps"]
-        if step.get("name") == "Login to CANFAR"
-    )
-    assert "if" not in login_step
-    assert 'CANFAR_TEST_HOME="$HOME" uv run pytest' in commands
-    assert "uv run cadc-get-cert" in commands
-    assert "rm -rf ~/.ssl/" in commands
-    assert '-m "not slow"' not in commands


### PR DESCRIPTION
Implements #248 as part of #244.

- shares fast and trusted post-merge Python test setup through an explicit reusable workflow
- shares identical edge/release container build implementation
- preserves event-specific wrappers, least-privilege permissions, secrets, BuildKit provenance/SBOM, attestations, triggers, and failure semantics
- leaves distinct security workflows unchanged

TDD and validation:
- workflow contract tests failed before reusable calls existed, then passed
- 6 focused workflow tests pass
- Actionlint passes
- Ruff and ty pass
- 832 deterministic non-slow tests pass

Base: `feat/interfaces`; this does not target `main` directly.