### PR TITLE
refactor(auth): persist mutations through config editor

### DIFF
--- a/canfar/auth/oidc.py
+++ b/canfar/auth/oidc.py
@@ -249,10 +249,13 @@ def _persist(
         raise ValueError(msg) from None
 
     updated = credential.model_copy(update={"token": token, "expiry": expiry})
+    if credential.idp not in config.authentication:
+        msg = f"Authentication record for IDP '{credential.idp}' not found."
+        raise KeyError(msg)
     candidate = config.model_copy(deep=True)
-    candidate.update_credential(updated)
-    candidate.save()
-    config.update_credential(updated)
+    candidate.editor.set(f"authentication.{updated.idp}", updated)
+    candidate.editor.save()
+    config.editor.set(f"authentication.{updated.idp}", updated)
     return updated
 
 

--- a/canfar/authentication.py
+++ b/canfar/authentication.py
@@ -13,7 +13,12 @@ from canfar.models.auth import (
     AuthMode,
     X509Credential,
 )
-from canfar.models.config import Configuration
+from canfar.models.config import (
+    Configuration,
+    default_active,
+    default_authentication,
+    default_servers,
+)
 
 if TYPE_CHECKING:
     import builtins
@@ -78,9 +83,9 @@ def login(idp: str, force: bool = False) -> None:
         return
 
     credential = _authenticate(idp_info)
-    config.upsert_credential(credential)
+    config.editor.set(f"authentication.{credential.idp}", credential)
     server_service.discover(idp, config=config, save=False)
-    config.save()
+    config.editor.save()
 
 
 def use(idp: str) -> None:
@@ -107,8 +112,7 @@ def use(idp: str) -> None:
             hint="Run canfar.login() for this IDP before selecting it.",
         ) from exc
 
-    config.set_active_authentication(idp)
-    config.save()
+    _select_authentication(config, idp)
 
 
 def list() -> builtins.list[Authentication]:  # noqa: A001
@@ -152,8 +156,7 @@ def remove(idp: str, *, force: bool = False) -> None:
             hint="Use --force or switch authentication before removing.",
         )
 
-    config.remove_authentication(idp)
-    config.save()
+    _remove_authentication(config, idp)
 
 
 def purge(*, force: bool = False) -> None:
@@ -175,8 +178,7 @@ def purge(*, force: bool = False) -> None:
         )
 
     config = Configuration()  # ty: ignore[missing-argument]
-    config.purge_authentication()
-    config.save()
+    _purge_authentication(config)
 
 
 def show() -> Authentication:
@@ -206,6 +208,123 @@ def show() -> Authentication:
 
 def _has_authentication(config: Configuration, idp: str) -> bool:
     return idp in config.authentication
