### PR TITLE
fix: address wave 3 review findings

### DIFF
--- a/canfar/cli/create.py
+++ b/canfar/cli/create.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Annotated, Any, get_args
+from typing import Annotated, Any, get_args
 
 import click
 import httpx
 import typer
 from pydantic import ValidationError
-from typer.core import TyperCommand, TyperGroup
 
 from canfar.cli import output
 from canfar.cli._run import run
@@ -22,47 +21,10 @@ from canfar.sessions import AsyncSession
 from canfar.utils import funny
 from canfar.utils.console import emit_cli_active_server_banner, get_console
 
-if TYPE_CHECKING:
-    from typer._click.core import Context
-
 kinds: list[str] = list(get_args(Kind))
 # Remove desktop-app from the list of kinds for usage message since,
 # they can only be created from within a desktop session.
 kinds.remove("desktop-app")
-
-
-class CreateUsageMessage(TyperGroup):
-    """Custom usage message for create command.
-
-    Args:
-        typer (TyperGroup): Base class for grouping commands in Typer.
-    """
-
-    def get_usage(self, ctx: Context) -> str:  # noqa: ARG002
-        """Get the usage message for the create command.
-
-        Args:
-            ctx (typer.Context): The Typer context.
-
-        Returns:
-            str: The usage message.
-        """
-        return "Usage: canfar create [OPTIONS] KIND IMAGE [-- CMD [ARGS]...]"
-
-
-class CreateCommandUsageMessage(TyperCommand):
-    """Keep the root create usage text aligned with its delimiter contract."""
-
-    def get_usage(self, ctx: Context) -> str:  # noqa: ARG002
-        """Return the documented create usage line."""
-        return "Usage: canfar create [OPTIONS] KIND IMAGE [-- CMD [ARGS]...]"
-
-
-create = typer.Typer(
-    name="create",
-    no_args_is_help=True,
-    cls=CreateUsageMessage,
-)
 
 
 def _parse_environment(env: list[str] | None) -> dict[str, Any]:
