### PR TITLE
refactor: apply Wave 2 review corrections

### DIFF
--- a/canfar/authentication.py
+++ b/canfar/authentication.py
@@ -210,51 +210,6 @@ def _has_authentication(config: Configuration, idp: str) -> bool:
     return idp in config.authentication
 
 
-def _selection_history(config: Configuration) -> dict[str, str]:
-    """Return remembered server selections including the active pair."""
-    selections = dict(config.active.servers)
-    active_name = config.active.server
-    if active_name is None:
-        return selections
-
-    active_server = config.servers.get(active_name)
-    if (
-        active_server is not None
-        and active_server.idp == config.active.authentication
-        and active_server.name is not None
-    ):
-        selections[config.active.authentication] = active_server.name
-    return selections
-
-
-def _select_authentication(config: Configuration, idp: str) -> None:
-    """Select an Authentication Record and its remembered Server, if any."""
-    selections = _selection_history(config)
-    server_name = selections.get(idp)
-    if server_name is not None:
-        remembered = config.servers.get(server_name)
-        if remembered is None or remembered.idp != idp:
-            server_name = None
-
-    if server_name is None:
-        server_name = config.active.server
-        active_server = (
-            config.servers.get(server_name) if server_name is not None else None
-        )
-        if active_server is None or active_server.idp != idp:
-            server_name = None
-
-    active = config.active.model_copy(
-        update={
-            "authentication": idp,
-            "server": server_name,
-            "servers": selections,
-        },
-    )
-    config.editor.set("active", active)
-    config.editor.save()
-
-
 def _remove_authentication(config: Configuration, idp: str) -> None:
     """Remove one Authentication Record and its associated Server state."""
     authentication = dict(config.authentication)

--- a/canfar/cli/machine.py
+++ b/canfar/cli/machine.py
@@ -2,23 +2,15 @@
 
 from __future__ import annotations
 
-from enum import Enum
-from typing import Annotated
+from typing import Annotated, Literal
 
 import typer
 
 from canfar.cli import output
 
 