+
+
+def _selection_history(config: Configuration) -> dict[str, str]:
+    """Return remembered server selections including the active pair."""
+    selections = dict(config.active.servers)
+    active_name = config.active.server
+    if active_name is None:
+        return selections
+
+    active_server = config.servers.get(active_name)
+    if (
+        active_server is not None
+        and active_server.idp == config.active.authentication
+        and active_server.name is not None
+    ):
+        selections[config.active.authentication] = active_server.name
+    return selections
+
+
+def _select_authentication(config: Configuration, idp: str) -> None:
+    """Select an Authentication Record and its remembered Server, if any."""
+    selections = _selection_history(config)
+    server_name = selections.get(idp)
+    if server_name is not None:
+        remembered = config.servers.get(server_name)
+        if remembered is None or remembered.idp != idp:
+            server_name = None
+
+    if server_name is None:
+        server_name = config.active.server
+        active_server = (
+            config.servers.get(server_name) if server_name is not None else None
+        )
+        if active_server is None or active_server.idp != idp:
+            server_name = None
+
+    active = config.active.model_copy(
+        update={
+            "authentication": idp,
+            "server": server_name,
+            "servers": selections,
+        },
+    )
+    config.editor.set("active", active)
+    config.editor.save()
+
+
+def _remove_authentication(config: Configuration, idp: str) -> None:
+    """Remove one Authentication Record and its associated Server state."""
+    authentication = dict(config.authentication)
+    authentication.pop(idp, None)
+    if not authentication:
+        _purge_authentication(config)
+        return
+
+    servers = {
+        name: server for name, server in config.servers.items() if server.idp != idp
+    }
+    selections = {
+        selected_idp: name
+        for selected_idp, name in config.active.servers.items()
+        if selected_idp != idp and name in servers
+    }
+    active = config.active.model_copy(update={"servers": selections})
+    if active.authentication == idp:
+        active = active.model_copy(
+            update={
+                "authentication": next(iter(authentication)),
+                "server": None,
+            },
+        )
+    elif active.server not in servers:
+        active = active.model_copy(update={"server": None})
+
+    editor = config.editor
+    editor.set("active", active)
+    editor.set("authentication", authentication)
+    editor.set("servers", servers)
+    editor.save()
+
+
+def _purge_authentication(config: Configuration) -> None:
+    """Reset Authentication and Server state while preserving other settings."""
+    authentication = {
+        **config.authentication,
+        **{
+            key: credential.model_copy(deep=True)
+            for key, credential in default_authentication.items()
+        },
+    }
+    servers = {
+        **config.servers,
+        **{
+            name: server.model_copy(deep=True)
+            for name, server in default_servers.items()
+        },
+    }
+    editor = config.editor
+    # Add defaults before switching active references so each editor update validates.
+    editor.set("authentication", authentication)
+    editor.set("servers", servers)
+    editor.set("active", default_active.model_copy(deep=True))
+    editor.set(
+        "authentication",
+        {
+            key: credential.model_copy(deep=True)
+            for key, credential in default_authentication.items()
+        },
+    )
+    editor.set(
+        "servers",
+        {
+            name: server.model_copy(deep=True)
+            for name, server in default_servers.items()
+        },
+    )
+    editor.save()
 
 
 def _authentication_for_credential(

--- a/canfar/cli/login.py
+++ b/canfar/cli/login.py
@@ -72,7 +72,7 @@ def _login_flow(
         raise typer.Exit(1) from exc
 
     config = Configuration()  # ty: ignore[missing-argument]
-    config.upsert_credential(credential)
+    config.editor.set(f"authentication.{credential.idp}", credential)
 
     try:
         servers = discover(

--- a/canfar/config/editor.py
+++ b/canfar/config/editor.py
@@ -67,7 +67,7 @@ def set_value(config: Configuration, path: str, value: Any) -> Configuration:
         cursor = _ensure_child_container(cursor, segment)
 
     _set_in_container(cursor, segments[-1], value)
-    return config.__class__.model_validate(data)
+    return config._validated_copy(**data)  # noqa: SLF001
 
 
 @dataclass(slots=True)

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -419,6 +419,10 @@ class TestAuthenticationLogin:
                 return_value=credential,
             ),
             patch(
+                "canfar.models.config.Configuration.upsert_credential",
+                side_effect=AssertionError("authentication must use config.editor"),
+            ),
+            patch(
                 "canfar.authentication.server_service.discover",
                 side_effect=lambda _idp, *, config, **_kwargs: (
                     _merge_servers(

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -255,9 +255,12 @@ def test_auth_remove_force_removes_active_idp(tmp_path: Path) -> None:
     config_path = tmp_path / "config.yaml"
     _write_config(config_path)
 
-    with _patch_config(config_path), patch(
-        "canfar.models.config.Configuration.remove_authentication",
-        side_effect=AssertionError("authentication must use config.editor"),
+    with (
+        _patch_config(config_path),
+        patch(
+            "canfar.models.config.Configuration.remove_authentication",
+            side_effect=AssertionError("authentication must use config.editor"),
+        ),
     ):
         result = runner.invoke(auth, ["rm", "cadc", "--force"])
 

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -176,6 +176,10 @@ def test_auth_use_switches_by_idp(tmp_path: Path) -> None:
 
     with (
         _patch_config(config_path),
+        patch(
+            "canfar.models.config.Configuration.set_active_authentication",
+            side_effect=AssertionError("authentication must use config.editor"),
+        ),
         patch("canfar.server._validate_server") as mock_validate,
     ):
         mock_validate.side_effect = lambda server, **_kwargs: server
@@ -251,7 +255,10 @@ def test_auth_remove_force_removes_active_idp(tmp_path: Path) -> None:
     config_path = tmp_path / "config.yaml"
     _write_config(config_path)
 
-    with _patch_config(config_path):
+    with _patch_config(config_path), patch(
+        "canfar.models.config.Configuration.remove_authentication",
+        side_effect=AssertionError("authentication must use config.editor"),
+    ):
         result = runner.invoke(auth, ["rm", "cadc", "--force"])
 
     assert result.exit_code == 0
@@ -281,7 +288,11 @@ def test_auth_purge_force_preserves_registry_and_console(tmp_path: Path) -> None
         before = Configuration()
         before.console = before.console.model_copy(update={"width": 99})
         before.save()
-        result = runner.invoke(auth, ["purge", "--force"])
+        with patch(
+            "canfar.models.config.Configuration.purge_authentication",
+            side_effect=AssertionError("authentication must use config.editor"),
+        ):
+            result = runner.invoke(auth, ["purge", "--force"])
 
     assert result.exit_code == 0
     with _patch_config(config_path):

--- a/tests/test_cli_login.py
+++ b/tests/test_cli_login.py
@@ -82,6 +82,10 @@ def test_login_without_config_file_does_not_require_force(tmp_path: Path) -> Non
         patch("canfar.cli.login.CONFIG_PATH", config_path),
         patch("canfar.models.config.CONFIG_PATH", config_path),
         patch("canfar.cli.login.authenticate_for_cli", return_value=credential),
+        patch(
+            "canfar.models.config.Configuration.upsert_credential",
+            side_effect=AssertionError("authentication must use config.editor"),
+        ),
         patch("canfar.server._validate_server", return_value=validated),
         patch(
             "canfar.cli.login.discover",

--- a/tests/test_client_auth_resolution.py
+++ b/tests/test_client_auth_resolution.py
@@ -593,7 +593,7 @@ class TestRequestAuthenticationResolution:
                 return_value=oauth_client,
             ),
             patch(
-                "canfar.models.config.Configuration.save",
+                "canfar.config.editor.ConfigurationEditor.save",
                 side_effect=(OSError(sentinel) if failure == "save" else None),
             ) as save,
             HTTPClient(config=config) as client,

--- a/tests/test_config_editor.py
+++ b/tests/test_config_editor.py
@@ -42,6 +42,20 @@ def test_editor_set_mutates_validated_configuration(tmp_path: Path) -> None:
         assert config.editor.get("servers.canfar.auths") == ["x509", "oidc"]
 
 
+def test_editor_replaces_top_level_mapping_without_reloading_saved_state(
+    tmp_path: Path,
+) -> None:
+    """Top-level mapping edits remove records instead of resurrecting YAML keys."""
+    config_path = tmp_path / "config.yaml"
+    with patch("canfar.models.config.CONFIG_PATH", config_path):
+        config = Configuration()
+        config.editor.set("authentication.srcnet", config.authentication["cadc"])
+        config.editor.save()
+        config.editor.set("authentication", {"cadc": config.authentication["cadc"]})
+
+    assert set(config.authentication) == {"cadc"}
+
+
 def test_editor_rejects_list_indexing(tmp_path: Path) -> None:
     """Dotted paths may retrieve a whole list but cannot address its items."""
     config_path = tmp_path / "config.yaml"

--- a/tests/test_hooks_httpx_auth.py
+++ b/tests/test_hooks_httpx_auth.py
@@ -39,7 +39,11 @@ def oidc_client() -> HTTPClient:
 class TestSyncHook:
     """Tests for the synchronous `hook` function."""
 
-    @patch("canfar.models.config.Configuration.save")
+    @patch(
+        "canfar.models.config.Configuration.update_credential",
+        side_effect=AssertionError("refresh must use config.editor"),
+    )
+    @patch("canfar.config.editor.ConfigurationEditor.save")
     @patch(
         "canfar.auth.oidc.sync_refresh",
         return_value={
@@ -54,6 +58,7 @@ class TestSyncHook:
         self,
         mock_refresh,
         mock_save,
+        mock_update,
         oidc_client,
     ) -> None:
         """Verify a successful token refresh updates state and headers."""
@@ -64,6 +69,7 @@ class TestSyncHook:
 
         mock_refresh.assert_called_once()
         mock_save.assert_called_once()
+        mock_update.assert_not_called()
 
         # Verify the request header was updated
         assert request.headers["Authorization"] == "Bearer new-access-token"
@@ -142,7 +148,11 @@ class TestSyncHook:
 class TestAsyncHook:
     """Tests for the asynchronous `ahook` function."""
 
-    @patch("canfar.models.config.Configuration.save")
+    @patch(
+        "canfar.models.config.Configuration.update_credential",
+        side_effect=AssertionError("refresh must use config.editor"),
+    )
+    @patch("canfar.config.editor.ConfigurationEditor.save")
     @patch(
         "canfar.auth.oidc.refresh",
         return_value={
@@ -157,6 +167,7 @@ class TestAsyncHook:
         self,
         mock_refresh,
         mock_save,
+        mock_update,
         oidc_client,
     ) -> None:
         """Verify a successful async token refresh updates state and headers."""
@@ -167,6 +178,7 @@ class TestAsyncHook:
 
         mock_refresh.assert_called_once()
         mock_save.assert_called_once()
+        mock_update.assert_not_called()
 
         assert request.headers["Authorization"] == "Bearer new-async-token"
         assert (


### PR DESCRIPTION
Implements #250 as part of #244.

Authentication operations now own Authentication Record create/update, IDP selection, removal, purge, and OIDC token-update decisions. `config.editor` owns dotted mutation and atomic save.

Compatibility retained:
- persisted Authentication Record keys/shape and secret handling
- runtime token/certificate precedence
- CLI and Python login/selection/removal behavior
- legacy Configuration service methods remain for the later contraction phase

Validation: 840 deterministic non-slow tests, Ruff, and ty pass. Base is `feat/interfaces`; this does not target `main` directly.