### PR TITLE
refactor(storage): make identifier resolution explicit

### DIFF
--- a/canfar/cli/data.py
+++ b/canfar/cli/data.py
@@ -9,7 +9,7 @@ from fsspec_cli import App
 from typer.core import TyperGroup
 from typer.main import get_group
 
-from canfar.storage import sources
+from canfar.storage import _sources
 
 if TYPE_CHECKING:
     from typer._click.core import Command, Context
@@ -25,7 +25,7 @@ def group() -> TyperGroup:
     """
     return get_group(
         App(
-            sources(),
+            _sources(),
             capabilities={"recursion": {"copy": True, "remove": False}},
         ).typer_app
     )

--- a/canfar/models/config.py
+++ b/canfar/models/config.py
@@ -37,7 +37,7 @@ from canfar.models.auth import (
     AuthenticationCredential,
     X509Credential,
 )
-from canfar.models.http import LOCAL, Server, VOSpaceService
+from canfar.models.http import Server, VOSpaceService
 from canfar.models.registry import ContainerRegistry
 
 log = get_logger(__name__)
@@ -386,35 +386,6 @@ class Configuration(BaseSettings):
             msg = f"Server '{name}' not found."
             raise KeyError(msg)
         return self.servers[name]
-
-    def storage_identifiers(self) -> list[str]:
-        """Return every addressable Storage Identifier, ``local`` last.
-
-        Returns:
-            list[str]: Configured Storage Identifiers plus reserved ``local``.
-        """
-        configured = {
-            identifier
-            for server in self.servers.values()
-            for identifier in server.storage
-        }
-        return [*sorted(configured), LOCAL]
-
-    def _resolve_storage(self, identifier: str) -> tuple[str, str]:
-        """Resolve a Storage Identifier to its endpoint and parent server IDP."""
-        for server in self.servers.values():
-            service = server.storage.get(identifier)
-            if service is not None:
-                if server.idp is None:
-                    msg = (
-                        f"Storage Identifier '{identifier}' belongs to a "
-                        "Science Platform "
-                        "Server without an IDP."
-                    )
-                    raise ValueError(msg)
-                return str(service.url), server.idp
-        msg = f"Storage Identifier '{identifier}' is not configured."
-        raise KeyError(msg)
 
     def upsert_credential(self, credential: AuthenticationCredential) -> None:
         """Insert or replace a validated Authentication Record.

--- a/canfar/models/http.py
+++ b/canfar/models/http.py
@@ -19,6 +19,7 @@ DEFAULT_SERVER_GPUS = 0
 LOCAL = "local"
 """Reserved Storage Identifier for the machine where the code runs."""
 
+
 class VOSpaceService(BaseModel):
     """VOSpace Service discovered through an IVOA registry."""
 

--- a/canfar/models/http.py
+++ b/canfar/models/http.py
@@ -19,12 +19,6 @@ DEFAULT_SERVER_GPUS = 0
 LOCAL = "local"
 """Reserved Storage Identifier for the machine where the code runs."""
 
-RESERVED_IDENTIFIERS = frozenset(
-    {LOCAL, "filesystem", "identifiers", "sources"},
-)
-"""Storage Identifiers that would shadow the ``canfar.storage`` module surface."""
-
-
 class VOSpaceService(BaseModel):
     """VOSpace Service discovered through an IVOA registry."""
 
@@ -150,14 +144,11 @@ class Server(BaseModel):
                 name = None
             else:
                 name = original_name.strip()
-            if name is None or (
-                not name or name in RESERVED_IDENTIFIERS or name.startswith("-")
-            ):
-                reserved = ", ".join(sorted(RESERVED_IDENTIFIERS))
+            if name is None or (not name or name == LOCAL or name.startswith("-")):
                 msg = (
                     f"Invalid Storage Identifier {original_name!r}: after whitespace "
-                    f"normalization it must be non-empty, avoid the reserved names "
-                    f"({reserved}), contain no colon, NUL, or newline, and not start "
+                    "normalization it must be non-empty, differ from reserved "
+                    f"'{LOCAL}', contain no colon, NUL, or newline, and not start "
                     "with '-'."
                 )
                 raise ValueError(msg)

