### PR TITLE
refactor: apply Wave 1 simplify review

### DIFF
--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -25,8 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
       CANFAR_BASEURL: ${{ secrets.CANFAR_BASEURL }}

--- a/canfar/config/editor.py
+++ b/canfar/config/editor.py
@@ -60,10 +60,6 @@ def get_value(config: Configuration, path: str) -> Any:
 def set_value(config: Configuration, path: str, value: Any) -> Configuration:
     """Return a new validated configuration with a dotted-path value updated."""
     segments = _parse_dotted_path(path)
-    if not segments:
-        msg = "Path cannot be empty"
-        raise ValueError(msg)
-
     data = config.model_dump(mode="python")
     cursor: Any = data
 

--- a/canfar/sessions.py
+++ b/canfar/sessions.py
@@ -68,56 +68,14 @@ def _view_parameters(view: str) -> dict[str, str]:
     return {"view": view}
 
 
-def _create_request(  # noqa: PLR0917
-    name: str | CreateRequest,
-    image: str | None,
-    cores: int | None,
-    ram: int | None,
-    kind: Kind,
-    gpu: int | None,
-    cmd: str | None,
-    args: str | None,
-    env: dict[str, Any] | None,
-    replicas: int,
-) -> CreateRequest:
-    """Normalize scalar create arguments to the domain request model."""
-    if isinstance(name, CreateRequest):
-        return name
-    if image is None:
-        msg = "image is required when creating a Session from scalar arguments"
-        raise TypeError(msg)
-    return CreateRequest(
-        name=name,
-        image=image,
-        cores=cores,
-        ram=ram,
-        kind=kind,
-        gpus=gpu,
-        cmd=cmd,
-        args=args,
-        env=env,
-        replicas=replicas,
-    )
-
-
-def _response_json(response: Response) -> Any:
-    """Interpret a JSON response through the shared Session policy."""
-    return response.json()
-
-
-def _response_text(response: Response) -> str:
-    """Interpret a text response through the shared Session policy."""
-    return response.text
-
-
 def _response_session_id(response: Response) -> str:
     """Interpret a create response as a clean Session identifier."""
-    return _response_text(response).rstrip("\r\n")
+    return response.text.rstrip("\r\n")
 
 
 def _response_event(session_id: str, response: Response) -> dict[str, str]:
     """Interpret an events response with its requested Session identifier."""
-    return {session_id: _response_text(response)}
+    return {session_id: response.text}
 
 
 def _session_name_pattern(selector: str) -> re.Pattern[str]:
@@ -202,7 +160,7 @@ class Session(HTTPClient):
         """
         parameters: dict[str, Any] = build.fetch_parameters(kind, status, view)
         response: Response = self.client.get(url="session", params=parameters)
-        data: list[dict[str, str]] = _response_json(response)
+        data: list[dict[str, str]] = response.json()
         return data
 
     def stats(self) -> dict[str, Any]:
@@ -222,7 +180,7 @@ class Session(HTTPClient):
         """
         parameters = _view_parameters("stats")
         response: Response = self.client.get("session", params=parameters)
-        data: dict[str, Any] = _response_json(response)
+        data: dict[str, Any] = response.json()
         return data
 
     def info(self, ids: list[str] | str) -> list[dict[str, Any]]:
@@ -243,7 +201,7 @@ class Session(HTTPClient):
         for value in ids:
             try:
                 response: Response = self.client.get(url=_session_url(value))
-                results.append(_response_json(response))
+                results.append(response.json())
             except HTTPError as err:
                 _task_result("failed to fetch session info for", value, err)
         return results
@@ -276,7 +234,7 @@ class Session(HTTPClient):
                     url=_session_url(value),
                     params=parameters,
                 )
-                results[value] = _response_text(response)
+                results[value] = response.text
             except HTTPError as err:
                 _task_result("failed to fetch logs for session", value, err)
 
