### PR TITLE
feat(cli): replace machine flags with output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 pip install canfar --upgrade
 canfar login cadc
 canfar create notebook skaha/astroml:26.04
-canfar ps --json
+canfar ps -o json
 # assumes jq is installed
-canfar open $(canfar ps --json | jq -r ".[0].id")
+canfar open $(canfar ps -o json | jq -r ".[0].id")
 ```
 
 ```python

--- a/canfar/cli/auth.py
+++ b/canfar/cli/auth.py
@@ -27,7 +27,7 @@ from canfar.authentication import (
     show as auth_show,
 )
 from canfar.cli import output
-from canfar.cli.machine import JsonOption, YamlOption, resolve_mode
+from canfar.cli.machine import OutputOption, resolve_mode
 from canfar.config.migration import ConfigResetRequiredError
 from canfar.errors import StructuredError
 from canfar.hooks.typer.aliases import AliasGroup
@@ -202,40 +202,37 @@ def _auth_show(mode: output.OutputMode) -> None:
 @auth.callback(invoke_without_command=True)
 def auth_default(
     ctx: typer.Context,
-    json_output: JsonOption = False,
-    yaml_output: YamlOption = False,
+    output_format: OutputOption = None,
 ) -> None:
     """Active authentication state."""
     if ctx.invoked_subcommand is not None:
-        if json_output or yaml_output:
+        if output_format is not None:
             typer.echo(
-                "Place --json or --yaml after the subcommand.",
+                "Place --output json or --output yaml after the subcommand.",
                 err=True,
             )
             raise typer.Exit(output.OUTPUT_CONFLICT_EXIT_CODE)
         return
 
-    mode = resolve_mode(json_output, yaml_output)
+    mode = resolve_mode(output_format)
     _auth_show(mode)
 
 
 @auth.command("show")
 def auth_show_command(
-    json_output: JsonOption = False,
-    yaml_output: YamlOption = False,
+    output_format: OutputOption = None,
 ) -> None:
     """Active authentication state."""
-    mode = resolve_mode(json_output, yaml_output)
+    mode = resolve_mode(output_format)
     _auth_show(mode)
 
 
 @auth.command("ls")
 def auth_list_command(
-    json_output: JsonOption = False,
-    yaml_output: YamlOption = False,
+    output_format: OutputOption = None,
 ) -> None:
     """Available auth providers."""
-    mode = resolve_mode(json_output, yaml_output)
+    mode = resolve_mode(output_format)
     try:
         summaries = auth_list()
     except ConfigResetRequiredError as exc:

--- a/canfar/cli/config.py
+++ b/canfar/cli/config.py
@@ -10,7 +10,7 @@ from pydantic_settings.exceptions import SettingsError
 
 from canfar import CONFIG_PATH
 from canfar.cli import output
-from canfar.cli.machine import JsonOption, YamlOption, resolve_mode
+from canfar.cli.machine import OutputOption, resolve_mode
 from canfar.config.migration import ConfigResetRequiredError
 from canfar.errors import ErrorCode, StructuredError
 from canfar.hooks.typer.aliases import AliasGroup
@@ -39,11 +39,10 @@ def _configuration_failure(error: Exception) -> StructuredError:
 
 @config.command("show", help="Display client configuration")
 def show(
-    json_output: JsonOption = False,
-    yaml_output: YamlOption = False,
+    output_format: OutputOption = None,
 ) -> None:
     """Display client configuration."""
-    mode = resolve_mode(json_output, yaml_output)
+    mode = resolve_mode(output_format)
     try:
         cfg = Configuration()  # ty: ignore[missing-argument]
     except (
@@ -95,8 +94,7 @@ def get(
         ...,
         help="Config key to get in dot notation.",
     ),
-    json_output: JsonOption = False,
-    yaml_output: YamlOption = False,
+    output_format: OutputOption = None,
 ) -> None:
     """Retrieve a config value.
 
@@ -104,7 +102,7 @@ def get(
     canfar config get active.server
     canfar config get servers.canfar.url
     """
-    mode = resolve_mode(json_output, yaml_output)
+    mode = resolve_mode(output_format)
     try:
         cfg = Configuration()  # ty: ignore[missing-argument]
     except (

--- a/canfar/cli/create.py
+++ b/canfar/cli/create.py
@@ -11,11 +11,7 @@ from pydantic import ValidationError
 
 from canfar.cli import output
 from canfar.cli._run import run
-from canfar.cli.machine import (
-    JsonOption,
-    YamlOption,
-    resolve_mode,
-)
+from canfar.cli.machine import OutputOption, resolve_mode
 from canfar.config.migration import ConfigResetRequiredError
 from canfar.errors import ErrorCode, StructuredError
 from canfar.exceptions.context import AuthContextError, AuthExpiredError
@@ -208,8 +204,7 @@ def creation(  # noqa: PLR0917
             help="Dry run. Parse parameters and exit.",
         ),
     ] = False,
-    json_output: JsonOption = False,
-    yaml_output: YamlOption = False,
+    output_format: OutputOption = None,
 ) -> None:
     """Launch a new session.
 
@@ -218,10 +213,11 @@ def creation(  # noqa: PLR0917
     canfar create notebook images.canfar.net/skaha/base-notebook:latest
     canfar create headless skaha/base-notebook:latest -- python3 /path/to/script.py
     """
-    mode = resolve_mode(json_output, yaml_output)
+    mode = resolve_mode(output_format)
     if dry and mode is not output.OutputMode.HUMAN:
         typer.echo(
-            "Incompatible flags: --dry-run cannot be used with --json or --yaml.",
+            "Incompatible flags: --dry-run cannot be used with --output json or "
+            "--output yaml.",
             err=True,
         )
         raise typer.Exit(output.OUTPUT_CONFLICT_EXIT_CODE)

--- a/canfar/cli/machine.py
+++ b/canfar/cli/machine.py
@@ -2,46 +2,55 @@
 
 from __future__ import annotations
 
+from enum import Enum
 from typing import Annotated
 
 import typer
 
 from canfar.cli import output
 
