### PR TITLE
refactor(server): own selection mutations

### DIFF
--- a/canfar/authentication.py
+++ b/canfar/authentication.py
@@ -112,7 +112,7 @@ def use(idp: str) -> None:
             hint="Run canfar.login() for this IDP before selecting it.",
         ) from exc
 
-    _select_authentication(config, idp)
+    server_service.activate_authentication(idp, config=config)
 
 
 def list() -> builtins.list[Authentication]:  # noqa: A001

--- a/canfar/server.py
+++ b/canfar/server.py
@@ -198,9 +198,9 @@ def discover(
         canonical[name]
         for name in sorted(canonical, key=lambda value: (value.casefold(), value))
     ]
-    target_config.upsert_servers(merged)
+    _store_discovered_servers(target_config, merged)
     if save:
-        target_config.save()
+        target_config.editor.save()
     return merged
 
 
@@ -240,8 +240,8 @@ def activate(
     if selector is None:
         active_server = _active_server_for_idp(target_config, idp)
         if active_server is not None:
-            target_config.set_active_selection(idp, active_server)
-            target_config.save()
+            _store_active_selection(target_config, idp, active_server)
+            target_config.editor.save()
             return ServerActivation(server=active_server, reason="active")
 
         servers = _servers_for_idp(target_config, idp)
@@ -255,11 +255,11 @@ def activate(
             )
 
         remembered = _remembered_server_for_idp(target_config, idp, servers)
-        if remembered is not None and remembered.uri is not None:
-            selector = str(remembered.uri)
+        if remembered is not None and remembered.name is not None:
+            selector = remembered.name
             reason = "remembered"
-        elif len(servers) == 1 and servers[0].uri is not None:
-            selector = str(servers[0].uri)
+        elif len(servers) == 1 and servers[0].name is not None:
+            selector = servers[0].name
             reason = "single"
         else:
             raise ServerSelectionRequiredError(idp, servers)
@@ -290,9 +290,34 @@ def activate(
         dev=dev,
         timeout=timeout,
     )
-    target_config.set_active_selection(idp, validated)
-    target_config.save()
+    _store_active_selection(target_config, idp, validated)
+    target_config.editor.save()
     return ServerActivation(server=validated, reason=reason)
+
+
+def activate_authentication(
+    idp: str,
+    *,
+    config: Configuration | None = None,
+) -> None:
+    """Activate an Authentication Record and its remembered Server Selection."""
+    target_config = config or Configuration()  # ty: ignore[missing-argument]
+    target_config.get_credential(idp)
+    servers = _servers_for_idp(target_config, idp)
+    remembered = _remembered_server_for_idp(target_config, idp, servers)
+    if remembered is not None:
+        _store_active_selection(target_config, idp, remembered)
+    else:
+        active_server = _active_server_for_idp(target_config, idp)
+        active = target_config.active.model_copy(
+            update={
+                "authentication": idp,
+                "server": active_server.name if active_server is not None else None,
+                "servers": _server_selection_history(target_config),
+            },
+        )
+        target_config.editor.set("active", active)
+    target_config.editor.save()
 
 
 def list_servers(
@@ -324,7 +349,7 @@ def list_servers(
         return servers
 
     discover(active_idp, config=config, dev=dev, timeout=timeout, save=False)
-    config.save()
+    config.editor.save()
     return [server for server in config.servers.values() if server.idp == active_idp]
 
 
@@ -364,9 +389,8 @@ def _servers_for_idp(config: Configuration, idp: str) -> list[Server]:
 def _active_server_for_idp(config: Configuration, idp: str) -> Server | None:
     if config.active.server is None:
         return None
-    try:
-        active_server = config.get_active_server()
-    except KeyError:
+    active_server = config.servers.get(config.active.server)
+    if active_server is None:
         return None
     if active_server.idp != idp:
         return None
@@ -378,14 +402,69 @@ def _remembered_server_for_idp(
     idp: str,
     servers: list[Server],
 ) -> Server | None:
-    remembered = config.get_remembered_server_for_idp(idp)
-    if remembered is None or remembered.uri is None:
+    name = _server_selection_history(config).get(idp)
+    if name is None:
         return None
-    if remembered.name is None:
+    remembered = config.servers.get(name)
+    if remembered is None or remembered.idp != idp:
         return None
-    if not any(server.name == remembered.name for server in servers):
+    if not any(server.name == name for server in servers):
         return None
     return remembered
+
+
+def _server_selection_history(config: Configuration) -> dict[str, str]:
+    """Return remembered Server Selections seeded by the active pair."""
+    selections = dict(config.active.servers)
+    active_name = config.active.server
+    if active_name is None:
+        return selections
+
+    active_server = config.servers.get(active_name)
+    if (
+        active_server is not None
+        and active_server.idp == config.active.authentication
+        and active_server.name is not None
+    ):
+        selections[config.active.authentication] = active_server.name
+    return selections
+
+
+def _store_discovered_servers(
+    config: Configuration,
+    servers: list[Server],
+) -> None:
+    """Merge discovered Science Platform Servers through the editor boundary."""
+    updated = dict(config.servers)
+    for server in servers:
+        if server.name is not None:
+            updated[server.name] = server
+    config.editor.set("servers", updated)
+
+
+def _store_active_selection(
+    config: Configuration,
+    idp: str,
+    server: Server,
+) -> None:
+    """Store a Server Selection and its history through the editor boundary."""
+    if server.name is None:
+        msg = "Server name is required for active selection."
+        raise ValueError(msg)
+
+    selected = server.model_copy(update={"idp": idp}, deep=True)
+    servers = {**config.servers, server.name: selected}
+    selections = _server_selection_history(config)
+    selections[idp] = server.name
+    active = config.active.model_copy(
+        update={
+            "authentication": idp,
+            "server": server.name,
+            "servers": selections,
+        },
+    )
+    config.editor.set("servers", servers)
+    config.editor.set("active", active)
 
 
 def _resolve_selector(

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -177,7 +177,19 @@ class TestAuthenticationUse:
         config_path = tmp_path / "config.yaml"
         _write_config(config_path, config_data)
 
-        with _patch_config(config_path):
+        with (
+            _patch_config(config_path),
+            patch.object(
+                canfar.models.config.Configuration,
+                "set_active_authentication",
+                side_effect=AssertionError("Platform owns Server Selection updates"),
+            ),
+            patch.object(
+                canfar.models.config.Configuration,
+                "save",
+                side_effect=AssertionError("persist through config.editor"),
+            ),
+        ):
             canfar.authentication.use("srcnet")
             config = canfar.models.config.Configuration()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -145,9 +145,125 @@ class TestServerList:
 
         assert servers == []
 
+    def test_discover_uses_editor_for_server_state_and_persistence(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Discovery updates and persists Servers through the editor boundary."""
+        discovered = _cadc_server(name="Discovered-CADC")
+        config_path = tmp_path / "config.yaml"
+
+        with (
+            patch("canfar.models.config.CONFIG_PATH", config_path),
+            patch("canfar.server._discover_for_idp", return_value=[discovered]),
+        ):
+            config = _anonymous_config()
+            with (
+                patch.object(
+                    Configuration,
+                    "upsert_servers",
+                    side_effect=AssertionError("discovery must use config.editor"),
+                ),
+                patch.object(
+                    Configuration,
+                    "save",
+                    side_effect=AssertionError("discovery must use config.editor"),
+                ),
+            ):
+                discover("cadc", config=config)
+
+            assert config.servers["Discovered-CADC"] == discovered
+            assert Configuration().servers["Discovered-CADC"] == discovered
+
 
 class TestServerUse:
     """Tests for canfar.server.use()."""
+
+    def test_activate_uses_editor_for_active_selection_and_history(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Activation records a Server Name through the editor boundary."""
+        target = _cadc_server(name="Selected-CADC")
+        fetched = target.model_copy(update={"cores": 8}, deep=True)
+        config_path = tmp_path / "config.yaml"
+
+        with patch("canfar.models.config.CONFIG_PATH", config_path):
+            config = _anonymous_config(target)
+            config.save()
+
+            with (
+                patch("canfar.server._validate_server", return_value=fetched),
+                patch.object(
+                    Configuration,
+                    "set_active_selection",
+                    side_effect=AssertionError("activation must use config.editor"),
+                ),
+                patch.object(
+                    Configuration,
+                    "save",
+                    side_effect=AssertionError("activation must use config.editor"),
+                ),
+            ):
+                activation = activate("cadc", "Selected-CADC", config=config)
+
+            assert activation.server == fetched
+            assert config.active.server == "Selected-CADC"
+            assert config.active.servers["cadc"] == "Selected-CADC"
+            saved = Configuration()
+
+        assert saved.active.server == "Selected-CADC"
+        assert saved.active.servers["cadc"] == "Selected-CADC"
+
+    def test_activate_resolves_remembered_selection_by_server_name(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Remembered Server Selection is resolved by Server Name, not URI."""
+        first = _cadc_server(name="First", uri=AnyUrl("ivo://first.example/skaha"))
+        remembered = _cadc_server(
+            name="Remembered",
+            uri=AnyUrl("ivo://remembered.example/skaha"),
+        )
+        config_path = tmp_path / "config.yaml"
+
+        with patch("canfar.models.config.CONFIG_PATH", config_path):
+            config = Configuration(
+                active=ActiveConfig(
+                    authentication="cadc",
+                    server=None,
+                    servers={"cadc": "Remembered"},
+                ),
+                authentication={"cadc": X509Credential(idp="cadc")},
+                servers={first.name: first, remembered.name: remembered},
+            )
+
+            with (
+                patch("canfar.server._validate_server", return_value=remembered),
+                patch.object(
+                    Configuration,
+                    "get_remembered_server_for_idp",
+                    side_effect=AssertionError(
+                        "remembered selection must be owned by Platform"
+                    ),
+                ),
+                patch.object(
+                    Configuration,
+                    "set_active_selection",
+                    side_effect=AssertionError("activation must use config.editor"),
+                ),
+                patch.object(
+                    Configuration,
+                    "save",
+                    side_effect=AssertionError("activation must use config.editor"),
+                ),
+            ):
+                activation = activate("cadc", config=config)
+
+        assert activation.reason == "remembered"
+        assert activation.server.name == "Remembered"
+        assert config.active.server == "Remembered"
+        assert config.active.servers["cadc"] == "Remembered"
 
     def test_use_by_uri_updates_active_server(self, tmp_path: Path) -> None:
         """Selecting by URI fetches, validates, and saves the active server."""


### PR DESCRIPTION
Implements #251 as part of #244.

Platform discovery/activation now owns Server Selection history and persists through `config.editor`; authentication selection delegates activation to that owner.

Compatibility retained:
- selection references Science Platform Servers by Server Name
- explicit URI selectors, metadata, history, active selection and Configuration shape
- #229 sentinel-signature proposal remains out of scope

Validation: 105 focused and 842 deterministic non-slow tests, Ruff and ty pass. Base is `feat/interfaces`; this does not target `main` directly.