### PR TITLE
refactor(logging): simplify runtime configuration

### DIFF
--- a/canfar/auth/oidc.py
+++ b/canfar/auth/oidc.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import socket
 import time
 from collections.abc import Awaitable, Callable, Generator
@@ -14,7 +15,6 @@ from authlib.integrations.base_client.errors import OAuthError
 from authlib.oauth2.rfc8628 import DEVICE_CODE_GRANT_TYPE
 from pydantic import SecretStr, ValidationError
 
-from canfar import get_logger
 from canfar.models.auth import DeviceAuthorization, Expiry, OIDCCredential, Token
 
 if TYPE_CHECKING:
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
     from canfar.models.config import Configuration
 
-log = get_logger(__name__)
+log = logging.getLogger(__name__)
 _BASIC_AUTH_METHOD = "client_secret_basic"
 
 DeviceFlow = Callable[

--- a/canfar/auth/x509.py
+++ b/canfar/auth/x509.py
@@ -6,6 +6,7 @@ using the cadcutils.net.auth library as the backbone for X509 authentication.
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -13,12 +14,12 @@ from typing import TYPE_CHECKING, Any
 from cadcutils.net.auth import Subject, get_cert
 from cryptography import x509
 
-from canfar import CERT_PATH, get_logger
+from canfar import CERT_PATH
 
 if TYPE_CHECKING:
     from canfar.models.auth import X509Credential
 
-log = get_logger(__name__)
+log = logging.getLogger(__name__)
 
 
 class CertificateError(ValueError):

--- a/canfar/client.py
+++ b/canfar/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import ssl
 from datetime import datetime, timezone
 from email.utils import formatdate
@@ -20,7 +21,7 @@ from pydantic import (
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing_extensions import Self
 
-from canfar import __version__, get_logger
+from canfar import __version__
 from canfar.auth import oidc, x509
 from canfar.exceptions.context import AuthContextError
 from canfar.hooks.httpx import auth, debug, errors, expiry
@@ -35,7 +36,7 @@ from canfar.models.config import Configuration
 if TYPE_CHECKING:
     from types import TracebackType
 
-log = get_logger(__name__)
+log = logging.getLogger(__name__)
 
 
 def _has_runtime_token(token: SecretStr | None) -> bool:

--- a/canfar/hooks/httpx/auth.py
+++ b/canfar/hooks/httpx/auth.py
@@ -29,9 +29,9 @@ Note:
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Callable
 
-from canfar import get_logger
 from canfar.auth import oidc
 from canfar.models.auth import OIDCCredential
 
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
 
     from canfar.client import HTTPClient
 
-log = get_logger(__name__)
+log = logging.getLogger(__name__)
 
 
 class AuthenticationError(Exception):

--- a/canfar/hooks/httpx/debug.py
+++ b/canfar/hooks/httpx/debug.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from canfar import get_logger
-
 if TYPE_CHECKING:
     import httpx
 
-log = get_logger(__name__)
+log = logging.getLogger(__name__)
 
 
 def request(req: httpx.Request) -> None:

--- a/canfar/hooks/httpx/errors.py
+++ b/canfar/hooks/httpx/errors.py
@@ -6,14 +6,14 @@ ReadTimeout during streaming) are warning-logged alongside status errors.
 """
 
 import contextlib
+import logging
 from collections.abc import Generator
 
 import httpx
 
-from canfar import get_logger
 from canfar.utils.logging import safe_url
 
-log = get_logger(__name__)
+log = logging.getLogger(__name__)
 
 CONN_ERR_MSG = (
     "Failed to establish connection within the timeout period. "

--- a/canfar/hooks/httpx/expiry.py
+++ b/canfar/hooks/httpx/expiry.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Callable
 
-from canfar import get_logger
 from canfar.auth import x509
 from canfar.exceptions.context import AuthExpiredError
 
-log = get_logger(__name__)
+log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable

--- a/canfar/images.py
+++ b/canfar/images.py
@@ -2,16 +2,16 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
-from canfar import get_logger
 from canfar.client import HTTPClient
 from canfar.models.containers import Image
 
 if TYPE_CHECKING:
     from httpx import Response
 
-log = get_logger(__name__)
+log = logging.getLogger(__name__)
 
 
 class Images(HTTPClient):

--- a/canfar/models/auth.py
+++ b/canfar/models/auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import math
 import time
 from pathlib import Path  # noqa: TC003
@@ -9,10 +10,9 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
-from canfar import get_logger
 from canfar.auth import x509
 
-log = get_logger(__name__)
+log = logging.getLogger(__name__)
 
 
 def _secret_present(value: SecretStr | str | None) -> bool:

--- a/canfar/models/config.py
+++ b/canfar/models/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Literal
@@ -28,7 +29,7 @@ from pydantic_settings import (
 )
 from pydantic_settings.sources import EnvSettingsSource
 
-from canfar import CONFIG_PATH, get_logger
+from canfar import CONFIG_PATH
 from canfar.config.editor import ConfigurationEditor as _ConfigurationEditor
 from canfar.config.editor import get_value as _get_value
 from canfar.config.editor import set_value as _set_value
@@ -40,7 +41,7 @@ from canfar.models.auth import (
 from canfar.models.http import Server, VOSpaceService
 from canfar.models.registry import ContainerRegistry
 
-log = get_logger(__name__)
+log = logging.getLogger(__name__)
 
 _CADC_URI = AnyUrl("ivo://cadc.nrc.ca/skaha")
 _CONFIG_KEY_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*$")

--- a/canfar/overview.py
+++ b/canfar/overview.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from defusedxml import ElementTree
@@ -9,13 +10,12 @@ from httpx import URL
 from pydantic import model_validator
 from typing_extensions import Self
 
-from canfar import get_logger
 from canfar.client import HTTPClient
 
 if TYPE_CHECKING:
     from httpx import Response
 
-log = get_logger(__name__)
+log = logging.getLogger(__name__)
 
 
 class Overview(HTTPClient):

--- a/canfar/server.py
+++ b/canfar/server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import TYPE_CHECKING, Literal
 from xml.etree.ElementTree import ParseError
 
@@ -10,7 +11,6 @@ import httpx
 from defusedxml.common import DefusedXmlException
 from pydantic import AnyHttpUrl, AnyUrl, BaseModel, ConfigDict, ValidationError
 
-from canfar import get_logger
 from canfar.auth.x509 import CertificateError
 from canfar.errors import ErrorCode, StructuredError
 from canfar.exceptions.context import AuthContextError, AuthExpiredError
@@ -31,7 +31,7 @@ from canfar.utils.registry import RegistryEvidenceError
 if TYPE_CHECKING:
     from pathlib import Path
 
-log = get_logger(__name__)
+log = logging.getLogger(__name__)
 
 _STORAGE_RESOURCE_UNSET = object()
 

--- a/canfar/sessions.py
+++ b/canfar/sessions.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import re
 from typing import TYPE_CHECKING, Any, TypeVar
 from webbrowser import open_new_tab
 
 from httpx import HTTPError, Response
 
-from canfar import get_logger
 from canfar.client import HTTPClient
 from canfar.models.session import CreateRequest
 from canfar.utils import build
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from canfar.models.types import Kind, Status, View
-log = get_logger(__name__)
+log = logging.getLogger(__name__)
 _Result = TypeVar("_Result")
 
 

--- a/canfar/utils/logging.py
+++ b/canfar/utils/logging.py
@@ -202,6 +202,7 @@ class CanfarLogger:
 
     def __init__(self) -> None:
         """Initialize per-instance file-handler state."""
+        self._configured = False
         self._rich_handler: RichHandler | None = None
         self._file_handler: logging.handlers.RotatingFileHandler | None = None
 
@@ -248,6 +249,7 @@ class CanfarLogger:
                 )
 
             logger.propagate = False
+            self._configured = True
 
     def _setup_file_logging(
         self,
@@ -283,6 +285,7 @@ class CanfarLogger:
             logger.removeHandler(handler)
         self._rich_handler = None
         self._file_handler = None
+        self._configured = False
 
 
 _canfar_logger = CanfarLogger()

--- a/canfar/utils/logging.py
+++ b/canfar/utils/logging.py
@@ -200,11 +200,10 @@ def _resolve_log_level(
 class CanfarLogger:
     """Configure stdlib logging for the CANFAR logger name."""
 
-    _configured = False
-    _rich_handler: RichHandler | None = None
-
     def __init__(self) -> None:
         """Initialize per-instance file-handler state."""
+        self._configured = False
+        self._rich_handler: RichHandler | None = None
         self._file_handler: logging.handlers.RotatingFileHandler | None = None
 
     @property
@@ -223,8 +222,7 @@ class CanfarLogger:
         target = _resolve_log_file_path(log_file) if log_file is not None else None
         with _LOCK:
             install_rich_traceback(show_locals=False, suppress=[])
-            if self._configured:
-                self._cleanup_handlers()
+            self._cleanup_handlers()
             if isinstance(loglevel, str):
                 loglevel = getattr(logging, loglevel.upper())
             logger = self.logger

--- a/canfar/utils/logging.py
+++ b/canfar/utils/logging.py
@@ -202,7 +202,6 @@ class CanfarLogger:
 
     def __init__(self) -> None:
         """Initialize per-instance file-handler state."""
-        self._configured = False
         self._rich_handler: RichHandler | None = None
         self._file_handler: logging.handlers.RotatingFileHandler | None = None
 
@@ -249,7 +248,6 @@ class CanfarLogger:
                 )
 
             logger.propagate = False
-            self._configured = True
 
     def _setup_file_logging(
         self,

--- a/canfar/utils/registry.py
+++ b/canfar/utils/registry.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from pathlib import Path
 
 from pydantic import AnyHttpUrl, BaseModel, ConfigDict
 
-from canfar import get_logger
 from canfar.auth.x509 import CertificateError
 from canfar.exceptions.context import AuthContextError, AuthExpiredError
 from canfar.idp import get_idp, registry_sources
@@ -16,7 +16,7 @@ from canfar.models.registry import IVOARegistrySearch
 from canfar.models.registry import Server as RegistryResource
 from canfar.utils.discover import Discover
 
-log = get_logger(__name__)
+log = logging.getLogger(__name__)
 
 
 class RegistryEvidenceError(RuntimeError):

--- a/tests/test_cli_stream_contracts.py
+++ b/tests/test_cli_stream_contracts.py
@@ -439,6 +439,31 @@ def test_invalid_logging_environment_uses_leaf_output_format(
     assert result.stderr.lstrip().startswith(prefix)
 
 
+def test_setup_failure_ignores_machine_option_after_command_delimiter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Passthrough command arguments cannot change root setup diagnostics."""
+    monkeypatch.setenv("CANFAR_LOGLEVEL", "chatty")
+
+    result = runner.invoke(
+        cli,
+        [
+            "create",
+            "--dry-run",
+            "headless",
+            "example.invalid/image",
+            "--",
+            "echo",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert result.stdout == ""
+    assert result.stderr.startswith("logging.invalid_env_value env_var=CANFAR_LOGLEVEL")
+
+
 def test_relative_log_file_creates_parents_without_contaminating_stdout(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_utils_logging.py
+++ b/tests/test_utils_logging.py
@@ -43,10 +43,8 @@ def canfar_logger() -> Generator[CanfarLogger]:
     logger = CanfarLogger()
     # Shared stdlib logger may already have handlers from earlier suite tests.
     logger._cleanup_handlers()  # noqa: SLF001
-    logger._configured = False  # noqa: SLF001
     yield logger
     logger._cleanup_handlers()  # noqa: SLF001
-    logger._configured = False  # noqa: SLF001
 
 
 def test_configure_rich_stderr_defaults(canfar_logger: CanfarLogger) -> None:
@@ -59,7 +57,6 @@ def test_configure_rich_stderr_defaults(canfar_logger: CanfarLogger) -> None:
     assert rich_handlers
     assert canfar_logger._rich_handler in rich_handlers  # noqa: SLF001
     assert not logger.propagate
-    assert canfar_logger._configured  # noqa: SLF001
 
 
 def test_reconfigure_replaces_handlers(canfar_logger: CanfarLogger) -> None:

--- a/tests/test_utils_logging.py
+++ b/tests/test_utils_logging.py
@@ -29,6 +29,14 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
+def _emit_exception_log(logger: logging.Logger) -> None:
+    """Emit one exception record for the JSONL formatter contract."""
+    try:
+        json.loads("not-json")
+    except json.JSONDecodeError:
+        logger.exception("operation failed")
+
+
 @pytest.fixture
 def canfar_logger() -> Generator[CanfarLogger]:
     """Fresh CanfarLogger cleaned after each test."""
@@ -63,6 +71,24 @@ def test_reconfigure_replaces_handlers(canfar_logger: CanfarLogger) -> None:
     assert canfar_logger._rich_handler is not first  # noqa: SLF001
     assert canfar_logger._rich_handler in canfar_logger.logger.handlers  # noqa: SLF001
     assert first not in canfar_logger.logger.handlers
+
+
+def test_separate_logger_lifecycles_do_not_accumulate_handlers(
+    tmp_path: Path,
+) -> None:
+    """Repeated application lifecycles leave one stderr/file sink pair."""
+    first = CanfarLogger()
+    second = CanfarLogger()
+    try:
+        first.configure(loglevel=logging.INFO, log_file=tmp_path / "first.jsonl")
+        second.configure(loglevel=logging.INFO, log_file=tmp_path / "second.jsonl")
+
+        logger = logging.getLogger(LOGGER_NAME)
+        assert len([h for h in logger.handlers if isinstance(h, RichHandler)]) == 1
+        assert len([h for h in logger.handlers if h is second._file_handler]) == 1  # noqa: SLF001
+        assert first._file_handler not in logger.handlers  # noqa: SLF001
+    finally:
+        second._cleanup_handlers()  # noqa: SLF001
 
 
 @pytest.mark.parametrize(
@@ -130,6 +156,24 @@ def test_jsonl_file_sink_writes_flat_events(
         assert event["logger"] == "canfar.jsonl"
         assert event["message"] == "hello"
         assert set(event.keys()) == {"timestamp", "level", "logger", "message"}
+    finally:
+        for handler in get_logger().handlers[:]:
+            handler.close()
+            get_logger().removeHandler(handler)
+
+
+def test_jsonl_file_sink_includes_exception_text(tmp_path: Path) -> None:
+    """Exception diagnostics remain available as one escaped JSONL field."""
+    log_file = tmp_path / "exception.jsonl"
+    try:
+        configure_logging(loglevel="INFO", log_file=log_file)
+        _emit_exception_log(get_logger("jsonl"))
+        for handler in get_logger().handlers:
+            handler.flush()
+
+        event = json.loads(log_file.read_text(encoding="utf-8"))
+        assert "exception" in event
+        assert "JSONDecodeError" in event["exception"]
     finally:
         for handler in get_logger().handlers[:]:
             handler.close()


### PR DESCRIPTION
## Summary

- use direct stdlib module loggers throughout runtime modules
- make rotating JSONL and Rich handler setup idempotent
- remove obsolete logger configuration state while preserving status compatibility
- preserve leaf output-mode cutoff for setup diagnostics

## Validation

- 859 deterministic non-slow tests
- Ruff and ty
- targeted Ruff formatting
- git diff --check

Implements #257.