### PR TITLE
fix(test): isolate pytest HOME per run

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,19 +8,19 @@ from pathlib import Path
 
 import pytest
 
-ISOLATED_HOME = Path(
-    os.environ.get(
-        "CANFAR_TEST_HOME",
-        str(Path(tempfile.gettempdir()) / "canfar-empty-home"),
-    )
-)
+_REQUESTED_TEST_HOME = os.environ.get("CANFAR_TEST_HOME")
+if _REQUESTED_TEST_HOME is None:
+    _REQUESTED_TEST_HOME = tempfile.mkdtemp(prefix="canfar-test-home-")
+
+ISOLATED_HOME = Path(_REQUESTED_TEST_HOME)
+os.environ["CANFAR_TEST_HOME"] = _REQUESTED_TEST_HOME
+os.environ["HOME"] = _REQUESTED_TEST_HOME
+ISOLATED_HOME.mkdir(parents=True, exist_ok=True)
 
 
 def pytest_configure(config: pytest.Config) -> None:  # noqa: ARG001
-    """Isolate ``HOME`` so tests never consume developer configuration."""
+    """Ensure the isolated HOME exists before collection starts."""
     ISOLATED_HOME.mkdir(parents=True, exist_ok=True)
-    os.environ["CANFAR_TEST_HOME"] = str(ISOLATED_HOME)
-    os.environ["HOME"] = str(ISOLATED_HOME)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_import_isolation.py
+++ b/tests/test_import_isolation.py
@@ -14,6 +14,87 @@ def test_conftest_isolates_home() -> None:
     assert Path(os.environ["HOME"]) == Path(os.environ["CANFAR_TEST_HOME"])
 
 
+def _run_home_probe(
+    tmp_path: Path,
+    *,
+    test_home: str | None = None,
+) -> list[tuple[str, str]]:
+    """Run isolated probe tests and return each worker's HOME values."""
+    probe_dir = tmp_path / "probe"
+    probe_dir.mkdir(parents=True)
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    probe = """
+import os
+from pathlib import Path
+
+
+def test_home():
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
+    output_dir = Path(os.environ["PROBE_OUTPUT_DIR"])
+    (output_dir / f"{Path(__file__).stem}-{worker}").write_text(
+        f"{os.environ['HOME']}\\n{os.environ['CANFAR_TEST_HOME']}",
+        encoding="utf-8",
+    )
+"""
+    for name in ("one", "two"):
+        (probe_dir / f"test_probe_{name}.py").write_text(probe, encoding="utf-8")
+
+    environment = os.environ.copy()
+    environment.pop("CANFAR_TEST_HOME", None)
+    environment["PROBE_OUTPUT_DIR"] = str(output_dir)
+    if test_home is not None:
+        environment["CANFAR_TEST_HOME"] = test_home
+
+    result = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(probe_dir),
+            "-p",
+            "tests.conftest",
+            "-n2",
+            "--dist=loadfile",
+            "--no-cov",
+            "-q",
+        ],
+        capture_output=True,
+        check=False,
+        cwd=Path.cwd(),
+        env=environment,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return [
+        tuple(path.read_text(encoding="utf-8").splitlines())
+        for path in sorted(output_dir.iterdir())
+    ]
+
+
+def test_default_home_is_fresh_per_run_and_shared_by_workers(tmp_path: Path) -> None:
+    """Default test HOME must not retain state between pytest invocations."""
+    first = _run_home_probe(tmp_path / "first")
+    second = _run_home_probe(tmp_path / "second")
+
+    assert len(first) == len(second) == 2
+    assert len({home for home, _ in first}) == 1
+    assert len({test_home for _, test_home in first}) == 1
+    assert first[0][0] == first[0][1]
+    assert second[0][0] == second[0][1]
+    assert first[0][0] != second[0][0]
+
+
+def test_explicit_home_is_preserved_for_workers(tmp_path: Path) -> None:
+    """An explicit test HOME remains unchanged, including its spelling."""
+    explicit = f"{tmp_path / 'explicit-home'}/"
+
+    values = _run_home_probe(tmp_path / "explicit", test_home=explicit)
+
+    assert len(values) == 2
+    assert values == [(explicit, explicit), (explicit, explicit)]
+
+
 def test_stale_list_config_does_not_break_canfar_or_cli_imports(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- Allocate a fresh temporary HOME for each pytest process when `CANFAR_TEST_HOME` is unset.
- Preserve an explicitly supplied `CANFAR_TEST_HOME` value exactly and propagate the selected HOME to xdist workers.
- Add subprocess regression coverage for consecutive runs, explicit overrides, and worker sharing.

## Root cause

`tests/conftest.py` reused `/tmp/canfar-empty-home`, allowing persisted configuration from an earlier run to affect later deterministic tests. The environment is now selected during conftest import, before CANFAR configuration paths are frozen during collection.

## Validation

- Two consecutive deterministic non-slow runs: `850 passed` each.
- Focused regression and named configuration tests pass under xdist.
- `uv run --no-sync ruff check . --no-cache`
- `uv run ty check canfar`

Relates to #244