--- a/canfar/storage.py
+++ b/canfar/storage.py
@@ -1,4 +1,4 @@
-"""Adapters for the configured VOSpace Services and the local filesystem."""
+"""Explicit access to configured VOSpace Services and the local filesystem."""
 
 from __future__ import annotations
 
@@ -24,15 +24,42 @@ if TYPE_CHECKING:
     from vosfs import VOSpaceFileSystem
 
     from canfar.models.auth import RuntimeCredential
+    from canfar.models.http import Server, VOSpaceService
 
-__all__ = ["LOCAL", "filesystem", "identifiers", "sources"]
-"""Public surface; Storage Identifiers resolve through ``__getattr__``."""
+__all__ = ["filesystem", "identifiers"]
 
 _LISTINGS_EXPIRY_SECONDS = 30
 """Seconds a cached directory listing stays valid on one filesystem."""
 
 _LISTINGS_MAX_PATHS = 1000
 """Maximum directory listings retained by one filesystem."""
+
+
+def _configured(
+    config: Configuration,
+) -> dict[str, tuple[Server, VOSpaceService]]:
+    """Return the private Storage Identifier to service mapping."""
+    return {
+        identifier: (server, service)
+        for server in config.servers.values()
+        for identifier, service in server.storage.items()
+    }
+
+
+def _service(config: Configuration, identifier: str) -> tuple[str, str]:
+    """Return a service endpoint and its parent server's IDP."""
+    try:
+        server, service = _configured(config)[identifier]
+    except KeyError:
+        msg = f"Storage Identifier '{identifier}' is not configured."
+        raise KeyError(msg) from None
+    if server.idp is None:
+        msg = (
+            f"Storage Identifier '{identifier}' belongs to a Science Platform "
+            "Server without an IDP."
+        )
+        raise ValueError(msg)
+    return str(service.url), server.idp
 
 
 async def _resolve(
@@ -54,7 +81,7 @@ async def _resolve(
         AuthContextError: If the credential cannot be materialized.
     """
     config = Configuration()  # ty: ignore[missing-argument]
-    endpoint, idp = config._resolve_storage(identifier)  # noqa: SLF001
+    endpoint, idp = _service(config, identifier)
     try:
         client = HTTPClient.build(
             config=config,
@@ -152,7 +179,7 @@ async def _local() -> AsyncIterator[AbstractFileSystem]:
     )
 
 
-def sources() -> dict[str, AsyncFilesystemSource]:
+def _sources() -> dict[str, AsyncFilesystemSource]:
     """Build the mapped storage sources for one data command invocation.
 
     Every configured VOSpace Service is mapped by its Storage Identifier, plus
@@ -164,8 +191,7 @@ def sources() -> dict[str, AsyncFilesystemSource]:
     config = Configuration()  # ty: ignore[missing-argument]
     mapped: dict[str, AsyncFilesystemSource] = {
         identifier: _vospace(identifier)
-        for identifier in config.storage_identifiers()
-        if identifier != LOCAL
+        for identifier in _configured(config)
     }
     mapped[LOCAL] = _local
     return mapped
@@ -178,7 +204,7 @@ def identifiers() -> list[str]:
         list[str]: Configured Storage Identifiers plus the reserved ``local``.
     """
     config = Configuration()  # ty: ignore[missing-argument]
-    return config.storage_identifiers()
+    return [*sorted(_configured(config)), LOCAL]
 
 
 def filesystem(
@@ -206,46 +232,3 @@ def filesystem(
     # fsspec's background loop, so this works inside a running loop too.
     endpoint, credential = sync(get_loop(), _resolve, identifier, token, certificate)
     return _build(endpoint, credential, asynchronous=False)
-
-
-def __getattr__(identifier: str) -> AbstractFileSystem:
-    """Return a filesystem for a Storage Identifier accessed as an attribute.
-
-    Makes ``from canfar.storage import vault`` resolve to a ready filesystem
-    for the ``vault`` Storage Identifier.
-
-    Args:
-        identifier: Attribute name, treated as a Storage Identifier.
-
-    Returns:
-        AbstractFileSystem: A ready, authenticated filesystem.
-
-    Raises:
-        AttributeError: If ``identifier`` is not a configured Storage
-            Identifier.
-    """
-    if identifier.startswith("_"):
-        message = f"module {__name__!r} has no attribute {identifier!r}"
-        raise AttributeError(message)
-    known = identifiers()
-    if identifier not in known:
-        message = (
-            f"module {__name__!r} has no attribute {identifier!r}; "
-            f"configured Storage Identifiers are: {', '.join(known)}"
-        )
-        raise AttributeError(message)
-    # Built outside the membership check so a failure to authenticate surfaces
-    # as itself rather than as a missing attribute.
-    return filesystem(identifier)
-
-
-def __dir__() -> list[str]:
-    """List the module's own names plus every Storage Identifier.
-
-    Returns:
-        list[str]: Names available on this module, for tab completion.
-    """
-    try:
-        return sorted({*__all__, *identifiers()})
-    except (OSError, ValueError):  # pragma: no cover - unreadable configuration
-        return sorted(__all__)

--- a/canfar/storage.py
+++ b/canfar/storage.py
@@ -190,8 +190,7 @@ def _sources() -> dict[str, AsyncFilesystemSource]:
     """
     config = Configuration()  # ty: ignore[missing-argument]
     mapped: dict[str, AsyncFilesystemSource] = {
-        identifier: _vospace(identifier)
-        for identifier in _configured(config)
+        identifier: _vospace(identifier) for identifier in _configured(config)
     }
     mapped[LOCAL] = _local
     return mapped

--- a/docs/cli/data.md
+++ b/docs/cli/data.md
@@ -104,32 +104,26 @@ verification and residual-state semantics—not portable `mv`.
 
 ### Directory listings
 
-Directory listings are cached automatically. Each command builds and closes its
-own filesystem, so a cached listing only ever serves the command that produced
-it and can never return a listing that outlives it. Repeated lookups while one
-command walks a tree are served without another round trip.
+Each command uses a fresh filesystem with a bounded in-memory directory-listing
+cache. The cache is closed with the command and never persists object contents.
+It is not controlled by environment variables.
 
 ### Files and byte ranges
 
 There is no CLI flag for caching file contents, but `vosfs` is a normal
-[fsspec](https://filesystem-spec.readthedocs.io/) filesystem, so any fsspec
-cache can wrap it from Python. On a CANFAR session, `/scratch` is fast local
-disk and is the right place to point a cache; it is not backed up and is
-cleared when the session ends, which is exactly what a cache wants.
+[fsspec](https://filesystem-spec.readthedocs.io/) filesystem, so an fsspec
+cache can wrap the explicit CANFAR Python filesystem. Caching is always a user
+choice: `/scratch` is a useful Session-local directory when named explicitly,
+but its presence or any `skaha_*` environment variable never enables a cache.
 
-Cache whole files under a named directory. The first read fetches over the
-network, and later reads come from `/scratch`:
+For example, cache whole files under an explicitly named directory. The first
+read fetches over the network, and later reads come from that directory:
 
 ```python
-from pathlib import Path
-
 from fsspec.implementations.cached import WholeFileCacheFileSystem
-from vosfs import VOSpaceFileSystem
+from canfar.storage import filesystem
 
-vault = VOSpaceFileSystem(
-    "https://cadc-west-01.canfar.net/vault",
-    certfile=str(Path.home() / ".ssl" / "cadcproxy.pem"),
-)
+vault = filesystem("vault")
 cached = WholeFileCacheFileSystem(fs=vault, cache_storage="/scratch/vault-cache")
 
 data = cached.cat_file("/ALMA/test-data/cutouts/test-4d-cube-cutout.fits")
@@ -140,60 +134,26 @@ staleness metadata that `WholeFileCacheFileSystem` keeps. Passing
 `cache_storage` a list of directories tries each in order and treats only the
 last as writable, so a shared read-only cache can back your own.
 
-### Cache byte ranges
+### Byte ranges
 
-`vosfs` sends an HTTP `Range` header and uses the response when the byte
-endpoint answers `206`, so a partial read such as `cat_file(path, start, end)`
-transfers only the bytes you asked for. Range support is per-backend:
+For an explicit partial read, `vosfs` sends an HTTP `Range` request and uses a
+validated `206` response. If the byte endpoint returns `200`, it downloads the
+whole object and slices locally. Capability is deployment-specific; do not
+infer it from a Storage Identifier's spelling. The staged file-object path is
+whole-object, even when `cat_file(path, start, end)` can use a range.
 
-| Storage Identifier | Backend | Ranged reads |
-| --- | --- | --- |
-| `vault` | `minoc` | Yes — a partial read returns `206` and transfers only that slice |
-| `arc` | Cavern | No — the whole object is fetched and sliced, which is correct but not cheaper |
-
-Because a range is now a real partial transfer against `vault`, a block cache
-is worth using there. `MMapCache` keeps fetched blocks in a sparse file, so
-only the blocks you touch occupy disk:
-
-```python
-from fsspec.caching import MMapCache
-
-path = "/ALMA/test-data/cutouts/test-4d-cube.fits"
-size = vault.info(path)["size"]
-blocks = MMapCache(
-    blocksize=1 << 20,
-    fetcher=lambda start, end: vault.cat_file(path, start, end),
-    size=size,
-    location="/scratch/vault-cache/test-4d-cube.blocks",
-)
-
-header = blocks._fetch(0, 2880)  # one FITS header block, one 1 MiB range request
-```
-
-Reading a FITS header from a 3.4 MB cube this way issues a single ranged
-request and materialises one block of four; a second read of the same range is
-served from `/scratch`. The saving is in bytes transferred rather than seconds
-on small files, because VOSpace transfer negotiation dominates a short request.
-It grows with file size, and matters most when many reads hit different parts
-of one large cube.
-
-Against `arc` a block cache still costs a whole download per block, so cache
-whole files there instead.
-
-The `blockcache` filesystem remains unavailable over a VOSpace Service. `Range`
-is honoured for byte reads, not through the file-object path, so wrapping
-`CachingFileSystem` still fails:
+The `blockcache` filesystem remains unavailable over a VOSpace Service because
+the opened object is a staged file rather than a ranged buffered reader:
 
 ```text
 AttributeError: 'StagedReadFile' object has no attribute 'blocksize'
 ```
 
-Stacked caches do not help either: chaining them (`filecache::simplecache::`)
-builds the layers, but the inner layer is never filled and never serves, so use
-exactly one cache layer on your fastest local disk.
+Use one explicitly selected cache layer on a local directory you own; do not
+silently stack caches or select one from environment variables.
 
-These caches use the synchronous filesystem interface. Build the filesystem
-without `asynchronous=True`, as above.
+The shown cache wrapper uses the synchronous filesystem returned by
+`canfar.storage.filesystem`.
 
 ## Output and accepted omissions
 

--- a/docs/client/data.md
+++ b/docs/client/data.md
@@ -6,18 +6,15 @@ endpoints and credentials; [`vosfs`](https://github.com/shinybrar/vosfs) is the
 so every tool that already speaks fsspec — astropy, pandas, dask, zarr — works
 without an adapter.
 
-The same Storage Identifiers the CLI uses are importable by name.
+Storage lookup is explicit. `canfar` does not register configured names as
+fsspec protocols and does not turn them into module attributes. This keeps
+fsspec's built-in `local` protocol untouched and makes filesystem ownership and
+cleanup visible to the caller.
 
 ## Open a VOSpace Service
 
-Import a Storage Identifier and you get a ready, authenticated filesystem. Run
-`canfar login` first; the credential resolution is the same one the CLI uses.
-
-```python
-from canfar.storage import arc, vault, local
-```
-
-Any configured Storage Identifier works this way. To see which are available:
+Run `canfar login` first; the credential resolution is the same one the CLI
+uses. To see which Storage Identifiers are available:
 
 ```python
 from canfar.storage import identifiers
@@ -25,9 +22,8 @@ from canfar.storage import identifiers
 identifiers()      # ['arc', 'vault', 'local']
 ```
 
-Import binds the filesystem once, which is what you usually want. To build one
-explicitly — to override a credential, or to name an identifier held in a
-variable — use `filesystem`:
+Build one explicitly — including the reserved local filesystem, overriding a
+credential, or naming an identifier held in a variable — with `filesystem`:
 
 ```python
 from canfar.storage import filesystem
@@ -35,9 +31,11 @@ from canfar.storage import filesystem
 vault = filesystem("vault")
 staging = filesystem("vault", token="...")        # runtime bearer token
 archive = filesystem("arc", certificate="/path/to/proxy.pem")
+local = filesystem("local")
 ```
 
-`local` is reserved for the machine your code runs on and needs no credential.
+`filesystem(identifier)` returns the ordinary upstream fsspec object. Close a
+remote filesystem when the operation is complete; `local` needs no credential.
 
 ## Filesystem operations
 
@@ -72,8 +70,8 @@ vault.tail(target, 100)
 
 Writes use `put_file`, `pipe_file`, `mkdir`, and `rm`. Directory listings are
 cached in memory for the lifetime of the filesystem object, so a long-lived
-object can serve a stale listing; build a fresh one, or pass
-`use_listings_cache=False`, when you need to observe another writer's changes.
+object can serve a stale listing; build a fresh filesystem when you need to
+observe another writer's changes.
 
 ## Get a local path
 
@@ -89,9 +87,16 @@ uploads.
 
 ## Cache
 
-Nothing is cached to disk unless you ask. On a CANFAR session `/scratch` is
-fast local NVMe, is not backed up, and is cleared when the session ends, which
-is exactly what a cache wants. Locally, any directory works.
+`filesystem()` never enables a persistent content cache. Directory-listing
+caching is an in-memory fsspec option on the returned object; it is not a byte
+cache. If you choose to cache object contents, construct one fsspec cache
+wrapper explicitly and own its directory, freshness policy, and cleanup. The
+presence of `/scratch` or any `skaha_*` environment variable does not enable
+caching.
+
+On a CANFAR Session `/scratch` is fast local NVMe, is not backed up, and is
+cleared when the Session ends. It is a useful explicit location for ephemeral
+staging or caching, but it is never selected implicitly.
 
 ### Whole files
 
@@ -104,7 +109,8 @@ cached.cat_file(target)   # cold: fetched over the network
 cached.cat_file(target)   # warm: served from /scratch
 ```
 
-A cold read of the 166 KiB cutout took 2.96 s; the warm read took 0.4 ms.
+The first read fetches the complete object; subsequent reads can come from the
+explicit cache directory.
 
 Use `SimpleCacheFileSystem` when you do not need the expiry and staleness
 metadata `WholeFileCacheFileSystem` keeps. Passing `cache_storage` a list of
@@ -113,74 +119,39 @@ shared read-only cache can back your own.
 
 ### Byte ranges
 
-`vosfs` sends an HTTP `Range` header and uses the response when the byte
-endpoint answers `206`, so a partial read transfers only the bytes you asked
-for. Support is per-backend:
-
-| Storage Identifier | Backend | Ranged reads |
-| --- | --- | --- |
-| `vault` | `minoc` | Yes — a partial read returns `206` and transfers only that slice |
-| `arc` | Cavern | No — the whole object is fetched and sliced, correct but not cheaper |
-
-Against `vault`, cache blocks instead of whole files when you touch small parts
-of a large cube. `MMapCache` keeps fetched blocks in a sparse file:
+For an explicit partial read, `vosfs` sends an HTTP `Range` request and uses a
+validated `206` response. If the byte endpoint returns the whole object with
+`200`, `vosfs` falls back to downloading that object and slicing it locally.
+Range support is therefore deployment-specific; do not infer it from a
+Storage Identifier's spelling or assume that a partial call saves bytes.
 
 ```python
-from fsspec.caching import MMapCache
-
-cube = "/ALMA/test-data/cutouts/test-4d-cube.fits"
-size = vault.info(cube)["size"]
-
-blocks = MMapCache(
-    blocksize=1 << 20,
-    fetcher=lambda start, end: vault.cat_file(cube, start, end),
-    size=size,
-    location="/scratch/vault-cache/cube.blocks",
-)
-
-header = blocks._fetch(0, 2880)   # one ranged request, one block of four
+header = vault.cat_file(target, 0, 2880)
 ```
 
-Reading a FITS header from the 3.4 MB cube materialises one block of four. The
-saving is in bytes transferred rather than seconds on small files, because
-VOSpace transfer negotiation dominates a short request; it grows with file
-size. Against `arc` a block cache still costs a whole download per block, so
-cache whole files there.
-
-### RAM
-
-Omit `location` and `MMapCache` uses an anonymous memory map — a RAM cache that
-never touches disk, for when `/scratch` is absent or you want the data gone
-when the process exits:
-
-```python
-blocks = MMapCache(
-    blocksize=1 << 20,
-    fetcher=lambda start, end: vault.cat_file(cube, start, end),
-    size=size,
-)
-```
-
-A warm re-read of a cached range returned in 18 µs.
+The result is correct in either case. `open()` is a separate path: `vosfs`
+stages the complete object into a seekable local file before returning the
+file-like object. Use an explicit whole-file cache or `get_file()` when a
+scientific tool will read the same object more than once.
 
 ### What does not work
 
-`blockcache` (`CachingFileSystem`) cannot wrap a VOSpace Service. `Range` is
-honoured for byte reads, not through the file-object path:
+`blockcache` (`CachingFileSystem`) cannot wrap a VOSpace Service. Range is
+negotiated for explicit byte reads, not through the staged file-object path:
 
 ```text
 AttributeError: 'StagedReadFile' object has no attribute 'blocksize'
 ```
 
-Stacked caches do not help either: chaining them (`filecache::simplecache::`)
-builds the layers, but the inner layer is never filled and never serves. Use
-exactly one cache layer, on your fastest local disk.
+Use one explicit cache layer, on a local directory you own; do not silently
+stack caches or select one from environment variables.
 
 ## Scientific tools
 
 ### astropy
 
-Read a header without downloading the file, using one ranged request:
+Read a header through the explicit byte-read path. Depending on the negotiated
+backend, this may transfer only the requested slice or the whole object:
 
 ```python
 from astropy.io import fits
@@ -255,34 +226,7 @@ with fits.open("/scratch/cutout.fits", memmap=True) as hdul:
 
 ## Async
 
-Every read has an async twin. Build the filesystem with `asynchronous=True`,
-use the underscore-prefixed coroutines, and close it when done:
-
-```python
-import asyncio
-
-from canfar.models.config import Configuration
-from vosfs import VOSpaceFileSystem
-
-
-async def main() -> None:
-    config = Configuration()
-    service = config.servers["canfar"].storage["vault"]
-    vault = VOSpaceFileSystem(
-        str(service.url),
-        certfile=str(config.get_credential("cadc").path),
-        asynchronous=True,
-    )
-    try:
-        entries = await vault._ls(cutouts, detail=False)
-        header = await vault._cat_file(cube, 0, 2880)
-    finally:
-        await vault.aclose()
-
-
-asyncio.run(main())
-```
-
-Async filesystems cannot open file objects — `open()` is rejected, and the
-fsspec caches are synchronous — so use the synchronous form for caching and for
-libraries that want a file handle.
+`filesystem(identifier)` intentionally returns the synchronous fsspec object.
+The embedded `canfar data` command owns its asynchronous source lifecycle. For
+Python scientific tools, use the synchronous object above; it is also the form
+that composes with fsspec's content caches and file-like readers.

--- a/tests/test_cli_data.py
+++ b/tests/test_cli_data.py
@@ -33,7 +33,6 @@ def _configuration(*storage_names: str) -> SimpleNamespace:
     storage = dict.fromkeys(storage_names, object())
     return SimpleNamespace(
         servers={"server": SimpleNamespace(storage=storage)},
-        storage_identifiers=lambda: [*storage_names, "local"],
     )
 
 
@@ -61,7 +60,6 @@ def test_upstream_app_receives_configured_sources_and_policy(monkeypatch) -> Non
                     "first": SimpleNamespace(storage={"arc": object()}),
                     "second": SimpleNamespace(storage={"cavern": object()}),
                 },
-                storage_identifiers=lambda: ["arc", "cavern", "local"],
             ),
             SimpleNamespace(
                 active=SimpleNamespace(server="second"),
@@ -71,7 +69,6 @@ def test_upstream_app_receives_configured_sources_and_policy(monkeypatch) -> Non
                         storage={"cavern": object(), "vault": object()}
                     ),
                 },
-                storage_identifiers=lambda: ["arc", "cavern", "vault", "local"],
             ),
         ]
     )

--- a/tests/test_data_smoke.py
+++ b/tests/test_data_smoke.py
@@ -27,7 +27,13 @@ def _require_live_credentials() -> None:
         _skip("configuration is unavailable")
 
     try:
-        _endpoint, idp = config._resolve_storage("arc")  # noqa: SLF001
+        server = next(
+            (server for server in config.servers.values() if "arc" in server.storage),
+            None,
+        )
+        if server is None or server.idp is None:
+            _skip("the named service has no parent Authentication Record")
+        idp = server.idp
         credential = config.get_credential(idp)
     except (KeyError, ValueError):
         _skip("the named service or its Authentication Record is unavailable")

--- a/tests/test_models_config.py
+++ b/tests/test_models_config.py
@@ -80,9 +80,19 @@ class TestConfigurationDefaults:
             ("arc", "https://ws-uv.canfar.net/arc"),
             ("vault", "https://cadc-west-01.canfar.net/vault"),
         ):
-            resolved, idp = config._resolve_storage(name)  # noqa: SLF001
-            assert resolved.rstrip("/") == endpoint
-            assert idp == "cadc"
+            service = config.servers["canfar"].storage[name]
+            assert str(service.url).rstrip("/") == endpoint
+
+    def test_storage_resolution_belongs_to_storage_module(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Configuration stores VOSpace metadata without resolving it."""
+        with patch("canfar.models.config.CONFIG_PATH", tmp_path / "config.yaml"):
+            config = Configuration()
+
+        assert not hasattr(config, "storage_identifiers")
+        assert not hasattr(config, "_resolve_storage")
 
     def test_legacy_server_named_storage_is_healed(self, tmp_path: Path) -> None:
         """A Storage Identifier saved as the Server Name is restored to its leaf."""
@@ -248,6 +258,21 @@ class TestConfigurationValidation:
     def test_long_storage_name_allowed(self) -> None:
         """Storage Identifiers do not inherit Server field length limits."""
         storage_name = "a" * 257
+        service = {
+            "uri": "ivo://cadc.nrc.ca/arc",
+            "url": "https://ws-cadc.canfar.net/arc",
+        }
+
+        server = Server(storage={storage_name: service})
+
+        assert list(server.storage) == [storage_name]
+
+    @pytest.mark.parametrize("storage_name", ["filesystem", "identifiers", "sources"])
+    def test_storage_name_can_match_storage_module_member(
+        self,
+        storage_name: str,
+    ) -> None:
+        """Module members are not reserved when lookup is explicit."""
         service = {
             "uri": "ivo://cadc.nrc.ca/arc",
             "url": "https://ws-cadc.canfar.net/arc",

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -6,6 +6,7 @@ import asyncio
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, Mock
 
+import fsspec
 import pytest
 import vosfs
 from fsspec.implementations.local import LocalFileSystem
@@ -16,7 +17,7 @@ from canfar.exceptions.context import AuthContextError
 from canfar.models.active import ActiveConfig
 from canfar.models.config import Configuration
 from canfar.models.http import Server, VOSpaceService
-from canfar.storage import _vospace
+from canfar.storage import _sources, _vospace
 from tests.helpers.config import oidc_credential, x509_credential
 
 if TYPE_CHECKING:
@@ -398,17 +399,35 @@ class TestPublicSurface:
 
         assert storage.identifiers() == ["archive", "local"]
 
+    def test_identifiers_discovers_services_on_every_server(self) -> None:
+        """Discovery does not narrow the list to the active Server Selection."""
+        config = _config(credential=x509_credential("inactive"))
+        config.servers["other"] = Server(
+            idp="inactive",
+            uri=AnyUrl("ivo://other.example/skaha"),
+            url=AnyHttpUrl("https://other.example/skaha"),
+            storage={
+                "second": VOSpaceService(
+                    uri=AnyUrl("ivo://other.example/second"),
+                    url=AnyHttpUrl("https://other.example/second"),
+                )
+            },
+        )
+        config.save()
+
+        assert storage.identifiers() == ["archive", "second", "local"]
+
     def test_local_identifier_returns_a_local_filesystem(self) -> None:
         """The reserved local identifier needs no credential."""
         assert isinstance(storage.filesystem("local"), LocalFileSystem)
-        assert isinstance(storage.local, LocalFileSystem)
+        assert fsspec.get_filesystem_class("file") is LocalFileSystem
 
-    def test_attribute_access_builds_a_filesystem(
+    def test_filesystem_builds_a_configured_identifier(
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
     ) -> None:
-        """A Storage Identifier resolves as a module attribute."""
+        """The explicit filesystem API resolves a configured identifier."""
         certificate = tmp_path / "saved.pem"
         _config(credential=x509_credential("inactive", path=certificate)).save()
         monkeypatch.setattr(
@@ -417,28 +436,28 @@ class TestPublicSurface:
         )
         monkeypatch.setattr(vosfs, "VOSpaceFileSystem", _Filesystem)
 
-        filesystem = storage.archive
+        filesystem = storage.filesystem("archive")
 
         assert filesystem.endpoint == "https://inactive.example/vospace"
         assert filesystem.kwargs["certfile"] == certificate.as_posix()
         assert filesystem.kwargs["use_listings_cache"] is True
 
-    def test_unknown_identifier_raises_attribute_error(self) -> None:
-        """An unconfigured name is an AttributeError naming what is available."""
+    def test_unknown_identifier_raises_key_error(self) -> None:
+        """An unconfigured Storage Identifier fails explicitly."""
         _config(credential=x509_credential("inactive")).save()
 
-        with pytest.raises(AttributeError, match="archive"):
-            _ = storage.missing
+        with pytest.raises(KeyError, match="missing"):
+            storage.filesystem("missing")
 
-    def test_private_names_are_not_treated_as_identifiers(self) -> None:
-        """Dunder lookups must not attempt a filesystem build."""
-        with pytest.raises(AttributeError):
-            _ = storage.__wrapped__
-
-    def test_dir_offers_identifiers_for_completion(self) -> None:
-        """Tab completion exposes identifiers alongside the module functions."""
+    def test_data_source_mapping_is_private(self) -> None:
+        """The fsspec-cli source mapping is not a public storage API."""
         _config(credential=x509_credential("inactive")).save()
 
-        listed = dir(storage)
+        assert not hasattr(storage, "sources")
+        assert set(_sources()) == {"archive", "local"}
 
-        assert {"archive", "local", "filesystem", "identifiers"} <= set(listed)
+    def test_storage_identifiers_are_not_dynamic_module_imports(self) -> None:
+        """Storage Identifiers must be passed to the explicit filesystem API."""
+        _config(credential=x509_credential("inactive")).save()
+
+        assert "archive" not in storage.__dict__


### PR DESCRIPTION
Implements #252 as part of #244.

- adds explicit `identifiers()` and `filesystem(identifier)` storage resolution
- discovers configured identifiers including local while leaving fsspec local registration untouched
- resolves remote VOSpace filesystems from the selected Science Platform Server, Authentication Record, and service metadata
- removes Configuration-owned storage helpers and dynamic identifier imports
- keeps internal source mapping private
- documents VOSFS/fsspec protocols and explicit opt-in cache composition

Explicit exclusions preserved: no `storage.configure()`, no `vault://`/`arc://` runtime registration, and no env-triggered persistent cache.

Validation: 53 focused tests, 844 deterministic non-slow tests, Ruff, ty, and MkDocs pass. Base is `feat/interfaces`; this does not target `main` directly.