@@ -140,13 +102,6 @@ def _render_create_result(
     raise typer.Exit(1)
 
 
-@create.callback(
-    invoke_without_command=True,
-    context_settings={
-        "help_option_names": ["-h", "--help"],
-        "allow_interspersed_args": True,
-    },
-)
 def creation(  # noqa: PLR0917
     kind: Annotated[
         Kind,

--- a/canfar/cli/delete.py
+++ b/canfar/cli/delete.py
@@ -11,13 +11,7 @@ from canfar.cli._run import run
 from canfar.sessions import AsyncSession
 from canfar.utils.console import emit_cli_active_server_banner, get_console
 
-delete = typer.Typer(
-    name="delete",
-    no_args_is_help=True,
-)
 
-
-@delete.callback(invoke_without_command=True)
 def delete_sessions(
     session_ids: Annotated[
         list[str],

--- a/canfar/cli/events.py
+++ b/canfar/cli/events.py
@@ -13,14 +13,7 @@ from canfar.cli._run import run
 from canfar.sessions import AsyncSession
 from canfar.utils.console import emit_cli_active_server_banner, get_console
 
-events = typer.Typer(
-    name="events",
-    help="List events for sessions.",
-    no_args_is_help=False,
-)
 
-
-@events.callback(invoke_without_command=True)
 def get_events(
     session_ids: Annotated[
         list[str],

--- a/canfar/cli/info.py
+++ b/canfar/cli/info.py
@@ -16,13 +16,6 @@ from canfar.models.session import FetchResponse
 from canfar.sessions import AsyncSession
 from canfar.utils.console import emit_cli_active_server_banner, get_console
 
-info = typer.Typer(
-    name="info",
-    help="Get detailed information about sessions.",
-    no_args_is_help=True,
-    context_settings={"allow_interspersed_args": True},
-)
-
 ALL_FIELDS: dict[str, str] = {
     "id": "Session ID",
     "name": "Name",
@@ -168,7 +161,6 @@ async def _get_info(
         _display(response, debug=debug)
 
 
-@info.callback(invoke_without_command=True)
 def get_info(
     session_ids: Annotated[
         list[str],

--- a/canfar/cli/logs.py
+++ b/canfar/cli/logs.py
@@ -10,14 +10,7 @@ from canfar.cli._run import run
 from canfar.sessions import AsyncSession
 from canfar.utils.console import emit_cli_active_server_banner, get_console
 
-logs = typer.Typer(
-    name="logs",
-    help="Get logs for sessions.",
-    no_args_is_help=True,
-)
 
-
-@logs.callback(invoke_without_command=True)
 def get_logs(
     session_ids: Annotated[
         list[str],

--- a/canfar/cli/main.py
+++ b/canfar/cli/main.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from pathlib import Path  # noqa: TC003 - Typer resolves callback annotations at runtime
 from typing import TYPE_CHECKING, Annotated
 
+import click
 import typer
+from typer.core import TyperGroup
 
 from canfar.cli import output
 from canfar.cli.auth import auth
@@ -38,7 +40,39 @@ if TYPE_CHECKING:
     from canfar.errors import StructuredError
 
 
-_MACHINE_OUTPUT_GROUPS = frozenset({"auth", "config", "create", "ps", "server"})
+_ROOT_CHILD_ARGS_META_KEY = "canfar.root_child_args"
+
+
+def _leaf_output_mode(args: list[str]) -> output.OutputMode:
+    """Infer a leaf output option before root setup has completed."""
+    for index, arg in enumerate(args):
+        if arg == "--":
+            break
+        if arg in {"-o", "--output"} and index + 1 < len(args):
+            value = args[index + 1]
+            if value in {"json", "yaml"}:
+                return output.OutputMode(value)
+        if arg.startswith("--output=") and arg.removeprefix("--output=") in {
+            "json",
+            "yaml",
+        }:
+            return output.OutputMode(arg.removeprefix("--output="))
+        if arg.startswith("-o") and arg not in {"-o", "--output"}:
+            value = arg.removeprefix("-o")
+            if value in {"json", "yaml"}:
+                return output.OutputMode(value)
+    return output.OutputMode.HUMAN
+
+
+class _RootTyperGroup(TyperGroup):
+    """Capture child argv so root setup can infer a leaf output mode."""
+
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        """Record unconsumed child arguments without changing dispatch."""
+        child_args = super().parse_args(ctx, args)
+        if ctx.parent is None:
+            ctx.meta[_ROOT_CHILD_ARGS_META_KEY] = list(child_args)
+        return child_args
 
 
 def callback(
@@ -66,17 +100,11 @@ def callback(
             help="Write JSON Lines logs to this file.",
         ),
     ] = None,
-) -> None:
+    ) -> None:
     """Main callback that handles no subcommand case."""
     activate_cli_root(ctx)
-    # Root setup runs before a nested command parses its own options.  Commands
-    # that own machine output therefore use structured setup diagnostics; all
-    # other root commands retain the human diagnostic path.
-    setup_mode = (
-        output.OutputMode.JSON
-        if ctx.invoked_subcommand in _MACHINE_OUTPUT_GROUPS
-        else output.OutputMode.HUMAN
-    )
+    child_args: list[str] = ctx.meta.get(_ROOT_CHILD_ARGS_META_KEY, [])
+    setup_mode = _leaf_output_mode(child_args)
 
     def warning_writer(error: StructuredError) -> None:
         if setup_mode is output.OutputMode.HUMAN:
@@ -116,6 +144,7 @@ cli: typer.Typer = typer.Typer(
     rich_help_panel="CANFAR CLI Commands",
     callback=callback,
     invoke_without_command=True,
+    cls=_RootTyperGroup,
 )
 
 register_login_command(cli)

--- a/canfar/cli/main.py
+++ b/canfar/cli/main.py
@@ -118,7 +118,7 @@ def callback(
             help="Write JSON Lines logs to this file.",
         ),
     ] = None,
-    ) -> None:
+) -> None:
     """Main callback that handles no subcommand case."""
     activate_cli_root(ctx)
     child_args: list[str] = ctx.meta.get(_ROOT_CHILD_ARGS_META_KEY, [])

--- a/canfar/cli/main.py
+++ b/canfar/cli/main.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 from pathlib import Path  # noqa: TC003 - Typer resolves callback annotations at runtime
 from typing import TYPE_CHECKING, Annotated
 
-import click
 import typer
-from typer.core import TyperGroup
+from typer.core import TyperCommand, TyperGroup
 
 from canfar.cli import output
 from canfar.cli.auth import auth
 from canfar.cli.config import config
-from canfar.cli.create import CreateCommandUsageMessage, creation
+from canfar.cli.create import creation
 from canfar.cli.data import data
 from canfar.cli.delete import delete_sessions
 from canfar.cli.events import get_events
@@ -21,7 +20,7 @@ from canfar.cli.info import get_info
 from canfar.cli.login import register_login_command
 from canfar.cli.logs import get_logs
 from canfar.cli.open import open_sessions
-from canfar.cli.prune import PruneCommandUsageMessage, prune_sessions
+from canfar.cli.prune import prune_sessions
 from canfar.cli.ps import show as show_sessions
 from canfar.cli.server import server
 from canfar.cli.stats import get_stats
@@ -37,6 +36,8 @@ from canfar.utils.logging import (
 )
 
 if TYPE_CHECKING:
+    from click import Context as ClickContext
+
     from canfar.errors import StructuredError
 
 
@@ -67,12 +68,29 @@ def _leaf_output_mode(args: list[str]) -> output.OutputMode:
 class _RootTyperGroup(TyperGroup):
     """Capture child argv so root setup can infer a leaf output mode."""
 
-    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+    def parse_args(self, ctx: ClickContext, args: list[str]) -> list[str]:
         """Record unconsumed child arguments without changing dispatch."""
         child_args = super().parse_args(ctx, args)
         if ctx.parent is None:
             ctx.meta[_ROOT_CHILD_ARGS_META_KEY] = list(child_args)
         return child_args
+
+
+_LEAF_USAGE = {
+    "create": "Usage: canfar create [OPTIONS] KIND IMAGE [-- CMD [ARGS]...]",
+    "prune": "Usage: canfar prune [OPTIONS] PREFIX KIND STATUS COMMAND [ARGS]...",
+}
+
+
+class _LeafUsageCommand(TyperCommand):
+    """Keep root leaf usage text aligned with delimiter-bearing commands."""
+
+    def get_usage(self, ctx: ClickContext) -> str:
+        """Return the canonical usage line for a leaf with custom syntax."""
+        name = self.name or ""
+        if name in _LEAF_USAGE:
+            return _LEAF_USAGE[name]
+        return super().get_usage(ctx)
 
 
 def callback(
@@ -173,7 +191,7 @@ cli.add_typer(
 
 cli.command(
     "create",
-    cls=CreateCommandUsageMessage,
+    cls=_LeafUsageCommand,
     context_settings={
         "help_option_names": ["-h", "--help"],
         "allow_interspersed_args": True,
@@ -218,7 +236,7 @@ cli.command(
 )(delete_sessions)
 cli.command(
     "prune",
-    cls=PruneCommandUsageMessage,
+    cls=_LeafUsageCommand,
     context_settings={"help_option_names": ["-h", "--help"]},
     help="Delete sessions by criteria.",
     no_args_is_help=True,

--- a/canfar/cli/main.py
+++ b/canfar/cli/main.py
@@ -36,7 +36,7 @@ from canfar.utils.logging import (
 )
 
 if TYPE_CHECKING:
-    from click import Context as ClickContext
+    from typer._click.core import Context as ClickContext
 
     from canfar.errors import StructuredError
 

--- a/canfar/cli/open.py
+++ b/canfar/cli/open.py
@@ -11,14 +11,7 @@ from canfar.cli._run import run
 from canfar.sessions import AsyncSession, connection_url
 from canfar.utils.console import emit_cli_active_server_banner
 
-open_command = typer.Typer(
-    name="open",
-    help="Open sessions in a browser.",
-    no_args_is_help=True,
-)
 
-
-@open_command.callback(invoke_without_command=True)
 def open_sessions(
     session_ids: Annotated[
         list[str],

--- a/canfar/cli/prune.py
+++ b/canfar/cli/prune.py
@@ -2,59 +2,17 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Annotated, get_args
+from typing import Annotated, get_args
 
 import click
 import typer
-import typer.core
 
 from canfar.cli._run import run
 from canfar.models.types import Pruneable, Status
 from canfar.sessions import AsyncSession
 from canfar.utils.console import emit_cli_active_server_banner, get_console
 
-if TYPE_CHECKING:
-    from typer._click.core import Context
 
-
-class PruneUsageMessage(typer.core.TyperGroup):
-    """Custom usage message for prune command.
-
-    Args:
-        typer (TyperGroup): Base class for grouping commands in Typer.
-    """
-
-    def get_usage(self, ctx: Context) -> str:  # noqa: ARG002
-        """Get the usage message for the prune command.
-
-        Args:
-            ctx (typer.Context): The Typer context.
-
-        Returns:
-            str: The usage message.
-        """
-        return "Usage: canfar prune [OPTIONS] PREFIX KIND STATUS COMMAND [ARGS]..."
-
-
-class PruneCommandUsageMessage(typer.core.TyperCommand):
-    """Keep the root leaf usage text aligned with the CLI contract."""
-
-    def get_usage(self, ctx: Context) -> str:  # noqa: ARG002
-        """Return the documented prune usage line."""
-        return "Usage: canfar prune [OPTIONS] PREFIX KIND STATUS COMMAND [ARGS]..."
-
-
-prune = typer.Typer(
-    name="prune",
-    no_args_is_help=True,
-)
-
-
-@prune.callback(
-    invoke_without_command=True,
-    context_settings={"help_option_names": ["-h", "--help"]},
-    cls=PruneUsageMessage,
-)
 def prune_sessions(
     prefix: Annotated[
         str,

--- a/canfar/cli/ps.py
+++ b/canfar/cli/ps.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
 
     from canfar.errors import StructuredError
 
+
 async def _fetch_sessions(
     kind: Kind | None,
     status: Status | None,

--- a/canfar/cli/ps.py
+++ b/canfar/cli/ps.py
@@ -28,12 +28,6 @@ if TYPE_CHECKING:
 
     from canfar.errors import StructuredError
 
-ps = typer.Typer(
-    name="ps",
-    no_args_is_help=False,
-)
-
-
 async def _fetch_sessions(
     kind: Kind | None,
     status: Status | None,
@@ -154,7 +148,6 @@ def _render_human_sessions(
             get_console(stderr=True).print(f"[dim]- {message}[/dim]")
 
 
-@ps.callback(invoke_without_command=True)
 def show(
     everything: Annotated[
         bool,

--- a/canfar/cli/stats.py
+++ b/canfar/cli/stats.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import typer
 from rich import box
 from rich.table import Table
 
@@ -10,14 +9,7 @@ from canfar.cli._run import run
 from canfar.sessions import AsyncSession
 from canfar.utils.console import emit_cli_active_server_banner, get_console
 
-stats = typer.Typer(
-    name="stats",
-    help="Display cluster-wide statistics.",
-    no_args_is_help=False,
-)
 
-
-@stats.callback(invoke_without_command=True)
 def get_stats() -> None:
     """Display cluster-wide usage and status statistics."""
     emit_cli_active_server_banner()

--- a/canfar/cli/version.py
+++ b/canfar/cli/version.py
@@ -90,16 +90,6 @@ def callback(
     raise typer.Exit(0)
 
 
-version = typer.Typer(
-    name="version",
-    help="Show canfar client version information",
-    no_args_is_help=False,
-    rich_help_panel="Information Commands",
-    callback=callback,
-    invoke_without_command=True,
-)
-
-
 def _get_package_version(name: str) -> str:
     """Get version of an installed package.
 

--- a/canfar/client.py
+++ b/canfar/client.py
@@ -245,6 +245,22 @@ class HTTPClient(BaseSettings):
             self._refresh_lock = asyncio.Lock()
         return self._refresh_lock
 
+    async def _refresh_oidc(self) -> OIDCCredential | None:
+        """Resolve and refresh the canonical saved OIDC record under one lock."""
+        async with self._get_refresh_lock():
+            prepared = auth._refresh(self)  # noqa: SLF001
+            if prepared is None:
+                return None
+            credential, parameters = prepared
+            if parameters is None:
+                return credential
+            refreshed = await oidc.refresh(*parameters)
+            return oidc._persist(  # noqa: SLF001
+                self.config,
+                credential,
+                refreshed,
+            )
+
     @classmethod
     def build(
         cls,
@@ -303,22 +319,9 @@ class HTTPClient(BaseSettings):
         if not isinstance(credential, OIDCCredential):
             raise TypeError
 
-        if credential.expired:
-            async with self._get_refresh_lock():
-                current = self.authentication_record
-                if not isinstance(current, OIDCCredential):
-                    raise TypeError
-                credential = current
-                if credential.expired:
-                    parameters = oidc._refresh(credential)  # noqa: SLF001
-                    if parameters is None:
-                        raise ValueError
-                    refreshed = await oidc.refresh(*parameters)
-                    credential = oidc._persist(  # noqa: SLF001
-                        self.config,
-                        credential,
-                        refreshed,
-                    )
+        credential = await self._refresh_oidc()
+        if credential is None:
+            raise ValueError
         if credential.token.access is None:
             raise ValueError
         token = credential.token.access.get_secret_value()

--- a/canfar/client.py
+++ b/canfar/client.py
@@ -38,6 +38,11 @@ if TYPE_CHECKING:
 log = get_logger(__name__)
 
 
+def _has_runtime_token(token: SecretStr | None) -> bool:
+    """Return whether a runtime token contains a non-empty value."""
+    return token is not None and bool(token.get_secret_value())
+
+
 class HTTPClient(BaseSettings):
     """HTTP Client for interacting with CANFAR Science Platform services (V2).
 
@@ -150,7 +155,7 @@ class HTTPClient(BaseSettings):
     @property
     def uses_runtime_credentials(self) -> bool:
         """Return whether runtime token or certificate credentials are active."""
-        return self.token is not None or self.certificate is not None
+        return _has_runtime_token(self.token) or self.certificate is not None
 
     @property
     def authentication_record(self) -> AuthenticationCredential | None:
@@ -178,7 +183,7 @@ class HTTPClient(BaseSettings):
         Returns:
             Self: The configured client.
         """
-        if self.token is not None and self.certificate is not None:
+        if _has_runtime_token(self.token) and self.certificate is not None:
             log.warning("Both runtime token and certificate values provided.")
             log.warning("Runtime token takes precedence over certificate.")
             log.warning("Certificate will be ignored in favor of the token.")
@@ -282,11 +287,9 @@ class HTTPClient(BaseSettings):
         Returns:
             RuntimeCredential: Exactly one of a bearer token or a certificate.
         """
-        if self.token is not None:
-            token = self.token.get_secret_value()
-            if token:
-                return RuntimeCredential(token=token)
-            raise ValueError
+        if _has_runtime_token(self.token):
+            assert self.token is not None
+            return RuntimeCredential(token=self.token.get_secret_value())
         if self.certificate is not None:
             return RuntimeCredential(certificate=x509.valid(self.certificate))
 
@@ -372,7 +375,7 @@ class HTTPClient(BaseSettings):
                 max_connections=self.concurrency,
                 max_keepalive_connections=self.concurrency // 4,
             )
-        if self.token is not None:
+        if _has_runtime_token(self.token):
             return kwargs
 
         if self.certificate is not None:
@@ -408,7 +411,7 @@ class HTTPClient(BaseSettings):
         request_logger = debug.arequest if asynchronous else debug.request
         response_logger = debug.aresponse if asynchronous else debug.response
         request_hooks: list[Any] = []
-        if not self.uses_runtime_credentials and credential is not None:
+        if credential is not None:
             if isinstance(credential, OIDCCredential):
                 request_hooks.append(
                     auth.arefresh(self) if asynchronous else auth.refresh(self)
@@ -457,7 +460,8 @@ class HTTPClient(BaseSettings):
             "User-Agent": f"python-canfar/{__version__}",
         }
 
-        if self.token is not None:
+        if _has_runtime_token(self.token):
+            assert self.token is not None
             headers["Authorization"] = f"Bearer {self.token.get_secret_value()}"
             headers["X-Skaha-Authentication-Type"] = "RUNTIME-TOKEN"
         elif self.certificate is not None:

--- a/canfar/hooks/httpx/auth.py
+++ b/canfar/hooks/httpx/auth.py
@@ -179,41 +179,33 @@ def arefresh(client: HTTPClient) -> Callable[[httpx.Request], Awaitable[None]]:
         Args:
             request (httpx.Request): The outgoing HTTP request.
         """
-        async with client._get_refresh_lock():  # noqa: SLF001
-            prepared = _refresh(client)
-            if prepared is None:
-                return
-            credential, parameters = prepared
-            if parameters is None:
-                if credential.token.access is not None:
-                    _apply_access_header(
-                        credential.token.access,
-                        client.asynclient.headers,
-                        request,
-                    )
-                log.debug("Skipping auth refresh, access token is not expired.")
-                return
-            token_url, identity, client_secret, refresh_token = parameters
-
-            try:
-                log.debug("Starting asynchronous OIDC token refresh.")
-                token = await oidc.refresh(
-                    url=token_url,
-                    identity=identity,
-                    secret=client_secret,
-                    token=refresh_token,
-                )
-                log.debug("Asynchronous OIDC token refresh successful.")
-                _apply_refreshed_token(
-                    client,
-                    credential,
-                    token,
+        previous = client.authentication_record
+        if isinstance(previous, OIDCCredential) and previous.expired:
+            log.debug("Starting asynchronous OIDC token refresh.")
+        try:
+            credential = await client._refresh_oidc()  # noqa: SLF001
+        except (ValueError, OSError):
+            msg = "Failed to refresh OIDC token"
+            raise AuthenticationError(msg) from None
+        if credential is None:
+            return
+        if credential == previous:
+            if credential.token.access is not None:
+                _apply_access_header(
+                    credential.token.access,
                     client.asynclient.headers,
                     request,
                 )
-
-            except (ValueError, OSError):
-                msg = "Failed to refresh OIDC token"
-                raise AuthenticationError(msg) from None
+            log.debug("Skipping auth refresh, access token is not expired.")
+            return
+        log.debug("Asynchronous OIDC token refresh successful.")
+        if credential.token.access is not None:
+            _apply_access_header(
+                credential.token.access,
+                client.asynclient.headers,
+                request,
+            )
+        log.debug("HTTP request headers updated with new token.")
+        log.info("OIDC Access Token Refreshed.")
 
     return ahook

--- a/tests/test_cli_create.py
+++ b/tests/test_cli_create.py
@@ -235,9 +235,7 @@ class TestCreateCLI:
         mock_session_cls.return_value.__aenter__.return_value = mock_session
         mock_session.create.return_value = []
 
-        result = runner.invoke(
-            cli, ["create", "headless", "skaha/worker:v1", *flag]
-        )
+        result = runner.invoke(cli, ["create", "headless", "skaha/worker:v1", *flag])
 
         assert result.exit_code == 1
         assert result.stdout == ""
@@ -378,9 +376,7 @@ class TestCreateCLI:
         }[phase]
         failing_call.side_effect = httpx.HTTPError(secret)
 
-        result = runner.invoke(
-            cli, ["create", "headless", "skaha/worker:v1", *flag]
-        )
+        result = runner.invoke(cli, ["create", "headless", "skaha/worker:v1", *flag])
 
         assert result.exit_code == 1
         assert result.stdout == ""
@@ -433,9 +429,7 @@ class TestCreateCLI:
         }[phase]
         failing_call.side_effect = KeyboardInterrupt(secret)
 
-        result = runner.invoke(
-            cli, ["create", "headless", "skaha/worker:v1", *flag]
-        )
+        result = runner.invoke(cli, ["create", "headless", "skaha/worker:v1", *flag])
 
         assert result.exit_code == 130
         assert result.stdout == ""

--- a/tests/test_cli_create.py
+++ b/tests/test_cli_create.py
@@ -8,7 +8,7 @@ import pytest
 import yaml
 from typer.testing import CliRunner
 
-from canfar.cli.create import create
+from canfar.cli.main import cli
 from canfar.errors import ErrorCode, StructuredError
 from canfar.models.session import CreateRequest
 
@@ -26,8 +26,9 @@ class TestCreateCLI:
         mock_session.create.return_value = ["id-1", "id-2"]
 
         result = runner.invoke(
-            create,
+            cli,
             [
+                "create",
                 "headless",
                 "skaha/worker:v1",
                 "--name",
@@ -80,8 +81,8 @@ class TestCreateCLI:
         mock_session.create.return_value = ["session-id"]
 
         result = runner.invoke(
-            create,
-            ["headless", "skaha/worker:v1", "--name", "single"],
+            cli,
+            ["create", "headless", "skaha/worker:v1", "--name", "single"],
         )
 
         assert result.exit_code == 0
@@ -95,8 +96,8 @@ class TestCreateCLI:
         mock_session.create.return_value = ["id-1", "id-2"]
 
         result = runner.invoke(
-            create,
-            ["headless", "skaha/worker:v1", "--replicas", "2"],
+            cli,
+            ["create", "headless", "skaha/worker:v1", "--replicas", "2"],
         )
 
         assert result.exit_code == 0
@@ -112,8 +113,8 @@ class TestCreateCLI:
         mock_session.create.return_value = ["session-id"]
 
         result = runner.invoke(
-            create,
-            ["headless", "skaha/worker:v1", "--output", "json"],
+            cli,
+            ["create", "headless", "skaha/worker:v1", "--output", "json"],
         )
 
         assert result.exit_code == 0
@@ -131,8 +132,9 @@ class TestCreateCLI:
         mock_session.create.return_value = ["session-id"]
 
         result = runner.invoke(
-            create,
+            cli,
             [
+                "create",
                 "headless",
                 "skaha/worker:v1",
                 "--output",
@@ -163,8 +165,8 @@ class TestCreateCLI:
         mock_session.create.return_value = ["session-id"]
 
         result = runner.invoke(
-            create,
-            ["headless", "skaha/worker:v1", "--debug", "--output", "json"],
+            cli,
+            ["create", "headless", "skaha/worker:v1", "--debug", "--output", "json"],
         )
 
         assert result.exit_code == 0
@@ -183,8 +185,9 @@ class TestCreateCLI:
         mock_session.create.return_value = ["id-1"]
 
         result = runner.invoke(
-            create,
+            cli,
             [
+                "create",
                 "headless",
                 "skaha/worker:v1",
                 "--replicas",
@@ -205,10 +208,10 @@ class TestCreateCLI:
         mock_session_cls.return_value.__aenter__.return_value = mock_session
         mock_session.create.return_value = []
 
-        result = runner.invoke(create, ["headless", "skaha/worker:v1"])
+        result = runner.invoke(cli, ["create", "headless", "skaha/worker:v1"])
 
         assert result.exit_code == 1
-        assert result.stdout == ""
+        assert result.stdout.startswith("@")
         assert "Failed to create session(s)" in result.stderr
         assert "CANFAR_TIMEOUT" in result.stderr
         assert "canfar --log-level debug create" in result.stderr
@@ -232,7 +235,9 @@ class TestCreateCLI:
         mock_session_cls.return_value.__aenter__.return_value = mock_session
         mock_session.create.return_value = []
 
-        result = runner.invoke(create, ["headless", "skaha/worker:v1", *flag])
+        result = runner.invoke(
+            cli, ["create", "headless", "skaha/worker:v1", *flag]
+        )
 
         assert result.exit_code == 1
         assert result.stdout == ""
@@ -260,8 +265,8 @@ class TestCreateCLI:
     ):
         """Invalid command input fails before the Session boundary opens."""
         result = runner.invoke(
-            create,
-            ["headless", "skaha/worker:v1", *invalid_args, *flag],
+            cli,
+            ["create", "headless", "skaha/worker:v1", *invalid_args, *flag],
         )
 
         assert result.exit_code == 1
@@ -277,8 +282,8 @@ class TestCreateCLI:
     ):
         """Human validation failure keeps detailed diagnostics and exit one."""
         result = runner.invoke(
-            create,
-            ["headless", "skaha/worker:v1", "--cpu", "-1"],
+            cli,
+            ["create", "headless", "skaha/worker:v1", "--cpu", "-1"],
         )
 
         assert result.exit_code == 1
@@ -294,8 +299,8 @@ class TestCreateCLI:
     ):
         """Human malformed-environment input keeps its existing message."""
         result = runner.invoke(
-            create,
-            ["headless", "skaha/worker:v1", "--env", "BROKEN"],
+            cli,
+            ["create", "headless", "skaha/worker:v1", "--env", "BROKEN"],
         )
 
         assert result.exit_code == 1
@@ -306,8 +311,8 @@ class TestCreateCLI:
     def test_create_command_dry_run(self):
         """Test create command dry run."""
         result = runner.invoke(
-            create,
-            ["headless", "skaha/worker:v1", "--dry-run"],
+            cli,
+            ["create", "headless", "skaha/worker:v1", "--dry-run"],
         )
 
         assert result.exit_code == 0
@@ -318,8 +323,9 @@ class TestCreateCLI:
     def test_create_command_rejects_dry_run_with_machine_output(self):
         """Dry-run diagnostics cannot contaminate machine stdout."""
         result = runner.invoke(
-            create,
+            cli,
             [
+                "create",
                 "headless",
                 "skaha/worker:v1",
                 "--dry-run",
@@ -339,7 +345,7 @@ class TestCreateCLI:
         mock_session_cls.return_value.__aenter__.return_value = mock_session
         mock_session.create.side_effect = httpx.HTTPError("API Error")
 
-        result = runner.invoke(create, ["headless", "skaha/worker:v1"])
+        result = runner.invoke(cli, ["create", "headless", "skaha/worker:v1"])
 
         assert result.exit_code == 1
         assert "Error: API Error" in result.stderr
@@ -372,7 +378,9 @@ class TestCreateCLI:
         }[phase]
         failing_call.side_effect = httpx.HTTPError(secret)
 
-        result = runner.invoke(create, ["headless", "skaha/worker:v1", *flag])
+        result = runner.invoke(
+            cli, ["create", "headless", "skaha/worker:v1", *flag]
+        )
 
         assert result.exit_code == 1
         assert result.stdout == ""
@@ -391,10 +399,10 @@ class TestCreateCLI:
         mock_session_cls.return_value.__aenter__.return_value = mock_session
         mock_session.create.side_effect = KeyboardInterrupt
 
-        result = runner.invoke(create, ["headless", "skaha/worker:v1"])
+        result = runner.invoke(cli, ["create", "headless", "skaha/worker:v1"])
 
         assert result.exit_code == 130
-        assert result.stdout == ""
+        assert result.stdout.startswith("@")
         assert "Operation cancelled by user" in result.stderr
 
     @pytest.mark.parametrize(
@@ -425,7 +433,9 @@ class TestCreateCLI:
         }[phase]
         failing_call.side_effect = KeyboardInterrupt(secret)
 
-        result = runner.invoke(create, ["headless", "skaha/worker:v1", *flag])
+        result = runner.invoke(
+            cli, ["create", "headless", "skaha/worker:v1", *flag]
+        )
 
         assert result.exit_code == 130
         assert result.stdout == ""

--- a/tests/test_cli_delete.py
+++ b/tests/test_cli_delete.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from typer.testing import CliRunner
 
-from canfar.cli.delete import delete
+from canfar.cli.main import cli
 
 runner = CliRunner()
 
@@ -22,7 +22,7 @@ def test_delete_force_success_error_and_cancel() -> None:
     with patch("canfar.cli.delete.AsyncSession") as session_cls:
         session = _mock_async_session(session_cls)
         session.destroy.return_value = {"abc": True}
-        result = runner.invoke(delete, ["--force", "abc"])
+        result = runner.invoke(cli, ["delete", "--force", "abc"])
 
     assert result.exit_code == 0
     assert "Successfully deleted" in result.stdout
@@ -30,12 +30,12 @@ def test_delete_force_success_error_and_cancel() -> None:
     with patch("canfar.cli.delete.AsyncSession") as session_cls:
         session = _mock_async_session(session_cls)
         session.destroy.side_effect = RuntimeError("delete failed")
-        result = runner.invoke(delete, ["--force", "abc"])
+        result = runner.invoke(cli, ["delete", "--force", "abc"])
 
     assert result.exit_code == 0
     assert "Error during deletion: delete failed" in result.stderr
 
     with patch("canfar.cli.delete.Confirm.ask", return_value=False):
-        result = runner.invoke(delete, ["abc"])
+        result = runner.invoke(cli, ["delete", "abc"])
 
     assert result.exit_code == 0

--- a/tests/test_cli_events.py
+++ b/tests/test_cli_events.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 from typer.testing import CliRunner
 
-from canfar.cli.events import events
+from canfar.cli.main import cli
 
 runner = CliRunner()
 
@@ -28,7 +28,7 @@ class TestEventsCLI:
         ]
         mock_session.events.return_value = mock_events
 
-        result = runner.invoke(events, ["session-id"])
+        result = runner.invoke(cli, ["events", "session-id"])
 
         assert result.exit_code == 0
         assert "Server events for session-id" in result.stdout
@@ -42,7 +42,7 @@ class TestEventsCLI:
         mock_session_cls.return_value.__aenter__.return_value = mock_session
         mock_session.events.return_value = []
 
-        result = runner.invoke(events, ["session-id"])
+        result = runner.invoke(cli, ["events", "session-id"])
 
         assert result.exit_code == 0
         assert "No events found" in result.stderr

--- a/tests/test_cli_info.py
+++ b/tests/test_cli_info.py
@@ -5,7 +5,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from typer.testing import CliRunner
 
-from canfar.cli.info import _format, _utilization, info
+from canfar.cli.info import _format, _utilization
+from canfar.cli.main import cli
 from canfar.models.session import FetchResponse
 
 runner = CliRunner()
@@ -75,7 +76,7 @@ class TestInfoCLI:
         }
         mock_session.info.return_value = [mock_response]
 
-        result = runner.invoke(info, ["test-id"])
+        result = runner.invoke(cli, ["info", "test-id"])
 
         assert result.exit_code == 0
         assert "test-id" in result.stdout
@@ -88,7 +89,7 @@ class TestInfoCLI:
         mock_session_cls.return_value.__aenter__.return_value = mock_session
         mock_session.info.return_value = []
 
-        result = runner.invoke(info, ["non-existent"])
+        result = runner.invoke(cli, ["info", "non-existent"])
 
         assert result.exit_code == 0
         assert "No information found" in result.stderr
@@ -100,7 +101,7 @@ class TestInfoCLI:
         mock_session_cls.return_value.__aenter__.return_value = mock_session
         mock_session.info.return_value = [{"id": "test-id", "name": "test-name"}]
 
-        result = runner.invoke(info, ["test-id", "--debug"])
+        result = runner.invoke(cli, ["info", "test-id", "--debug"])
 
         assert result.exit_code == 0
         assert "Session Response Warnings" in result.stderr

--- a/tests/test_cli_logs.py
+++ b/tests/test_cli_logs.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from typer.testing import CliRunner
 
-from canfar.cli.logs import logs
+from canfar.cli.main import cli
 
 runner = CliRunner()
 
@@ -22,7 +22,7 @@ def test_logs_outputs_logs_and_empty_message() -> None:
     with patch("canfar.cli.logs.AsyncSession") as session_cls:
         session = _mock_async_session(session_cls)
         session.logs.return_value = {"abc": "hello\nworld"}
-        result = runner.invoke(logs, ["abc"])
+        result = runner.invoke(cli, ["logs", "abc"])
 
     assert result.exit_code == 0
     assert "Logs for session abc" in result.stdout
@@ -31,7 +31,7 @@ def test_logs_outputs_logs_and_empty_message() -> None:
     with patch("canfar.cli.logs.AsyncSession") as session_cls:
         session = _mock_async_session(session_cls)
         session.logs.return_value = {}
-        result = runner.invoke(logs, ["abc"])
+        result = runner.invoke(cli, ["logs", "abc"])
 
     assert result.exit_code == 0
     assert "No logs found" in result.stderr
@@ -42,7 +42,7 @@ def test_logs_reports_fetch_error() -> None:
     with patch("canfar.cli.logs.AsyncSession") as session_cls:
         session = _mock_async_session(session_cls)
         session.logs.side_effect = RuntimeError("boom")
-        result = runner.invoke(logs, ["abc"])
+        result = runner.invoke(cli, ["logs", "abc"])
 
     assert result.exit_code == 1
     assert "Could not fetch logs" not in result.stdout

--- a/tests/test_cli_open.py
+++ b/tests/test_cli_open.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from typer.testing import CliRunner
 
-from canfar.cli.open import open_command
+from canfar.cli.main import cli
 
 runner = CliRunner()
 
@@ -37,7 +37,7 @@ def test_open_command_opens_url_and_reports_missing_data() -> None:
             },
             {"id": "missing"},
         ]
-        result = runner.invoke(open_command, ["abc", "stopped", "missing"])
+        result = runner.invoke(cli, ["open", "abc", "stopped", "missing"])
 
     assert result.exit_code == 0
     assert "Opening session abc" in result.stdout
@@ -52,7 +52,7 @@ def test_open_command_no_session_info() -> None:
     with patch("canfar.cli.open.AsyncSession") as session_cls:
         session = _mock_async_session(session_cls)
         session.info.return_value = []
-        result = runner.invoke(open_command, ["abc"])
+        result = runner.invoke(cli, ["open", "abc"])
 
     assert result.exit_code == 0
     assert "No information found" in result.stderr

--- a/tests/test_cli_prune.py
+++ b/tests/test_cli_prune.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from typer.testing import CliRunner
 
-from canfar.cli.prune import PruneUsageMessage, prune
+from canfar.cli.main import cli
 
 runner = CliRunner()
 
@@ -22,7 +22,7 @@ def test_prune_success_and_usage_message() -> None:
     with patch("canfar.cli.prune.AsyncSession") as session_cls:
         session = _mock_async_session(session_cls)
         session.destroy_with.return_value = {"abc": True, "def": False}
-        result = runner.invoke(prune, ["batch", "headless", "Succeeded"])
+        result = runner.invoke(cli, ["prune", "batch", "headless", "Succeeded"])
 
     assert result.exit_code == 0
     assert "Deleted 2 sessions" in result.stdout
@@ -30,9 +30,8 @@ def test_prune_success_and_usage_message() -> None:
         prefix="batch", kind="headless", status="Succeeded"
     )
 
-    usage = PruneUsageMessage(name="prune").get_usage(MagicMock())
-    assert "canfar prune" in usage
-
-    help_result = runner.invoke(prune, ["--help"])
+    help_result = runner.invoke(cli, ["prune", "--help"])
     assert help_result.exit_code == 0
-    assert "canfar prune 'session.*' notebook Running" in help_result.output
+    assert "Usage: canfar prune [OPTIONS] PREFIX KIND STATUS COMMAND [ARGS]..." in (
+        help_result.output
+    )

--- a/tests/test_cli_prune.py
+++ b/tests/test_cli_prune.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import click
 from typer.testing import CliRunner
 
 from canfar.cli.main import cli
@@ -32,6 +33,8 @@ def test_prune_success_and_usage_message() -> None:
 
     help_result = runner.invoke(cli, ["prune", "--help"])
     assert help_result.exit_code == 0
-    assert "Usage: canfar prune [OPTIONS] PREFIX KIND STATUS COMMAND [ARGS]..." in (
-        help_result.output
+    help_text = " ".join(click.unstyle(help_result.output).split())
+    assert (
+        "Usage: canfar prune [OPTIONS] PREFIX KIND STATUS COMMAND [ARGS]..."
+        in help_text
     )

--- a/tests/test_cli_root.py
+++ b/tests/test_cli_root.py
@@ -76,14 +76,6 @@ def test_session_and_information_leaves_are_root_commands() -> None:
         assert not isinstance(root.commands[name], TyperGroup)
 
 
-def test_removed_root_aliases_are_usage_errors() -> None:
-    """Removed root aliases fail with Click's standard usage exit code."""
-    for alias in ("authentication", "run", "launch", "del"):
-        result = runner.invoke(cli, [alias, "--help"])
-        assert result.exit_code == 2
-        assert f"No such command '{alias}'" in result.output
-
-
 def test_create_root_usage_preserves_delimiter_contract() -> None:
     """The root create command reserves every token after ``--``."""
     result = runner.invoke(

--- a/tests/test_cli_stats_ps.py
+++ b/tests/test_cli_stats_ps.py
@@ -217,9 +217,7 @@ def test_ps_json_kind_filter_parity(tmp_path: Path) -> None:
     ):
         session = _mock_async_session(session_cls)
         session.fetch.return_value = [payloads[0]]
-        result = runner.invoke(
-            cli, ["ps", "--kind", "headless", "--output", "json"]
-        )
+        result = runner.invoke(cli, ["ps", "--kind", "headless", "--output", "json"])
 
     assert result.exit_code == 0
     session.fetch.assert_awaited_once_with(kind="headless", status=None)

--- a/tests/test_cli_stats_ps.py
+++ b/tests/test_cli_stats_ps.py
@@ -11,8 +11,6 @@ import yaml
 from typer.testing import CliRunner
 
 from canfar.cli.main import cli
-from canfar.cli.ps import ps
-from canfar.cli.stats import stats
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -114,7 +112,7 @@ def test_ps_outputs_running_table_and_debug_anomalies() -> None:
     with patch("canfar.cli.ps.AsyncSession") as session_cls:
         session = _mock_async_session(session_cls)
         session.fetch.return_value = payloads
-        result = runner.invoke(ps, ["--debug"])
+        result = runner.invoke(cli, ["ps", "--debug"])
 
     assert result.exit_code == 0
     assert "running-1" in result.stdout
@@ -152,18 +150,22 @@ def test_ps_quiet_prints_all_matching_session_ids() -> None:
     with patch("canfar.cli.ps.AsyncSession") as session_cls:
         session = _mock_async_session(session_cls)
         session.fetch.return_value = payloads
-        result = runner.invoke(ps, ["--quiet"])
+        result = runner.invoke(cli, ["ps", "--quiet"])
 
     assert result.exit_code == 0
-    assert result.stdout.splitlines() == ["running-1", "running-2"]
+    lines = result.stdout.splitlines()
+    assert lines[0].startswith("@")
+    assert lines[1:] == ["running-1", "running-2"]
 
     with patch("canfar.cli.ps.AsyncSession") as session_cls:
         session = _mock_async_session(session_cls)
         session.fetch.return_value = payloads
-        result = runner.invoke(ps, ["--quiet", "--all"])
+        result = runner.invoke(cli, ["ps", "--quiet", "--all"])
 
     assert result.exit_code == 0
-    assert result.stdout.splitlines() == ["running-1", "done-1", "running-2"]
+    lines = result.stdout.splitlines()
+    assert lines[0].startswith("@")
+    assert lines[1:] == ["running-1", "done-1", "running-2"]
 
 
 @pytest.mark.parametrize(
@@ -191,7 +193,7 @@ def test_ps_machine_emits_filtered_session_array(
     ):
         session = _mock_async_session(session_cls)
         session.fetch.return_value = payloads
-        result = runner.invoke(ps, flag)
+        result = runner.invoke(cli, ["ps", *flag])
 
     assert result.exit_code == 0
     assert not result.stdout.startswith("@")
@@ -215,7 +217,9 @@ def test_ps_json_kind_filter_parity(tmp_path: Path) -> None:
     ):
         session = _mock_async_session(session_cls)
         session.fetch.return_value = [payloads[0]]
-        result = runner.invoke(ps, ["--kind", "headless", "--output", "json"])
+        result = runner.invoke(
+            cli, ["ps", "--kind", "headless", "--output", "json"]
+        )
 
     assert result.exit_code == 0
     session.fetch.assert_awaited_once_with(kind="headless", status=None)
@@ -238,7 +242,7 @@ def test_ps_json_malformed_payload_keeps_stdout_pure(tmp_path: Path) -> None:
     ):
         session = _mock_async_session(session_cls)
         session.fetch.return_value = payloads
-        result = runner.invoke(ps, ["--output", "json"])
+        result = runner.invoke(cli, ["ps", "--output", "json"])
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -249,7 +253,7 @@ def test_ps_json_malformed_payload_keeps_stdout_pure(tmp_path: Path) -> None:
 
 def test_ps_quiet_with_machine_output_exits_two() -> None:
     """``ps --quiet`` is incompatible with machine output."""
-    result = runner.invoke(ps, ["--quiet", "--output", "json"])
+    result = runner.invoke(cli, ["ps", "--quiet", "--output", "json"])
     assert result.exit_code == 2
     assert "quiet" in result.stderr.lower()
 
@@ -267,7 +271,7 @@ def test_ps_allows_empty_running_view() -> None:
                 "isFixedResources": True,
             },
         ]
-        result = runner.invoke(ps, [])
+        result = runner.invoke(cli, ["ps"])
 
     assert result.exit_code == 0
     assert "No pending or running sessions found" in result.stderr
@@ -282,7 +286,7 @@ def test_stats_outputs_cluster_tables() -> None:
             "cores": {"requestedCPUCores": 4, "cpuCoresAvailable": 64},
             "ram": {"requestedRAM": "8Gi", "ramAvailable": "128Gi"},
         }
-        result = runner.invoke(stats, [])
+        result = runner.invoke(cli, ["stats"])
 
     assert result.exit_code == 0
     assert "CANFAR Platform Load" in result.stdout
@@ -304,7 +308,7 @@ def test_stats_renders_only_cpu_and_ram_columns() -> None:
             "cores": {"requestedCPUCores": 4, "cpuCoresAvailable": 64},
             "ram": {"requestedRAM": "8Gi", "ramAvailable": "128Gi"},
         }
-        result = runner.invoke(stats, [])
+        result = runner.invoke(cli, ["stats"])
 
     assert result.exit_code == 0
     # The CPU/RAM table and its values are rendered.

--- a/tests/test_cli_stream_contracts.py
+++ b/tests/test_cli_stream_contracts.py
@@ -402,6 +402,41 @@ def test_invalid_logging_environment_is_one_structured_machine_error(
     assert error.expected == ["critical", "error", "warning", "info", "debug"]
 
 
+@pytest.mark.parametrize("command", [["config", "get", "console.width"], ["auth", "ls"]])
+def test_invalid_logging_environment_is_human_without_leaf_output(
+    monkeypatch: pytest.MonkeyPatch,
+    command: list[str],
+) -> None:
+    """Setup failures stay human when a machine-capable leaf has no output flag."""
+    monkeypatch.setenv("CANFAR_LOGLEVEL", "chatty")
+
+    result = runner.invoke(cli, command)
+
+    assert result.exit_code == 2
+    assert result.stdout == ""
+    assert result.stderr.startswith("logging.invalid_env_value env_var=CANFAR_LOGLEVEL")
+    assert not result.stderr.lstrip().startswith("{")
+
+
+@pytest.mark.parametrize(
+    ("flag", "prefix"),
+    [(["-o", "json"], "{"), (["--output", "yaml"], "code:")],
+)
+def test_invalid_logging_environment_uses_leaf_output_format(
+    monkeypatch: pytest.MonkeyPatch,
+    flag: list[str],
+    prefix: str,
+) -> None:
+    """Setup failures use the selected leaf format, not the owning group."""
+    monkeypatch.setenv("CANFAR_LOGLEVEL", "chatty")
+
+    result = runner.invoke(cli, ["config", "get", "console.width", *flag])
+
+    assert result.exit_code == 2
+    assert result.stdout == ""
+    assert result.stderr.lstrip().startswith(prefix)
+
+
 def test_relative_log_file_creates_parents_without_contaminating_stdout(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_cli_stream_contracts.py
+++ b/tests/test_cli_stream_contracts.py
@@ -402,7 +402,9 @@ def test_invalid_logging_environment_is_one_structured_machine_error(
     assert error.expected == ["critical", "error", "warning", "info", "debug"]
 
 
-@pytest.mark.parametrize("command", [["config", "get", "console.width"], ["auth", "ls"]])
+@pytest.mark.parametrize(
+    "command", [["config", "get", "console.width"], ["auth", "ls"]]
+)
 def test_invalid_logging_environment_is_human_without_leaf_output(
     monkeypatch: pytest.MonkeyPatch,
     command: list[str],

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -3,9 +3,7 @@
 import pytest
 from typer.testing import CliRunner
 
-from canfar.cli.version import (
-    version,
-)
+from canfar.cli.main import cli
 
 
 class TestVersionCLI:
@@ -18,14 +16,14 @@ class TestVersionCLI:
 
     def test_version_simple_output(self, runner: CliRunner) -> None:
         """Test simple version output without debug flag."""
-        result = runner.invoke(version, [])
+        result = runner.invoke(cli, ["version"])
 
         assert result.exit_code == 0
         assert "CANFAR Python Client" in result.stdout
 
     def test_version_debug_output(self, runner: CliRunner) -> None:
         """Test detailed debug output with --debug flag."""
-        result = runner.invoke(version, ["--debug"])
+        result = runner.invoke(cli, ["version", "--debug"])
         assert result.exit_code == 0
         assert "CANFAR Python Client Debug Information" in result.stdout
         assert "Client Version" in result.stdout

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -145,6 +145,48 @@ class TestInitializationAndConfiguration:
 class TestRuntimeCredentialHandling:
     """Test runtime credential handling including mutual exclusivity and validation."""
 
+    @pytest.mark.parametrize("asynchronous", [False, True])
+    def test_empty_token_is_saved_oidc_authentication(
+        self,
+        canfar_client_fixture,
+        asynchronous: bool,
+    ) -> None:
+        """An empty runtime token does not mask saved OIDC state."""
+        config = oidc_config(idp="oidc")
+        client = canfar_client_fixture(
+            config=config,
+            token=SecretStr(""),
+        )
+
+        assert not client.uses_runtime_credentials
+        credential = client._resolved_authentication_record()
+        assert credential is not None
+        assert credential.mode == "oidc"
+        headers = client._get_http_headers(credential=credential)
+        assert headers["Authorization"] == "Bearer access-token"
+        assert headers["X-Skaha-Authentication-Type"] == "OIDC"
+
+        kwargs = client._get_client_kwargs(
+            asynchronous=asynchronous,
+            credential=credential,
+        )
+        request_hooks = kwargs["event_hooks"]["request"]
+        assert request_hooks[0].__name__ == ("ahook" if asynchronous else "hook")
+
+    async def test_empty_token_materializes_saved_oidc_access_token(
+        self,
+        canfar_client_fixture,
+    ) -> None:
+        """Credential materialization falls through to saved OIDC state."""
+        client = canfar_client_fixture(
+            config=oidc_config(idp="oidc"),
+            token=SecretStr(""),
+        )
+
+        credential = await client._materialize_credentials()
+
+        assert credential.token == "access-token"
+
     def test_token_only(self, canfar_client_fixture) -> None:
         """Test instantiation with token only."""
         client = canfar_client_fixture(

--- a/tests/test_hooks_httpx_auth.py
+++ b/tests/test_hooks_httpx_auth.py
@@ -228,6 +228,31 @@ class TestAsyncHook:
 class TestSyncAsyncParity:
     """Characterization tests: sync and async auth hooks share guard behavior."""
 
+    async def test_empty_runtime_token_keeps_saved_oidc_sync_and_async(self) -> None:
+        """An empty runtime token does not bypass either saved OIDC hook."""
+        config = oidc_config(
+            idp="testoidc",
+            access="saved-access-token",
+            access_expiry=time.time() + 3600,
+            refresh_expiry=time.time() + 7200,
+        )
+        client = HTTPClient(
+            config=config,
+            token=SecretStr(""),
+            url="https://platform.example",
+        )
+
+        sync_request = httpx.Request("GET", "https://platform.example/sync")
+        refresh(client)(sync_request)
+        assert sync_request.headers["Authorization"] == "Bearer saved-access-token"
+
+        async with client:
+            async_request = httpx.Request("GET", "https://platform.example/async")
+            await arefresh(client)(async_request)
+
+        assert async_request.headers["Authorization"] == "Bearer saved-access-token"
+        client._close()  # noqa: SLF001
+
     @patch("canfar.auth.oidc.sync_refresh")
     @patch("canfar.auth.oidc.refresh")
     async def test_refresh_and_arefresh_both_skip_non_oidc(


### PR DESCRIPTION
## Summary

- restore human, JSON, and YAML setup diagnostics from leaf output options without restoring aliases
- treat empty runtime tokens as unset and preserve saved-auth hooks
- share async OIDC refresh policy behind one per-client lock
- remove test-only root leaf Typer shells and duplicate alias coverage

## Validation

- 258 focused CLI tests
- 75 focused client/auth tests
- 856 deterministic non-slow tests
- Ruff and ty
- git diff --check

Follow-up corrections from the Wave 3 standards, specification, and simplify reviews for #254 and #255.