@@ -348,7 +306,7 @@ class Session(HTTPClient):
                 )
             >>> ["hjko98yghj", "ikvp1jtp"]
         """
-        request = _create_request(
+        payloads = build.create_parameters(
             name,
             image,
             cores,
@@ -360,9 +318,8 @@ class Session(HTTPClient):
             env,
             replicas,
         )
-        payloads = build.create_parameters(request)
         results: list[str] = []
-        session_kind = request.kind
+        session_kind = name.kind if isinstance(name, CreateRequest) else kind
         log.debug("Creating %d %s session[s].", len(payloads), session_kind)
         for replica, payload in enumerate(payloads, start=1):
             try:
@@ -577,7 +534,7 @@ class AsyncSession(HTTPClient):
         """
         parameters: dict[str, Any] = build.fetch_parameters(kind, status, view)
         response: Response = await self.asynclient.get(url="session", params=parameters)
-        data: list[dict[str, str]] = _response_json(response)
+        data: list[dict[str, str]] = response.json()
         return data
 
     async def stats(self) -> dict[str, Any]:
@@ -597,7 +554,7 @@ class AsyncSession(HTTPClient):
         """
         parameters = _view_parameters("stats")
         response: Response = await self.asynclient.get("session", params=parameters)
-        data: dict[str, Any] = _response_json(response)
+        data: dict[str, Any] = response.json()
         return data
 
     async def info(self, ids: list[str] | str) -> list[dict[str, Any]]:
@@ -620,7 +577,7 @@ class AsyncSession(HTTPClient):
 
         async def request(value: str) -> dict[str, Any]:
             response = await self.asynclient.get(url=_session_url(value))
-            data: dict[str, Any] = _response_json(response)
+            data: dict[str, Any] = response.json()
             return data
 
         tasks = [request(value) for value in ids]
@@ -661,7 +618,7 @@ class AsyncSession(HTTPClient):
                 url=_session_url(value),
                 params=parameters,
             )
-            return value, _response_text(response)
+            return value, response.text
 
         tasks = [request(value) for value in ids]
         responses = await asyncio.gather(*tasks, return_exceptions=True)
@@ -738,7 +695,7 @@ class AsyncSession(HTTPClient):
                 )
             >>> ["hjko98yghj", "ikvp1jtp"]
         """
-        request = _create_request(
+        payloads: list[list[tuple[str, Any]]] = build.create_parameters(
             name,
             image,
             cores,
@@ -750,7 +707,6 @@ class AsyncSession(HTTPClient):
             env,
             replicas,
         )
-        payloads: list[list[tuple[str, Any]]] = build.create_parameters(request)
         results: list[str] = []
 
         async def request_session(parameters: list[tuple[str, Any]]) -> str:
@@ -758,7 +714,7 @@ class AsyncSession(HTTPClient):
             return _response_session_id(response)
 
         tasks = [request_session(payload) for payload in payloads]
-        session_kind = request.kind
+        session_kind = name.kind if isinstance(name, CreateRequest) else kind
         msg = f"Creating {len(payloads)} {session_kind} session[s]."
         log.debug(msg)
         responses = await asyncio.gather(*tasks, return_exceptions=True)

--- a/docs/platform/community/alma/index.md
+++ b/docs/platform/community/alma/index.md
@@ -14,7 +14,7 @@ Science Portal layout changes.
 - A persistent destination: use `/arc/home/[username]` for personal files or
   `/arc/projects/[project]` for shared work. Treat `/scratch` as temporary;
   it is suitable for fast intermediate files, not final results.
-- A Session type that matches the task: use **Desktop** for CASA and other GUI
+- A Session Kind that matches the task: use **Desktop** for CASA and other GUI
   applications, **Notebook** for Python-based analysis, and **CARTA** for
   inspecting images and spectral cubes.
 - Optional command-line access. Install the shipped client and log in:
@@ -94,7 +94,7 @@ lists version-specific package notes and known issues.
 
 Open calibrated measurement sets or image products from a CARTA Session when
 you need cube navigation, spectra, regions, or moment-map inspection. Use a
-Notebook Session for Python analysis. Both Session types can read files saved
+Notebook Session for Python analysis. Both Session Kinds can read files saved
 under `/arc/home/[username]` and `/arc/projects/[project]`.
 
 For a local or scripted check, list the result before opening it:
@@ -150,7 +150,7 @@ At the end of the workflow:
 | --- | --- |
 | Login fails or credentials are stale | Run `canfar --log-level debug login cadc --force`, then `canfar auth show`. |
 | No suitable image appears | Run `canfar image ls --kind desktop` (or `--kind notebook`/`--kind carta`) and choose an image that includes the required software. |
-| Session remains pending | Run `canfar ps --all`, `canfar events [session-id]`, and `canfar stats`; reduce requested resources if the cluster has no capacity. |
+| Session remains pending | Run `canfar ps --all`, `canfar events [session-id]`, and `canfar stats`; reduce requested resources if the Science Platform Server has no capacity. |
 | A data copy fails | Confirm the `local:`, `arc:`, or `vault:` source and destination with `canfar data ls`; check that the active Authentication can access the target. |
 | Files disappear after the Session ends | Move them from `/scratch` to `/arc/home/[username]` or `/arc/projects/[project]` before deleting the Session. |
 | A shared project path is denied | Ask the project administrator to add your CADC account to the project group; see [Permissions](../../permissions.md). |

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -22,30 +22,6 @@ def run_commands(workflow: dict) -> list[str]:
     ]
 
 