-class OutputFormat(str, Enum):
-    """Machine output formats accepted by leaf commands."""
-
-    JSON = "json"
-    YAML = "yaml"
-
-
 OutputOption = Annotated[
-    OutputFormat | None,
+    Literal["json", "yaml"] | None,
     typer.Option(
         "-o",
         "--output",
@@ -29,7 +21,7 @@ OutputOption = Annotated[
 """Leaf command option for selecting machine output format."""
 
 
-def resolve_mode(output_format: OutputFormat | str | None) -> output.OutputMode:
+def resolve_mode(output_format: str | None) -> output.OutputMode:
     """Resolve machine output mode from the leaf output option.
 
     Args:
@@ -43,14 +35,4 @@ def resolve_mode(output_format: OutputFormat | str | None) -> output.OutputMode:
     """
     if output_format is None:
         return output.OutputMode.HUMAN
-    value = (
-        output_format.value
-        if isinstance(output_format, OutputFormat)
-        else output_format
-    )
-    if value == "json":
-        return output.OutputMode.JSON
-    if value == "yaml":
-        return output.OutputMode.YAML
-    message = f"Unsupported output format: {value}"
-    raise ValueError(message)
+    return output.OutputMode(output_format)

--- a/canfar/cli/machine.py
+++ b/canfar/cli/machine.py
@@ -8,7 +8,6 @@ import typer
 
 from canfar.cli import output
 
-
 OutputOption = Annotated[
     Literal["json", "yaml"] | None,
     typer.Option(

--- a/docs/agents/research/2026-07-25-storage-python-api.md
+++ b/docs/agents/research/2026-07-25-storage-python-api.md
@@ -31,10 +31,11 @@ What changed, VERIFIED against the live service on 0.8.0:
   `AttributeError: 'StagedReadFile' object has no attribute 'blocksize'`.
   `Range` is honoured for byte reads, not through the file-object path.
 
-The recommended module has since shipped as `canfar/storage.py`, adding
-attribute access (`from canfar.storage import vault, arc`) on top of the
-`filesystem` / `fetch` / `sources` surface proposed below, so any text quoting
-the old "no public CANFAR storage Python API" wording is historical.
+The shipped module's public surface is now `identifiers()` and `filesystem()`.
+The earlier proposals for dynamic attributes, `fetch()`, and public `sources()`
+were superseded: callers pass Storage Identifiers explicitly, materialize with
+standard fsspec methods, and the fsspec-cli source mapping remains private
+(`_sources()`). No dynamic protocols or module attributes are registered.
 
 Sections 2 and 4 describe the 0.7.0 behaviour and are kept as the historical
 record. The single-cache-layer recommendation in the Verdict stands, but its

--- a/docs/cli/authentication-contexts.md
+++ b/docs/cli/authentication-contexts.md
@@ -155,7 +155,7 @@ Legacy or unsupported config files are backed up to
 | Unsupported placement | `canfar auth -o json ls` exits 2. |
 | stdout | Data only in machine mode. |
 | stderr | Diagnostics and errors. |
-| Unsupported commands | Exit 1 with `machine output not supported for this command yet` and `use default human output for now`. |
+| Unsupported commands | Leaf commands without machine output do not define `-o/--output`; Click rejects the option with exit 2 and a parser error on stderr. |
 
 Lists have no ordering guarantee. Scripts should select by IDP key, Server
 Name, URI, Session ID, or another stable field.

--- a/docs/cli/cli-help.md
+++ b/docs/cli/cli-help.md
@@ -224,5 +224,5 @@ does not change the logging level.
 | Placement | Put the option after the command, for example `canfar ps -o json`. |
 | stdout | Data payload only. |
 | stderr | Diagnostics and errors. |
-| Unsupported command | Exits 1 with a clear unsupported-machine-output message. |
+| Unsupported command | Leaf commands without machine output do not define `-o/--output`; Click rejects the option with exit 2 and a parser error on stderr. |
 | Ordering | List ordering is not guaranteed. |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,11 +18,6 @@ os.environ["HOME"] = _REQUESTED_TEST_HOME
 ISOLATED_HOME.mkdir(parents=True, exist_ok=True)
 
 
-def pytest_configure(config: pytest.Config) -> None:  # noqa: ARG001
-    """Ensure the isolated HOME exists before collection starts."""
-    ISOLATED_HOME.mkdir(parents=True, exist_ok=True)
-
-
 @pytest.fixture(autouse=True)
 def isolate_canfar_environment(monkeypatch: pytest.MonkeyPatch) -> None:
     """Clear CANFAR env overrides so tests do not depend on shell state."""

--- a/tests/test_cli_machine_output.py
+++ b/tests/test_cli_machine_output.py
@@ -153,32 +153,6 @@ def test_auth_ls_machine_stdout_is_data_only(
 
     assert result.exit_code == 0
     assert not result.stdout.startswith("@")
-    parser(result.stdout)
-
-
-@pytest.mark.parametrize(
-    ("option", "parser"),
-    [
-        (["-o", "json"], json.loads),
-        (["--output", "json"], json.loads),
-        (["-o", "yaml"], yaml.safe_load),
-        (["--output", "yaml"], yaml.safe_load),
-    ],
-)
-def test_auth_ls_output_option_is_data_only(
-    tmp_path: Path,
-    option: list[str],
-    parser: Callable[[str], object],
-) -> None:
-    """The leaf output option emits the filtered auth result as data only."""
-    config_path = tmp_path / "config.yaml"
-    _write_config(config_path)
-
-    with _patch_config(config_path):
-        result = runner.invoke(cli, ["auth", "ls", *option])
-
-    assert result.exit_code == 0
-    assert not result.stdout.startswith("@")
     assert result.stderr == ""
     parser(result.stdout)
 
@@ -200,14 +174,6 @@ def test_auth_ls_invalid_output_format_is_rejected() -> None:
     assert result.exit_code == 2
     assert result.stdout == ""
     assert "Invalid value" in click.unstyle(result.stderr)
-
-
-def test_auth_group_output_option_before_subcommand_is_rejected() -> None:
-    """The output option belongs to the emitting leaf command only."""
-    result = runner.invoke(cli, ["auth", "--output", "json", "ls"])
-
-    assert result.exit_code == 2
-    assert "--output" in click.unstyle(result.stderr)
 
 
 def test_passthrough_output_options_keep_human_banner(tmp_path: Path) -> None:
@@ -367,3 +333,12 @@ def test_unsupported_command_rejects_leaf_json_flag() -> None:
     result = runner.invoke(cli, ["auth", "purge", "--json", "--force"])
     assert result.exit_code == 2
     assert "--json" in click.unstyle(result.stderr)
+
+
+def test_unsupported_command_rejects_leaf_output_option() -> None:
+    """Commands without machine flags let Click reject the ``-o`` option."""
+    result = runner.invoke(cli, ["auth", "purge", "-o", "json", "--force"])
+
+    assert result.exit_code == 2
+    assert result.stdout == ""
+    assert "No such option: -o" in click.unstyle(result.stderr)

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -42,7 +42,7 @@ def test_resolve_mode_json_and_yaml() -> None:
 
 def test_resolve_mode_rejects_unknown_format() -> None:
     """The resolver rejects formats outside the extensible output contract."""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="not a valid OutputMode"):
         machine.resolve_mode("toml")
 
 

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -42,7 +42,7 @@ def test_resolve_mode_json_and_yaml() -> None:
 
 def test_resolve_mode_rejects_unknown_format() -> None:
     """The resolver rejects formats outside the extensible output contract."""
-    with pytest.raises(ValueError, match="Unsupported output format"):
+    with pytest.raises(ValueError):
         machine.resolve_mode("toml")
 
 


### PR DESCRIPTION
Applies the accepted Wave 2 standards, specification, and simplify findings for #244.

- deletes unreachable authentication-side Server Selection policy; server.py remains the sole live owner
- removes the duplicate output enum and defensive mode plumbing
- contracts duplicate CLI tests and redundant pytest setup
- documents unsupported `-o/--output` on non-emitting leaves truthfully as Click exit 2
- updates the older storage research note to the current `identifiers()`/`filesystem()` surface

Net diff: 21 additions, 114 deletions across 8 files.

Validation:
- 110 focused tests pass
- 857 deterministic non-slow tests pass
- Ruff and ty pass
- MkDocs builds
- diff check passes

Base: `feat/interfaces`; this does not target `main` directly.