-JsonOption = Annotated[
-    bool,
-    typer.Option("--json", help="Emit machine-readable JSON on stdout."),
+
+class OutputFormat(str, Enum):
+    """Machine output formats accepted by leaf commands."""
+
+    JSON = "json"
+    YAML = "yaml"
+
+
+OutputOption = Annotated[
+    OutputFormat | None,
+    typer.Option(
+        "-o",
+        "--output",
+        metavar="json|yaml",
+        help="Emit machine-readable JSON or YAML on stdout.",
+    ),
 ]
-"""Leaf command flag for JSON machine output."""
-
-YamlOption = Annotated[
-    bool,
-    typer.Option("--yaml", help="Emit machine-readable YAML on stdout."),
-]
-"""Leaf command flag for YAML machine output."""
+"""Leaf command option for selecting machine output format."""
 
 
-def resolve_mode(json_output: bool, yaml_output: bool) -> output.OutputMode:
-    """Resolve machine output mode from leaf command flags.
+def resolve_mode(output_format: OutputFormat | str | None) -> output.OutputMode:
+    """Resolve machine output mode from the leaf output option.
 
     Args:
-        json_output: Whether ``--json`` was supplied.
-        yaml_output: Whether ``--yaml`` was supplied.
+        output_format: Requested machine output format, if any.
 
     Returns:
         Effective output mode for the invocation.
 
     Raises:
-        typer.Exit: Exit code 2 when both machine flags are supplied.
+        ValueError: If the format is not supported.
     """
-    if json_output and yaml_output:
-        typer.echo(
-            "Conflicting machine output flags: use only one of --json or --yaml.",
-            err=True,
-        )
-        raise typer.Exit(output.OUTPUT_CONFLICT_EXIT_CODE)
-    if json_output:
+    if output_format is None:
+        return output.OutputMode.HUMAN
+    value = (
+        output_format.value
+        if isinstance(output_format, OutputFormat)
+        else output_format
+    )
+    if value == "json":
         return output.OutputMode.JSON
-    if yaml_output:
+    if value == "yaml":
         return output.OutputMode.YAML
-    return output.OutputMode.HUMAN
+    message = f"Unsupported output format: {value}"
+    raise ValueError(message)

--- a/canfar/cli/main.py
+++ b/canfar/cli/main.py
@@ -46,17 +46,29 @@ if TYPE_CHECKING:
 
 
 def _leaf_output_mode(args: list[str]) -> output.OutputMode:
-    """Infer an already-parsed leaf machine flag for root setup failures."""
-    if "--json" in args:
-        return output.OutputMode.JSON
-    if "--yaml" in args:
-        return output.OutputMode.YAML
+    """Infer an already-parsed leaf output option for root setup failures."""
+    for index, arg in enumerate(args):
+        if arg == "--":
+            break
+        if arg in {"-o", "--output"} and index + 1 < len(args):
+            value = args[index + 1]
+            if value in {"json", "yaml"}:
+                return output.OutputMode(value)
+        if arg.startswith("--output=") and arg.removeprefix("--output=") in {
+            "json",
+            "yaml",
+        }:
+            return output.OutputMode(arg.removeprefix("--output="))
+        if arg.startswith("-o") and arg not in {"-o", "--output"}:
+            value = arg.removeprefix("-o")
+            if value in {"json", "yaml"}:
+                return output.OutputMode(value)
     return output.OutputMode.HUMAN
 
 
 def _emit_banner_for_command(params: Mapping[str, object]) -> None:
     """Emit the active-server banner for a parsed human-output command."""
-    if params.get("json_output") or params.get("yaml_output"):
+    if params.get("output_format"):
         return
     emit_active_server_banner()
 

--- a/canfar/cli/ps.py
+++ b/canfar/cli/ps.py
@@ -15,7 +15,7 @@ from rich.table import Table
 
 from canfar.cli import output
 from canfar.cli._run import run
-from canfar.cli.machine import JsonOption, YamlOption, resolve_mode
+from canfar.cli.machine import OutputOption, resolve_mode
 from canfar.config.migration import ConfigResetRequiredError
 from canfar.exceptions.context import AuthContextError, AuthExpiredError
 from canfar.hooks.typer.aliases import AliasGroup
@@ -195,16 +195,15 @@ def show(
             help="Show Session response warnings.",
         ),
     ] = False,
-    json_output: JsonOption = False,
-    yaml_output: YamlOption = False,
+    output_format: OutputOption = None,
 ) -> None:
     """Show sessions."""
-    mode = resolve_mode(json_output, yaml_output)
+    mode = resolve_mode(output_format)
 
     if quiet and mode is not output.OutputMode.HUMAN:
         typer.echo(
             "Incompatible flags: --quiet is human-only and cannot be used with "
-            "--json or --yaml.",
+            "--output json or --output yaml.",
             err=True,
         )
         raise typer.Exit(output.OUTPUT_CONFLICT_EXIT_CODE)

--- a/canfar/cli/server.py
+++ b/canfar/cli/server.py
@@ -11,7 +11,7 @@ from rich.table import Table
 from canfar.authentication import AuthenticationError
 from canfar.authentication import show as auth_show
 from canfar.cli import output
-from canfar.cli.machine import JsonOption, YamlOption, resolve_mode
+from canfar.cli.machine import OutputOption, resolve_mode
 from canfar.config.migration import ConfigResetRequiredError
 from canfar.errors import ErrorCode, StructuredError
 from canfar.hooks.typer.aliases import AliasGroup
@@ -65,11 +65,10 @@ def _render_server_list_table(servers: list[Server]) -> None:
 
 @server.command("list, ls")
 def server_list_command(
-    json_output: JsonOption = False,
-    yaml_output: YamlOption = False,
+    output_format: OutputOption = None,
 ) -> None:
     """List servers for the active Identity Provider."""
-    mode = resolve_mode(json_output, yaml_output)
+    mode = resolve_mode(output_format)
 
     try:
         auth_show()

--- a/docs/cli/authentication-contexts.md
+++ b/docs/cli/authentication-contexts.md
@@ -51,8 +51,8 @@ canfar auth ls
 Use machine output when a script needs stable stdout:
 
 ```bash
-canfar auth show --json
-canfar auth ls --yaml
+canfar auth show -o json
+canfar auth ls --output yaml
 ```
 
 ## Switch IDP
@@ -150,10 +150,9 @@ Legacy or unsupported config files are backed up to
 
 | Rule | Behavior |
 | --- | --- |
-| Supported flags | `--json` and `--yaml` |
-| Placement | Put the flag after the command that emits data, for example `canfar auth ls --json`. |
-| Unsupported placement | `canfar auth --json ls` exits 2. |
-| Conflicts | `--json --yaml` exits 2. |
+| Output option | `-o/--output` with `json` or `yaml` |
+| Placement | Put the option after the command that emits data, for example `canfar auth ls -o json`. |
+| Unsupported placement | `canfar auth -o json ls` exits 2. |
 | stdout | Data only in machine mode. |
 | stderr | Diagnostics and errors. |
 | Unsupported commands | Exit 1 with `machine output not supported for this command yet` and `use default human output for now`. |

--- a/docs/cli/cli-help.md
+++ b/docs/cli/cli-help.md
@@ -72,8 +72,8 @@ canfar auth purge --force
 Machine output is supported for `auth` / `auth show` and `auth ls`:
 
 ```bash
-canfar auth show --json
-canfar auth ls --yaml
+canfar auth show -o json
+canfar auth ls --output yaml
 ```
 
 ### `canfar server`
@@ -112,10 +112,10 @@ canfar create [OPTIONS] KIND IMAGE [-- CMD [ARGS]...]
 | `--replicas` | `-r` | Number of replicas. Default: `1`. |
 | `--debug` | | Print parsed Session request details. |
 | `--dry-run` | | Parse parameters and exit. |
-| `--json` | | Emit created Session IDs as a JSON list. |
-| `--yaml` | | Emit created Session IDs as a YAML list. |
+| `--output FORMAT` | `-o` | Emit created Session IDs as JSON or YAML (`json` or `yaml`). |
 
-`--json` and `--yaml` are mutually exclusive. `--dry-run` is human-output only.
+`--output` is recognized before `--`; tokens after `--` are passed verbatim to
+the container command. `--dry-run` is human-output only.
 
 Examples:
 
@@ -142,8 +142,8 @@ canfar ps [OPTIONS]
 Machine output:
 
 ```bash
-canfar ps --json
-canfar ps --yaml
+canfar ps -o json
+canfar ps --output yaml
 ```
 
 `--quiet` is a human-output shortcut and is incompatible with machine output.
@@ -212,7 +212,7 @@ canfar version --debug
 `config set` parses values as YAML.
 `console.banner` defaults to `true`. Set it to `false` to hide the
 `@<server-name>` prefix from human-readable CLI output. The banner is always
-disabled for `--json` and `--yaml` output.
+disabled for `-o json` and `--output yaml` output.
 `version --debug` shows environment and dependency details for bug reports; it
 does not change the logging level.
 
@@ -220,9 +220,8 @@ does not change the logging level.
 
 | Rule | Behavior |
 | --- | --- |
-| Flags | `--json` or `--yaml`. |
-| Placement | Put the flag after the command, for example `canfar ps --json`. |
-| Conflict | `--json --yaml` exits 2. |
+| Option | `-o/--output` with `json` or `yaml`. |
+| Placement | Put the option after the command, for example `canfar ps -o json`. |
 | stdout | Data payload only. |
 | stderr | Diagnostics and errors. |
 | Unsupported command | Exits 1 with a clear unsupported-machine-output message. |

--- a/docs/cli/logging.md
+++ b/docs/cli/logging.md
@@ -40,10 +40,10 @@ Precedence is:
 `--log-level` therefore wins when it is combined with `-v`. Level names are
 case-insensitive.
 
-The machine-output flags remain leaf options after the command. For example:
+The machine-output option remains a leaf option after the command. For example:
 
 ```bash
-canfar --log-level debug ps --json
+canfar --log-level debug ps -o json
 ```
 
 The corresponding environment setting is:
@@ -97,7 +97,7 @@ DEBUG  HTTP STATUS CODE -> 200
 ```
 
 These lines follow the normal logging policy: stderr (and the optional file
-sink), never mixed into `--json`/`--yaml` stdout payloads.
+sink), never mixed into `-o json`/`--output yaml` stdout payloads.
 
 ## stdout and stderr
 
@@ -112,12 +112,12 @@ JSON and YAML stdout remain data-only at every log level. Redirect the streams
 independently when a script needs both:
 
 ```bash
-canfar --log-level debug ps --json \
+canfar --log-level debug ps -o json \
   > sessions.json \
   2> diagnostics.log
 ```
 
-In `--json` or `--yaml` mode, logging setup failures and file-sink warnings are
+In `-o json` or `--output yaml` mode, logging setup failures and file-sink warnings are
 serialized in the selected format on stderr. They never add a banner or log
 line to the command payload on stdout.
 

--- a/docs/cli/quick-start.md
+++ b/docs/cli/quick-start.md
@@ -70,7 +70,7 @@ canfar info $(canfar ps -q)
 Use machine output in scripts:
 
 ```bash
-canfar ps --json
+canfar ps -o json
 ```
 
 ## 6. Open the notebook
@@ -125,7 +125,7 @@ canfar create headless skaha/terminal:1.1.2 -- python /arc/projects/demo/run.py
 | Need another Server | `canfar server ls` then `canfar server use <name-or-uri>` |
 | Session is pending | `canfar events $(canfar ps -q)` |
 | Need cluster capacity | `canfar stats` |
-| Need structured output | `canfar ps --json` |
+| Need structured output | `canfar ps -o json` |
 
 Logging controls belong before the command. See
 [Logging and observability](logging.md) for the complete policy.

--- a/docs/client/quick-start.md
+++ b/docs/client/quick-start.md
@@ -78,7 +78,7 @@ async with AsyncSession() as session:
 | Authentication fails | Run `canfar --log-level debug login cadc --force`. |
 | Session does not start | Run `canfar stats`, then try smaller `cores` or `ram`. |
 | Browser URL fails | Wait 60-120 seconds and confirm the Session is `Running`. |
-| Script needs stable output | Use CLI machine output such as `canfar ps --json`. |
+| Script needs stable output | Use CLI machine output such as `canfar ps -o json`. |
 
 See [Logging](../cli/logging.md) for the CLI and Python
 logging controls.

--- a/docs/platform/sessions/batch.md
+++ b/docs/platform/sessions/batch.md
@@ -175,4 +175,4 @@ see the [registry guide](../containers/registry.md).
 | Command exits unexpectedly | `canfar logs SESSION_ID` |
 | Resource request waits too long | Try flexible mode or smaller fixed resources |
 | Image pull fails | Verify the image name and registry credentials |
-| Need structured Session data | `canfar ps --json` |
+| Need structured Session data | `canfar ps -o json` |

--- a/docs/presentations/srcnet-june-2026-demo.typ
+++ b/docs/presentations/srcnet-june-2026-demo.typ
@@ -56,11 +56,11 @@ Ubiquitous *front door* to the CANFAR Science Platform.
 ```bash
 canfar server use sweSRC
 canfar create headless skaha/base-notebook:latest -- env
-canfar logs $(canfar ps -a --json | jq -r ".[0].id")
+canfar logs $(canfar ps -a -o json | jq -r ".[0].id")
 
 canfar server use canSRC
 canfar create headless skaha/base-notebook:latest -- env
-canfar logs $(canfar ps -a --json | jq -r ".[0].id")
+canfar logs $(canfar ps -a -o json | jq -r ".[0].id")
 ```
 
 - Pick a node, browse images, launch a headless session, read its logs
@@ -72,11 +72,11 @@ canfar logs $(canfar ps -a --json | jq -r ".[0].id")
 == Machine output you can pipe
 
 ```bash
-canfar config get active.server --json
-canfar open $(canfar ps --json | jq -r ".[0].id")
+canfar config get active.server -o json
+canfar open $(canfar ps -o json | jq -r ".[0].id")
 ```
 
-- `--json` / `--yaml` on `auth`, `server`, `ps`, `config`
+- `-o/--output json|yaml` on `auth`, `server`, `ps`, `config`
 - Data on *stdout*, diagnostics on *stderr* → safe to pipe
 
 The same flow at package level, for notebooks and pipelines:

--- a/docs/releases/2026-2.md
+++ b/docs/releases/2026-2.md
@@ -68,10 +68,10 @@
 
         The CLI remembers the last valid server for each identity provider, so switching back and forth is seamless.
 
-    - **Script-friendly machine output** — `--json` and `--yaml` are now supported on `auth`, `server`, `ps` and `config` commands. Output is clean, stable-keyed data on stdout — errors and diagnostics go to stderr — so piping into tools like `jq` is safe,
+    - **Script-friendly machine output** — `-o/--output json|yaml` is supported on `auth`, `server`, `ps` and `config` commands. Output is clean, stable-keyed data on stdout — errors and diagnostics go to stderr — so piping into tools like `jq` is safe,
 
         ```bash
-        canfar config get active.server --json
+        canfar config get active.server -o json
         ```
   
     - **Scientist session names** — sessions launched without an explicit `--name` now get memorable defaults like `einstein`, `curie`, or `ramanujan` instead of random word pairs.

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -81,7 +81,10 @@ def test_config_get_full_server_record_includes_runtime_name(tmp_path: Path) -> 
         patch("canfar.cli.config.CONFIG_PATH", config_path),
         patch("canfar.models.config.CONFIG_PATH", config_path),
     ):
-        json_result = runner.invoke(config, ["get", "servers.canfar", "--json"])
+        json_result = runner.invoke(
+            config,
+            ["get", "servers.canfar", "--output", "json"],
+        )
         human_result = runner.invoke(config, ["get", "servers.canfar"])
 
     assert json_result.exit_code == 0
@@ -115,7 +118,10 @@ def test_config_get_full_credential_record_includes_runtime_idp(tmp_path: Path) 
         patch("canfar.cli.config.CONFIG_PATH", config_path),
         patch("canfar.models.config.CONFIG_PATH", config_path),
     ):
-        json_result = runner.invoke(config, ["get", "authentication.cadc", "--json"])
+        json_result = runner.invoke(
+            config,
+            ["get", "authentication.cadc", "--output", "json"],
+        )
         human_result = runner.invoke(config, ["get", "authentication.cadc"])
 
     assert json_result.exit_code == 0
@@ -205,14 +211,14 @@ def test_config_show_path_format_and_errors(tmp_path: Path) -> None:
 
 
 def test_config_show_json_emits_configuration_model(tmp_path: Path) -> None:
-    """``config show --json`` emits the Configuration model with stable keys."""
+    """``config show -o json`` emits the Configuration model with stable keys."""
     config_path = tmp_path / "config.yaml"
     with (
         _patch_config_path(config_path),
         patch("canfar.cli.config.CONFIG_PATH", config_path),
         patch("canfar.models.config.CONFIG_PATH", config_path),
     ):
-        result = runner.invoke(config, ["show", "--json"])
+        result = runner.invoke(config, ["show", "-o", "json"])
 
     assert result.exit_code == 0
     assert not result.stdout.startswith("@")
@@ -222,14 +228,14 @@ def test_config_show_json_emits_configuration_model(tmp_path: Path) -> None:
 
 
 def test_config_show_yaml_emits_configuration_model(tmp_path: Path) -> None:
-    """``config show --yaml`` emits the Configuration model on stdout."""
+    """``config show -o yaml`` emits the Configuration model on stdout."""
     config_path = tmp_path / "config.yaml"
     with (
         _patch_config_path(config_path),
         patch("canfar.cli.config.CONFIG_PATH", config_path),
         patch("canfar.models.config.CONFIG_PATH", config_path),
     ):
-        result = runner.invoke(config, ["show", "--yaml"])
+        result = runner.invoke(config, ["show", "-o", "yaml"])
 
     assert result.exit_code == 0
     payload = yaml.safe_load(result.stdout)
@@ -237,7 +243,7 @@ def test_config_show_yaml_emits_configuration_model(tmp_path: Path) -> None:
 
 
 def test_config_show_json_redacts_oidc_secrets(tmp_path: Path) -> None:
-    """``config show --json`` must not emit raw OIDC secrets from saved auth."""
+    """``config show -o json`` must not emit raw OIDC secrets from saved auth."""
     config_path = tmp_path / "config.yaml"
     config_path.write_text(
         yaml.dump(
@@ -278,7 +284,7 @@ def test_config_show_json_redacts_oidc_secrets(tmp_path: Path) -> None:
         patch("canfar.cli.config.CONFIG_PATH", config_path),
         patch("canfar.models.config.CONFIG_PATH", config_path),
     ):
-        result = runner.invoke(config, ["show", "--json"])
+        result = runner.invoke(config, ["show", "-o", "json"])
 
     assert result.exit_code == 0
     rendered = result.stdout
@@ -331,7 +337,7 @@ def test_config_show_json_keeps_null_secrets_null(tmp_path: Path) -> None:
         patch("canfar.cli.config.CONFIG_PATH", config_path),
         patch("canfar.models.config.CONFIG_PATH", config_path),
     ):
-        result = runner.invoke(config, ["show", "--json"])
+        result = runner.invoke(config, ["show", "--output", "json"])
 
     assert result.exit_code == 0
     oidc = json.loads(result.stdout)["authentication"]["srcnet"]
@@ -341,14 +347,14 @@ def test_config_show_json_keeps_null_secrets_null(tmp_path: Path) -> None:
 
 
 def test_config_get_json_emits_scalar_value(tmp_path: Path) -> None:
-    """``config get --json`` emits the resolved value without human formatting."""
+    """``config get -o json`` emits the resolved value without human formatting."""
     config_path = tmp_path / "config.yaml"
     with (
         _patch_config_path(config_path),
         patch("canfar.cli.config.CONFIG_PATH", config_path),
         patch("canfar.models.config.CONFIG_PATH", config_path),
     ):
-        result = runner.invoke(config, ["get", "console.width", "--json"])
+        result = runner.invoke(config, ["get", "console.width", "-o", "json"])
 
     assert result.exit_code == 0
     assert not result.stdout.startswith("@")
@@ -356,21 +362,24 @@ def test_config_get_json_emits_scalar_value(tmp_path: Path) -> None:
 
 
 def test_config_get_yaml_emits_scalar_value(tmp_path: Path) -> None:
-    """``config get --yaml`` emits the resolved scalar value on stdout."""
+    """``config get -o yaml`` emits the resolved scalar value on stdout."""
     config_path = tmp_path / "config.yaml"
     with (
         _patch_config_path(config_path),
         patch("canfar.cli.config.CONFIG_PATH", config_path),
         patch("canfar.models.config.CONFIG_PATH", config_path),
     ):
-        result = runner.invoke(config, ["get", "console.width", "--yaml"])
+        result = runner.invoke(
+            config,
+            ["get", "console.width", "--output", "yaml"],
+        )
 
     assert result.exit_code == 0
     assert yaml.safe_load(result.stdout) == 120
 
 
 def test_config_get_json_redacts_sensitive_paths(tmp_path: Path) -> None:
-    """``config get --json`` masks sensitive OIDC credential values."""
+    """``config get -o json`` masks sensitive OIDC credential values."""
     config_path = tmp_path / "config.yaml"
     config_path.write_text(
         yaml.dump(
@@ -410,7 +419,12 @@ def test_config_get_json_redacts_sensitive_paths(tmp_path: Path) -> None:
     ):
         result = runner.invoke(
             config,
-            ["get", "authentication.srcnet.client.secret", "--json"],
+            [
+                "get",
+                "authentication.srcnet.client.secret",
+                "--output",
+                "json",
+            ],
         )
 
     assert result.exit_code == 0
@@ -421,7 +435,7 @@ def test_config_get_json_redacts_sensitive_paths(tmp_path: Path) -> None:
 def test_config_get_json_redacts_secrets_inside_credential_record(
     tmp_path: Path,
 ) -> None:
-    """``config get authentication.<idp> --json`` masks nested OIDC secrets."""
+    """``config get authentication.<idp> -o json`` masks nested OIDC secrets."""
     config_path = tmp_path / "config.yaml"
     config_path.write_text(
         yaml.dump(
@@ -459,10 +473,13 @@ def test_config_get_json_redacts_secrets_inside_credential_record(
         patch("canfar.cli.config.CONFIG_PATH", config_path),
         patch("canfar.models.config.CONFIG_PATH", config_path),
     ):
-        record = runner.invoke(config, ["get", "authentication.srcnet", "--json"])
+        record = runner.invoke(
+            config,
+            ["get", "authentication.srcnet", "-o", "json"],
+        )
         token = runner.invoke(
             config,
-            ["get", "authentication.srcnet.token", "--json"],
+            ["get", "authentication.srcnet.token", "-o", "json"],
         )
 
     assert record.exit_code == 0

--- a/tests/test_cli_create.py
+++ b/tests/test_cli_create.py
@@ -111,11 +111,46 @@ class TestCreateCLI:
         mock_session_cls.return_value.__aenter__.return_value = mock_session
         mock_session.create.return_value = ["session-id"]
 
-        result = runner.invoke(create, ["headless", "skaha/worker:v1", "--json"])
+        result = runner.invoke(
+            create,
+            ["headless", "skaha/worker:v1", "--output", "json"],
+        )
 
         assert result.exit_code == 0
         assert json.loads(result.stdout) == ["session-id"]
         assert result.stderr == ""
+
+    @patch("canfar.cli.create.AsyncSession")
+    def test_create_output_option_stops_at_command_delimiter(
+        self,
+        mock_session_cls,
+    ):
+        """Only the output option before ``--`` is parsed by ``create``."""
+        mock_session = AsyncMock()
+        mock_session_cls.return_value.__aenter__.return_value = mock_session
+        mock_session.create.return_value = ["session-id"]
+
+        result = runner.invoke(
+            create,
+            [
+                "headless",
+                "skaha/worker:v1",
+                "--output",
+                "json",
+                "--",
+                "echo",
+                "-o",
+                "yaml",
+                "--output",
+                "json",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert json.loads(result.stdout) == ["session-id"]
+        request = mock_session.create.await_args.args[0]
+        assert request.cmd == "echo"
+        assert request.args == "-o yaml --output json"
 
     @patch("canfar.cli.create.AsyncSession")
     def test_create_command_debug_keeps_machine_stdout_data_only(
@@ -129,7 +164,7 @@ class TestCreateCLI:
 
         result = runner.invoke(
             create,
-            ["headless", "skaha/worker:v1", "--debug", "--json"],
+            ["headless", "skaha/worker:v1", "--debug", "--output", "json"],
         )
 
         assert result.exit_code == 0
@@ -149,7 +184,14 @@ class TestCreateCLI:
 
         result = runner.invoke(
             create,
-            ["headless", "skaha/worker:v1", "--replicas", "2", "--yaml"],
+            [
+                "headless",
+                "skaha/worker:v1",
+                "--replicas",
+                "2",
+                "--output",
+                "yaml",
+            ],
         )
 
         assert result.exit_code == 0
@@ -173,7 +215,10 @@ class TestCreateCLI:
 
     @pytest.mark.parametrize(
         ("flag", "load"),
-        [("--json", json.loads), ("--yaml", yaml.safe_load)],
+        [
+            (["--output", "json"], json.loads),
+            (["--output", "yaml"], yaml.safe_load),
+        ],
     )
     @patch("canfar.cli.create.AsyncSession")
     def test_create_command_machine_empty_is_transport_failure(
@@ -187,7 +232,7 @@ class TestCreateCLI:
         mock_session_cls.return_value.__aenter__.return_value = mock_session
         mock_session.create.return_value = []
 
-        result = runner.invoke(create, ["headless", "skaha/worker:v1", flag])
+        result = runner.invoke(create, ["headless", "skaha/worker:v1", *flag])
 
         assert result.exit_code == 1
         assert result.stdout == ""
@@ -196,7 +241,10 @@ class TestCreateCLI:
 
     @pytest.mark.parametrize(
         ("flag", "load"),
-        [("--json", json.loads), ("--yaml", yaml.safe_load)],
+        [
+            (["--output", "json"], json.loads),
+            (["--output", "yaml"], yaml.safe_load),
+        ],
     )
     @pytest.mark.parametrize(
         "invalid_args",
@@ -213,7 +261,7 @@ class TestCreateCLI:
         """Invalid command input fails before the Session boundary opens."""
         result = runner.invoke(
             create,
-            ["headless", "skaha/worker:v1", *invalid_args, flag],
+            ["headless", "skaha/worker:v1", *invalid_args, *flag],
         )
 
         assert result.exit_code == 1
@@ -271,23 +319,18 @@ class TestCreateCLI:
         """Dry-run diagnostics cannot contaminate machine stdout."""
         result = runner.invoke(
             create,
-            ["headless", "skaha/worker:v1", "--dry-run", "--json"],
+            [
+                "headless",
+                "skaha/worker:v1",
+                "--dry-run",
+                "--output",
+                "json",
+            ],
         )
 
         assert result.exit_code == 2
         assert result.stdout == ""
         assert "--dry-run" in result.stderr
-
-    def test_create_command_rejects_conflicting_machine_formats(self):
-        """The shared resolver rejects simultaneous JSON and YAML output."""
-        result = runner.invoke(
-            create,
-            ["headless", "skaha/worker:v1", "--json", "--yaml"],
-        )
-
-        assert result.exit_code == 2
-        assert result.stdout == ""
-        assert "Conflicting machine output flags" in result.stderr
 
     @patch("canfar.cli.create.AsyncSession")
     def test_create_command_exception(self, mock_session_cls):
@@ -303,7 +346,10 @@ class TestCreateCLI:
 
     @pytest.mark.parametrize(
         ("flag", "load"),
-        [("--json", json.loads), ("--yaml", yaml.safe_load)],
+        [
+            (["--output", "json"], json.loads),
+            (["--output", "yaml"], yaml.safe_load),
+        ],
     )
     @pytest.mark.parametrize("phase", ["enter", "body", "exit"])
     @patch("canfar.cli.create.AsyncSession")
@@ -326,7 +372,7 @@ class TestCreateCLI:
         }[phase]
         failing_call.side_effect = httpx.HTTPError(secret)
 
-        result = runner.invoke(create, ["headless", "skaha/worker:v1", flag])
+        result = runner.invoke(create, ["headless", "skaha/worker:v1", *flag])
 
         assert result.exit_code == 1
         assert result.stdout == ""
@@ -353,7 +399,10 @@ class TestCreateCLI:
 
     @pytest.mark.parametrize(
         ("flag", "load"),
-        [("--json", json.loads), ("--yaml", yaml.safe_load)],
+        [
+            (["--output", "json"], json.loads),
+            (["--output", "yaml"], yaml.safe_load),
+        ],
     )
     @pytest.mark.parametrize("phase", ["enter", "body", "exit"])
     @patch("canfar.cli.create.AsyncSession")
@@ -376,7 +425,7 @@ class TestCreateCLI:
         }[phase]
         failing_call.side_effect = KeyboardInterrupt(secret)
 
-        result = runner.invoke(create, ["headless", "skaha/worker:v1", flag])
+        result = runner.invoke(create, ["headless", "skaha/worker:v1", *flag])
 
         assert result.exit_code == 130
         assert result.stdout == ""

--- a/tests/test_cli_machine_output.py
+++ b/tests/test_cli_machine_output.py
@@ -130,12 +130,17 @@ def test_invalid_console_banner_value_fails_validation(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize(
     ("flag", "parser"),
-    [("--json", json.loads), ("--yaml", yaml.safe_load)],
+    [
+        (["-o", "json"], json.loads),
+        (["--output", "json"], json.loads),
+        (["-o", "yaml"], yaml.safe_load),
+        (["--output", "yaml"], yaml.safe_load),
+    ],
 )
 @pytest.mark.parametrize("banner", [True, False])
 def test_auth_ls_machine_stdout_is_data_only(
     tmp_path: Path,
-    flag: str,
+    flag: list[str],
     parser: Callable[[str], object],
     banner: bool,
 ) -> None:
@@ -144,15 +149,69 @@ def test_auth_ls_machine_stdout_is_data_only(
     _write_config(config_path, banner=banner)
 
     with _patch_config(config_path):
-        result = runner.invoke(cli, ["auth", "ls", flag])
+        result = runner.invoke(cli, ["auth", "ls", *flag])
 
     assert result.exit_code == 0
     assert not result.stdout.startswith("@")
     parser(result.stdout)
 
 
-def test_passthrough_json_argument_keeps_human_banner(tmp_path: Path) -> None:
-    """A container argument named ``--json`` does not select machine output."""
+@pytest.mark.parametrize(
+    ("option", "parser"),
+    [
+        (["-o", "json"], json.loads),
+        (["--output", "json"], json.loads),
+        (["-o", "yaml"], yaml.safe_load),
+        (["--output", "yaml"], yaml.safe_load),
+    ],
+)
+def test_auth_ls_output_option_is_data_only(
+    tmp_path: Path,
+    option: list[str],
+    parser: Callable[[str], object],
+) -> None:
+    """The leaf output option emits the filtered auth result as data only."""
+    config_path = tmp_path / "config.yaml"
+    _write_config(config_path)
+
+    with _patch_config(config_path):
+        result = runner.invoke(cli, ["auth", "ls", *option])
+
+    assert result.exit_code == 0
+    assert not result.stdout.startswith("@")
+    assert result.stderr == ""
+    parser(result.stdout)
+
+
+@pytest.mark.parametrize("legacy", ["--json", "--yaml"])
+def test_auth_ls_legacy_machine_switch_is_removed(legacy: str) -> None:
+    """The former format-specific switches are no longer leaf options."""
+    result = runner.invoke(cli, ["auth", "ls", legacy])
+
+    assert result.exit_code == 2
+    assert result.stdout == ""
+    assert legacy in click.unstyle(result.stderr)
+
+
+def test_auth_ls_invalid_output_format_is_rejected() -> None:
+    """Output formats are validated at the CLI boundary."""
+    result = runner.invoke(cli, ["auth", "ls", "--output", "toml"])
+
+    assert result.exit_code == 2
+    assert result.stdout == ""
+    assert "Invalid value" in click.unstyle(result.stderr)
+
+
+def test_auth_group_output_option_before_subcommand_is_rejected() -> None:
+    """The output option belongs to the emitting leaf command only."""
+    result = runner.invoke(cli, ["auth", "--output", "json", "ls"])
+
+    assert result.exit_code == 2
+    assert "--output" in click.unstyle(result.stderr)
+
+
+def test_passthrough_output_options_keep_human_banner(tmp_path: Path) -> None:
+    """Output-looking container arguments remain verbatim after ``--``."""
     config_path = tmp_path / "config.yaml"
     _write_config(config_path)
 
@@ -166,16 +225,19 @@ def test_passthrough_json_argument_keeps_human_banner(tmp_path: Path) -> None:
                 "example.invalid/image",
                 "--",
                 "echo",
-                "--json",
+                "-o",
+                "yaml",
+                "--output",
+                "json",
             ],
         )
 
     assert result.exit_code == 0
     assert result.stdout.startswith("@CADC-CANFAR")
-    assert "Arguments: --json" in result.stdout
+    assert "Arguments: -o yaml --output json" in result.stdout
 
 
-@pytest.mark.parametrize("name", ["--json", "--yaml"])
+@pytest.mark.parametrize("name", ["--output", "--json"])
 def test_machine_flag_spelling_as_option_value_keeps_human_banner(
     tmp_path: Path,
     name: str,
@@ -203,18 +265,22 @@ def test_machine_flag_spelling_as_option_value_keeps_human_banner(
 
 
 def test_auth_group_flag_before_subcommand_is_rejected(tmp_path: Path) -> None:
-    """Group-level ``--json``/``--yaml`` placement exits 2 with guidance."""
+    """Group-level output placement exits 2 with guidance."""
     config_path = tmp_path / "config.yaml"
     _write_config(config_path)
 
     with _patch_config(config_path):
-        json_result = runner.invoke(cli, ["auth", "--json", "ls"])
-        yaml_result = runner.invoke(cli, ["auth", "--yaml", "show"])
+        json_result = runner.invoke(cli, ["auth", "-o", "json", "ls"])
+        yaml_result = runner.invoke(cli, ["auth", "--output", "yaml", "show"])
 
     assert json_result.exit_code == 2
-    assert "Place --json or --yaml after the subcommand." in json_result.stderr
+    assert "Place --output json or --output yaml after the subcommand." in (
+        json_result.stderr
+    )
     assert yaml_result.exit_code == 2
-    assert "Place --json or --yaml after the subcommand." in yaml_result.stderr
+    assert "Place --output json or --output yaml after the subcommand." in (
+        yaml_result.stderr
+    )
 
 
 def test_ps_human_mode_emits_banner(tmp_path: Path) -> None:
@@ -236,13 +302,13 @@ def test_ps_human_mode_emits_banner(tmp_path: Path) -> None:
 
 
 def test_auth_default_json_matches_show(tmp_path: Path) -> None:
-    """Default ``auth`` emits the same payload as ``auth show --json``."""
+    """Default ``auth`` emits the same payload as ``auth show -o json``."""
     config_path = tmp_path / "config.yaml"
     _write_config(config_path)
 
     with _patch_config(config_path):
-        default_result = runner.invoke(cli, ["auth", "--json"])
-        show_result = runner.invoke(cli, ["auth", "show", "--json"])
+        default_result = runner.invoke(cli, ["auth", "-o", "json"])
+        show_result = runner.invoke(cli, ["auth", "show", "-o", "json"])
 
     assert default_result.exit_code == 0
     assert show_result.exit_code == 0
@@ -250,12 +316,12 @@ def test_auth_default_json_matches_show(tmp_path: Path) -> None:
 
 
 def test_auth_show_json_payload_shape(tmp_path: Path) -> None:
-    """``auth show --json`` emits a domain Authentication object without envelopes."""
+    """``auth show -o json`` emits a domain Authentication object without envelopes."""
     config_path = tmp_path / "config.yaml"
     _write_config(config_path)
 
     with _patch_config(config_path):
-        result = runner.invoke(cli, ["auth", "show", "--json"])
+        result = runner.invoke(cli, ["auth", "show", "-o", "json"])
 
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
@@ -265,12 +331,12 @@ def test_auth_show_json_payload_shape(tmp_path: Path) -> None:
 
 
 def test_auth_ls_json_payload_shape(tmp_path: Path) -> None:
-    """``auth ls --json`` emits a JSON array of Authentication objects."""
+    """``auth ls -o json`` emits a JSON array of Authentication objects."""
     config_path = tmp_path / "config.yaml"
     _write_config(config_path)
 
     with _patch_config(config_path):
-        result = runner.invoke(cli, ["auth", "ls", "--json"])
+        result = runner.invoke(cli, ["auth", "ls", "-o", "json"])
 
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
@@ -282,25 +348,18 @@ def test_auth_ls_json_payload_shape(tmp_path: Path) -> None:
     assert srcnet["server"] is None
 
 
-def test_root_json_flag_before_command_path_is_not_supported(
+def test_root_output_option_before_command_path_is_not_supported(
     tmp_path: Path,
 ) -> None:
-    """Root ``--json`` is rejected; supported commands own machine output."""
+    """Root output options are rejected; supported commands own machine output."""
     config_path = tmp_path / "config.yaml"
     _write_config(config_path)
 
     with _patch_config(config_path):
-        result = runner.invoke(cli, ["--json", "auth", "ls"])
+        result = runner.invoke(cli, ["-o", "json", "auth", "ls"])
 
     assert result.exit_code == 2
-    assert "--json" in click.unstyle(result.stderr)
-
-
-def test_conflicting_output_flags_exit_two() -> None:
-    """Conflicting machine output flags exit with code 2."""
-    result = runner.invoke(cli, ["auth", "ls", "--json", "--yaml"])
-    assert result.exit_code == 2
-    assert "Conflicting machine output flags" in result.stderr
+    assert "-o" in click.unstyle(result.stderr)
 
 
 def test_unsupported_command_rejects_leaf_json_flag() -> None:

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -6,7 +6,6 @@ import json
 from io import StringIO
 
 import pytest
-import typer
 import yaml
 from pydantic import BaseModel
 
@@ -31,27 +30,20 @@ def test_output_mode_values() -> None:
 
 
 def test_resolve_mode_defaults_to_human() -> None:
-    """No machine flags resolve to human output mode."""
-    assert machine.resolve_mode(json_output=False, yaml_output=False) == (
-        output.OutputMode.HUMAN
-    )
+    """No output option resolves to human output mode."""
+    assert machine.resolve_mode(None) == output.OutputMode.HUMAN
 
 
 def test_resolve_mode_json_and_yaml() -> None:
-    """Single machine flags select the matching output mode."""
-    assert machine.resolve_mode(json_output=True, yaml_output=False) == (
-        output.OutputMode.JSON
-    )
-    assert machine.resolve_mode(json_output=False, yaml_output=True) == (
-        output.OutputMode.YAML
-    )
+    """The output option selects the matching machine output mode."""
+    assert machine.resolve_mode("json") == output.OutputMode.JSON
+    assert machine.resolve_mode("yaml") == output.OutputMode.YAML
 
 
-def test_resolve_mode_conflict_exits_two() -> None:
-    """Conflicting machine output flags exit with code 2."""
-    with pytest.raises(typer.Exit) as exc_info:
-        machine.resolve_mode(json_output=True, yaml_output=True)
-    assert exc_info.value.exit_code == output.OUTPUT_CONFLICT_EXIT_CODE
+def test_resolve_mode_rejects_unknown_format() -> None:
+    """The resolver rejects formats outside the extensible output contract."""
+    with pytest.raises(ValueError, match="Unsupported output format"):
+        machine.resolve_mode("toml")
 
 
 def test_model_dump_includes_null_fields() -> None:
@@ -94,13 +86,13 @@ def test_render_stderr_error_json_on_stderr_channel() -> None:
     error = StructuredError(
         code="output.conflict",
         message="Conflicting output flags.",
-        hint="Use only one of --json or --yaml.",
+        hint="Use --output json or --output yaml.",
     )
     rendered = output.render_stderr_error(error, output.OutputMode.JSON)
     payload = json.loads(rendered)
     assert payload["code"] == "output.conflict"
     assert payload["message"] == "Conflicting output flags."
-    assert payload["hint"] == "Use only one of --json or --yaml."
+    assert payload["hint"] == "Use --output json or --output yaml."
 
 
 def test_render_stderr_error_yaml_on_stderr_channel() -> None:

--- a/tests/test_cli_server.py
+++ b/tests/test_cli_server.py
@@ -130,12 +130,12 @@ def test_server_use_selects_by_name(tmp_path: Path) -> None:
 
 
 def test_server_ls_json_output(tmp_path: Path) -> None:
-    """``server ls --json`` emits a JSON array of Server objects on stdout."""
+    """``server ls -o json`` emits a JSON array of Server objects on stdout."""
     config_path = tmp_path / "config.yaml"
     _write_config(config_path)
 
     with _patch_config(config_path):
-        result = runner.invoke(cli, ["server", "ls", "--json"])
+        result = runner.invoke(cli, ["server", "ls", "-o", "json"])
 
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
@@ -165,8 +165,8 @@ def test_server_ls_machine_output_includes_server_name(tmp_path: Path) -> None:
     _write_config(config_path)
 
     with _patch_config(config_path):
-        json_result = runner.invoke(cli, ["server", "ls", "--json"])
-        yaml_result = runner.invoke(cli, ["server", "ls", "--yaml"])
+        json_result = runner.invoke(cli, ["server", "ls", "--output", "json"])
+        yaml_result = runner.invoke(cli, ["server", "ls", "--output", "yaml"])
 
     assert json_result.exit_code == 0
     assert json.loads(json_result.stdout)[0]["name"] == "CADC-CANFAR"

--- a/tests/test_cli_stats_ps.py
+++ b/tests/test_cli_stats_ps.py
@@ -168,11 +168,14 @@ def test_ps_quiet_prints_all_matching_session_ids() -> None:
 
 @pytest.mark.parametrize(
     ("flag", "load"),
-    [("--json", json.loads), ("--yaml", yaml.safe_load)],
+    [
+        (["-o", "json"], json.loads),
+        (["--output", "yaml"], yaml.safe_load),
+    ],
 )
 def test_ps_machine_emits_filtered_session_array(
     tmp_path: Path,
-    flag: str,
+    flag: list[str],
     load: Callable[[str], object],
 ) -> None:
     """Machine ``ps`` emits validated session models with running-only filtering."""
@@ -188,7 +191,7 @@ def test_ps_machine_emits_filtered_session_array(
     ):
         session = _mock_async_session(session_cls)
         session.fetch.return_value = payloads
-        result = runner.invoke(ps, [flag])
+        result = runner.invoke(ps, flag)
 
     assert result.exit_code == 0
     assert not result.stdout.startswith("@")
@@ -212,7 +215,7 @@ def test_ps_json_kind_filter_parity(tmp_path: Path) -> None:
     ):
         session = _mock_async_session(session_cls)
         session.fetch.return_value = [payloads[0]]
-        result = runner.invoke(ps, ["--kind", "headless", "--json"])
+        result = runner.invoke(ps, ["--kind", "headless", "--output", "json"])
 
     assert result.exit_code == 0
     session.fetch.assert_awaited_once_with(kind="headless", status=None)
@@ -235,7 +238,7 @@ def test_ps_json_malformed_payload_keeps_stdout_pure(tmp_path: Path) -> None:
     ):
         session = _mock_async_session(session_cls)
         session.fetch.return_value = payloads
-        result = runner.invoke(ps, ["--json"])
+        result = runner.invoke(ps, ["--output", "json"])
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -244,9 +247,9 @@ def test_ps_json_malformed_payload_keeps_stdout_pure(tmp_path: Path) -> None:
     assert "validation error" in result.stderr.lower()
 
 
-def test_ps_quiet_with_json_exits_two() -> None:
-    """``ps --quiet`` is incompatible with machine output flags."""
-    result = runner.invoke(ps, ["--quiet", "--json"])
+def test_ps_quiet_with_machine_output_exits_two() -> None:
+    """``ps --quiet`` is incompatible with machine output."""
+    result = runner.invoke(ps, ["--quiet", "--output", "json"])
     assert result.exit_code == 2
     assert "quiet" in result.stderr.lower()
 

--- a/tests/test_cli_stream_contracts.py
+++ b/tests/test_cli_stream_contracts.py
@@ -92,8 +92,8 @@ def _client_factory(
     ("flags", "load"),
     [
         ([], None),
-        (["--json"], json.loads),
-        (["--yaml"], yaml.safe_load),
+        (["-o", "json"], json.loads),
+        (["--output", "yaml"], yaml.safe_load),
     ],
 )
 def test_config_success_warning_and_failure_keep_stream_contracts(
@@ -157,13 +157,13 @@ def test_config_success_warning_and_failure_keep_stream_contracts(
 @pytest.mark.parametrize(
     ("flag", "load"),
     [
-        ("--json", json.loads),
-        ("--yaml", yaml.safe_load),
+        (["-o", "json"], json.loads),
+        (["--output", "yaml"], yaml.safe_load),
     ],
 )
 def test_real_ps_log_and_payload_stay_on_separate_streams(
     tmp_path: Path,
-    flag: str,
+    flag: list[str],
     load: Callable[[str], Any],
 ) -> None:
     """A real HTTP-backed command emits logs beside one machine payload."""
@@ -181,7 +181,7 @@ def test_real_ps_log_and_payload_stay_on_separate_streams(
             side_effect=_async_client_factory(httpx.MockTransport(response)),
         ),
     ):
-        result = runner.invoke(cli, ["-vvvv", "ps", flag])
+        result = runner.invoke(cli, ["-vvvv", "ps", *flag])
 
     assert result.exit_code == 0
     assert load(result.stdout) == []
@@ -192,13 +192,13 @@ def test_real_ps_log_and_payload_stay_on_separate_streams(
 @pytest.mark.parametrize(
     ("flag", "load"),
     [
-        ("--json", json.loads),
-        ("--yaml", yaml.safe_load),
+        (["-o", "json"], json.loads),
+        (["--output", "yaml"], yaml.safe_load),
     ],
 )
 def test_ps_transport_failure_is_one_structured_machine_error(
     tmp_path: Path,
-    flag: str,
+    flag: list[str],
     load: Callable[[str], Any],
 ) -> None:
     """Expected HTTP transport failure preserves empty stdout and exit one."""
@@ -217,7 +217,7 @@ def test_ps_transport_failure_is_one_structured_machine_error(
             side_effect=_async_client_factory(httpx.MockTransport(unavailable)),
         ),
     ):
-        result = runner.invoke(cli, ["ps", flag])
+        result = runner.invoke(cli, ["ps", *flag])
 
     assert result.exit_code == 1
     assert result.stdout == ""
@@ -228,13 +228,13 @@ def test_ps_transport_failure_is_one_structured_machine_error(
 @pytest.mark.parametrize(
     ("flag", "load"),
     [
-        ("--json", json.loads),
-        ("--yaml", yaml.safe_load),
+        (["-o", "json"], json.loads),
+        (["--output", "yaml"], yaml.safe_load),
     ],
 )
 def test_fresh_server_discovery_keeps_progress_out_of_machine_payload(
     tmp_path: Path,
-    flag: str,
+    flag: list[str],
     load: Callable[[str], Any],
 ) -> None:
     """Fresh registry discovery emits progress on stderr and data on stdout."""
@@ -279,7 +279,7 @@ def test_fresh_server_discovery_keeps_progress_out_of_machine_payload(
             side_effect=_client_factory(httpx.MockTransport(capability_response)),
         ),
     ):
-        result = runner.invoke(cli, ["server", "ls", flag])
+        result = runner.invoke(cli, ["server", "ls", *flag])
 
     assert result.exit_code == 0, result.stderr
     payload = load(result.stdout)
@@ -317,13 +317,13 @@ def test_fresh_server_discovery_errors_are_diagnostics(
 @pytest.mark.parametrize(
     ("flag", "load"),
     [
-        ("--json", json.loads),
-        ("--yaml", yaml.safe_load),
+        (["-o", "json"], json.loads),
+        (["--output", "yaml"], yaml.safe_load),
     ],
 )
 def test_fresh_server_discovery_failure_is_one_structured_machine_error(
     tmp_path: Path,
-    flag: str,
+    flag: list[str],
     load: Callable[[str], Any],
 ) -> None:
     """Registry transport failure emits one machine-readable boundary error."""
@@ -341,7 +341,7 @@ def test_fresh_server_discovery_failure_is_one_structured_machine_error(
             side_effect=_async_client_factory(httpx.MockTransport(unavailable)),
         ),
     ):
-        result = runner.invoke(cli, ["server", "ls", flag])
+        result = runner.invoke(cli, ["server", "ls", *flag])
 
     assert result.exit_code == 1
     assert result.stdout == ""
@@ -352,11 +352,11 @@ def test_fresh_server_discovery_failure_is_one_structured_machine_error(
 @pytest.mark.parametrize(
     "command",
     [
-        ["config", "get", "console.width", "--json"],
-        ["auth", "show", "--json"],
-        ["auth", "ls", "--json"],
-        ["server", "ls", "--json"],
-        ["ps", "--json"],
+        ["config", "get", "console.width", "--output", "json"],
+        ["auth", "show", "--output", "json"],
+        ["auth", "ls", "--output", "json"],
+        ["server", "ls", "--output", "json"],
+        ["ps", "--output", "json"],
     ],
 )
 def test_malformed_config_is_structured_for_every_machine_command(
@@ -379,19 +379,19 @@ def test_malformed_config_is_structured_for_every_machine_command(
 @pytest.mark.parametrize(
     ("flag", "load"),
     [
-        ("--json", json.loads),
-        ("--yaml", yaml.safe_load),
+        (["-o", "json"], json.loads),
+        (["--output", "yaml"], yaml.safe_load),
     ],
 )
 def test_invalid_logging_environment_is_one_structured_machine_error(
     monkeypatch: pytest.MonkeyPatch,
-    flag: str,
+    flag: list[str],
     load: Callable[[str], Any],
 ) -> None:
     """Root dispatch preserves parsed leaf args for callback setup failures."""
     monkeypatch.setenv("CANFAR_LOGLEVEL", "chatty")
 
-    result = runner.invoke(cli, ["config", "get", "console.width", flag])
+    result = runner.invoke(cli, ["config", "get", "console.width", *flag])
 
     assert result.exit_code == 2
     assert result.stdout == ""
@@ -417,7 +417,8 @@ def test_relative_log_file_creates_parents_without_contaminating_stdout(
             "config",
             "get",
             "console.width",
-            "--json",
+            "--output",
+            "json",
         ],
     )
 
@@ -430,14 +431,18 @@ def test_relative_log_file_creates_parents_without_contaminating_stdout(
 @pytest.mark.parametrize(("target", "directory"), [("-", False), ("logs", True)])
 @pytest.mark.parametrize(
     ("flag", "load"),
-    [(None, None), ("--json", json.loads), ("--yaml", yaml.safe_load)],
+    [
+        (None, None),
+        (["--output", "json"], json.loads),
+        (["--output", "yaml"], yaml.safe_load),
+    ],
 )
 def test_invalid_log_file_target_is_a_structured_setup_error(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     target: str,
     directory: bool,
-    flag: str | None,
+    flag: list[str] | None,
     load: Callable[[str], Any] | None,
 ) -> None:
     """Directory and pseudo-file targets fail at the existing setup boundary."""
@@ -446,7 +451,7 @@ def test_invalid_log_file_target_is_a_structured_setup_error(
         (tmp_path / target).mkdir()
     args = ["--log-file", target, "config", "get", "console.width"]
     if flag:
-        args.append(flag)
+        args.extend(flag)
 
     result = runner.invoke(cli, args)
 
@@ -461,18 +466,22 @@ def test_invalid_log_file_target_is_a_structured_setup_error(
 
 @pytest.mark.parametrize(
     ("flag", "load"),
-    [(None, None), ("--json", json.loads), ("--yaml", yaml.safe_load)],
+    [
+        (None, None),
+        (["--output", "json"], json.loads),
+        (["--output", "yaml"], yaml.safe_load),
+    ],
 )
 def test_log_file_initialization_failure_keeps_command_running(
     tmp_path: Path,
-    flag: str | None,
+    flag: list[str] | None,
     load: Callable[[str], Any] | None,
 ) -> None:
     """An unavailable sink emits one mode-aware structured warning."""
     log_file = tmp_path / "unavailable.jsonl"
     args = ["--log-file", str(log_file), "config", "get", "console.width"]
     if flag:
-        args.append(flag)
+        args.extend(flag)
 
     with patch(
         "logging.handlers.RotatingFileHandler.__init__",

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -73,13 +73,13 @@ class TestStructuredErrorSerialization:
         error = StructuredError(
             code=ErrorCode.OUTPUT_CONFLICT,
             message="Conflicting machine output flags.",
-            hint="Use only one of --json or --yaml.",
+            hint="Use --output json or --output yaml.",
         )
         payload = json.loads(structured_error_to_json(error))
         assert payload == {
             "code": "output.conflict",
             "message": "Conflicting machine output flags.",
-            "hint": "Use only one of --json or --yaml.",
+            "hint": "Use --output json or --output yaml.",
         }
 
     def test_structured_error_to_json_includes_null_hint(self) -> None:


### PR DESCRIPTION
## Summary

- Replace leaf `--json` and `--yaml` switches with extensible `-o/--output json|yaml` options.
- Preserve filtered command results, human rendering, stdout/stderr separation, and create passthrough arguments after `--`.
- Update CLI and user-facing documentation.

Closes #253

## RED

Added CliRunner contracts first for short/long option spellings, invalid formats, legacy-switch rejection, leaf-only placement, filtered `ps` output, stream separation, and create delimiter handling. The new contracts failed against the paired-switch implementation.

## GREEN

Implemented the shared `OutputFormat`/`OutputOption` seam and migrated auth, server, create, ps, and config leaf commands. Banner/setup mode detection now follows `-o/--output` before a create `--` delimiter; payload serialization continues to use the existing filtered result/model and `to_jsonable_python` path.

## Validation

- Focused CLI contracts: `140 passed`.
- Ruff: `uv run --no-sync ruff check . --no-cache` passed.
- Type check: `uv run ty check canfar` passed.
- Docs: `uv run --group docs mkdocs build` passed.
- Deterministic suite: `848 passed`; two unrelated pre-existing configuration tests still fail in `tests/test_models_config.py::TestConfigurationSerialization::test_v1_storage_json_and_yaml_round_trip` and `tests/test_config.py::TestConfigServices::test_selection_service_sets_active_server` (both reproduce in isolation).