-def test_fast_and_full_test_workflows_delegate_to_one_explicit_contract():
-    fast = load_workflow("ci.yml")
-    full = load_workflow("full-tests.yml")
-
-    fast_job = fast["jobs"]["tests"]
-    full_job = full["jobs"]["tests"]
-
-    assert fast_job["uses"] == "./.github/workflows/reusable-tests.yml"
-    assert fast_job["with"] == {"full-suite": False}
-    assert fast_job["secrets"] == {
-        "CODECOV_TOKEN": "${{ secrets.CODECOV_TOKEN }}",
-    }
-    assert fast_job["needs"] == "pre-commit-checks"
-
-    assert full_job["uses"] == "./.github/workflows/reusable-tests.yml"
-    assert full_job["with"] == {"full-suite": True}
-    assert full_job["secrets"] == {
-        "CANFAR_BASEURL": "${{ secrets.CANFAR_BASEURL }}",
-        "CANFAR_USERNAME": "${{ secrets.CANFAR_USERNAME }}",
-        "CANFAR_PASSWORD": "${{ secrets.CANFAR_PASSWORD }}",
-        "CODECOV_TOKEN": "${{ secrets.CODECOV_TOKEN }}",
-    }
-
-
 def test_reusable_tests_preserve_fast_and_credentialed_commands():
     workflow = load_workflow("reusable-tests.yml")
     events = workflow_events(workflow)
@@ -183,8 +159,13 @@ def test_pull_requests_use_the_fast_suite_for_maintained_branches():
 
     assert set(events["pull_request"]["branches"]) == {"main", "feat/interfaces"}
     assert "paths-ignore" not in events["pull_request"]
-    assert workflow["jobs"]["tests"]["uses"] == "./.github/workflows/reusable-tests.yml"
-    assert workflow["jobs"]["tests"]["with"] == {"full-suite": False}
+    job = workflow["jobs"]["tests"]
+    assert job["uses"] == "./.github/workflows/reusable-tests.yml"
+    assert job["with"] == {"full-suite": False}
+    assert job["needs"] == "pre-commit-checks"
+    assert job["secrets"] == {
+        "CODECOV_TOKEN": "${{ secrets.CODECOV_TOKEN }}",
+    }
 
 
 def test_full_suite_is_limited_to_merged_code_prs_into_main():


### PR DESCRIPTION
Applies the accepted Wave 1 review corrections for #244.

- removes duplicate Session request normalization and no-op response wrappers
- routes both native transports through the existing request builder without changing signatures or return shapes
- removes the one-value CI runner matrix and duplicate workflow assertions
- removes an unreachable Configuration editor guard
- corrects ALMA glossary terminology

Review conflict resolved against the confirmed epic decision: numeric dotted-path/list indexing remains rejected; whole-list reads remain supported. The old Configuration service methods are internal and this PR does not restore `auths.0`.

Validation:
- 38 focused tests pass
- 839 deterministic non-slow tests pass
- Ruff and ty pass
- Actionlint pre-commit hook passes
- MkDocs build passes

Base: `feat/interfaces`; this does not target `main` directly.