### PR TITLE
feat(auth): expose native OIDC device login APIs

### DIFF
--- a/canfar/__init__.py
+++ b/canfar/__init__.py
@@ -14,7 +14,7 @@ from .utils.logging import (  # noqa: E402
 CERT_PATH: Path = Path.home() / ".ssl" / "cadcproxy.pem"
 
 from . import authentication, server  # noqa: E402
-from .authentication import login  # noqa: E402
+from .authentication import alogin, login  # noqa: E402
 
 # Kept in sync with pyproject.toml by release-please
 # DO NOT EDIT MANUALLY
@@ -24,6 +24,7 @@ __all__ = [
     "CONFIG_DIR",
     "CONFIG_PATH",
     "__version__",
+    "alogin",
     "authentication",
     "configure_logging",
     "get_logger",

--- a/canfar/auth/oidc.py
+++ b/canfar/auth/oidc.py
@@ -128,6 +128,45 @@ def _install_tokens(credential: OIDCCredential, tokens: dict[str, Any]) -> None:
     credential.token, credential.expiry = token, expiry
 
 
+def _client_credentials(device: Any) -> tuple[str, str]:
+    """Extract a valid dynamic client pair without exposing provider data."""
+    if not isinstance(device, dict):
+        msg = "OIDC device authorization failed: malformed client response"
+        raise TypeError(msg)
+    try:
+        identity = device["client_id"]
+        secret = device["client_secret"]
+    except KeyError:
+        msg = "OIDC device authorization failed: malformed client response"
+        raise ValueError(msg) from None
+    if not isinstance(identity, str) or not isinstance(secret, str):
+        msg = "OIDC device authorization failed: malformed client response"
+        raise TypeError(msg)
+    return identity, secret
+
+
+def _userinfo_headers(credential: OIDCCredential) -> dict[str, str]:
+    """Build the bearer header for the post-login UserInfo request."""
+    access = credential.token.access
+    return {"Authorization": f"Bearer {access.get_secret_value() if access else ''}"}
+
+
+def _userinfo_username(response: httpx.Response) -> str | None:
+    """Validate UserInfo and return its optional display identifier."""
+    response.raise_for_status()
+    return response.json().get("preferred_username")
+
+
+def _set_discovered_endpoints(
+    credential: OIDCCredential,
+    discovery: dict[str, Any],
+) -> None:
+    """Install provider endpoints while preserving the credential object."""
+    credential.endpoints.device = discovery["device_authorization_endpoint"]
+    credential.endpoints.registration = discovery["registration_endpoint"]
+    credential.endpoints.token = discovery["token_endpoint"]
+
+
 async def discover(
     url: str,
     client: httpx.AsyncClient | None = None,
@@ -599,9 +638,7 @@ async def authenticate_credential(
             client,
             expected_issuer=expected_issuer,
         )
-        credential.endpoints.device = response["device_authorization_endpoint"]
-        credential.endpoints.registration = response["registration_endpoint"]
-        credential.endpoints.token = response["token_endpoint"]
+        _set_discovered_endpoints(credential, response)
 
         log.debug("Discovered OIDC configuration:")
         log.debug("Device Registration Endpoint: %s", credential.endpoints.registration)
@@ -611,8 +648,8 @@ async def authenticate_credential(
         device: dict[str, Any] = await register(
             str(credential.endpoints.registration), client
         )
-        credential.client.identity = device["client_id"]
-        client_secret = device["client_secret"]
+        identity, client_secret = _client_credentials(device)
+        credential.client.identity = identity
         credential.client.secret = SecretStr(client_secret)
 
         from authlib.integrations.httpx_client import (  # noqa: PLC0415
@@ -621,13 +658,13 @@ async def authenticate_credential(
 
         if request_timeout is None:
             oauth_context = AsyncOAuth2Client(
-                credential.client.identity,
+                identity,
                 client_secret,
                 token_endpoint_auth_method=_BASIC_AUTH_METHOD,
             )
         else:
             oauth_context = AsyncOAuth2Client(
-                credential.client.identity,
+                identity,
                 client_secret,
                 token_endpoint_auth_method=_BASIC_AUTH_METHOD,
                 timeout=request_timeout,
@@ -638,7 +675,7 @@ async def authenticate_credential(
                 tokens = await authflow(
                     str(credential.endpoints.device),
                     str(credential.endpoints.token),
-                    str(credential.client.identity),
+                    identity,
                     client_secret,
                     oauth_client,
                     on_challenge=on_challenge,
@@ -647,7 +684,7 @@ async def authenticate_credential(
                 tokens = await device_flow(
                     str(credential.endpoints.device),
                     str(credential.endpoints.token),
-                    str(credential.client.identity),
+                    identity,
                     client_secret,
                     oauth_client,
                 )
@@ -655,16 +692,8 @@ async def authenticate_credential(
         _install_tokens(credential, tokens)
 
         url: str = response["userinfo_endpoint"]
-        headers = {
-            "Authorization": (
-                f"Bearer {credential.token.access.get_secret_value()}"
-                if credential.token.access
-                else ""
-            ),
-        }
-        user = await client.get(url, headers=headers)
-        user.raise_for_status()
-        username = user.json().get("preferred_username")
+        user = await client.get(url, headers=_userinfo_headers(credential))
+        username = _userinfo_username(user)
         if on_authenticated is not None:
             on_authenticated(username)
         return credential
@@ -672,21 +701,14 @@ async def authenticate_credential(
 
 def sync_discover(
     url: str,
-    client: httpx.Client | None = None,
+    client: httpx.Client,
     *,
     expected_issuer: str,
 ) -> dict[str, Any]:
     """Discover OIDC provider configuration with a synchronous HTTP client."""
-    if client is None:
-        with httpx.Client() as http_client:
-            response = http_client.get(url)
-            response.raise_for_status()
-            data: dict[str, Any] = response.json()
-    else:
-        response = client.get(url)
-        response.raise_for_status()
-        data = response.json()
-
+    response = client.get(url)
+    response.raise_for_status()
+    data: dict[str, Any] = response.json()
     data = _validate_discovery_data(data, expected_issuer)
     log.debug("OIDC Discovery Data: %s", data)
     return data
@@ -694,21 +716,13 @@ def sync_discover(
 
 def sync_register(
     url: str,
-    client: httpx.Client | None = None,
+    client: httpx.Client,
 ) -> dict[str, Any]:
     """Register a device-flow client with a synchronous HTTP client."""
     payload = _registration_payload()
-
-    if client is None:
-        with httpx.Client() as http_client:
-            response = http_client.post(url, json=payload)
-            response.raise_for_status()
-            data: dict[str, Any] = response.json()
-    else:
-        response = client.post(url, json=payload)
-        response.raise_for_status()
-        data = response.json()
-
+    response = client.post(url, json=payload)
+    response.raise_for_status()
+    data: dict[str, Any] = response.json()
     log.debug("OIDC dynamic client registration succeeded.")
     return data
 
@@ -802,7 +816,7 @@ def sync_authflow(
             secret,
             token_endpoint_auth_method=_BASIC_AUTH_METHOD,
         ) as http_client:
-            return _sync_authflow_impl(
+            return sync_authflow(
                 device_auth_url,
                 token_url,
                 identity,
@@ -810,26 +824,6 @@ def sync_authflow(
                 http_client,
                 on_challenge=on_challenge,
             )
-    return _sync_authflow_impl(
-        device_auth_url,
-        token_url,
-        identity,
-        secret,
-        client,
-        on_challenge=on_challenge,
-    )
-
-
-def _sync_authflow_impl(
-    device_auth_url: str,
-    token_url: str,
-    identity: str,
-    secret: str,
-    client: OAuth2Client,
-    *,
-    on_challenge: ChallengePresenter | None = None,
-) -> dict[str, Any]:
-    """Run one synchronous device challenge and token exchange."""
     challenge = sync_start_device_authorization(
         device_auth_url,
         identity,
@@ -866,9 +860,7 @@ def sync_authenticate_credential(
             client,
             expected_issuer=expected_issuer,
         )
-        credential.endpoints.device = response["device_authorization_endpoint"]
-        credential.endpoints.registration = response["registration_endpoint"]
-        credential.endpoints.token = response["token_endpoint"]
+        _set_discovered_endpoints(credential, response)
 
         log.debug("Discovered OIDC configuration:")
         log.debug("Device Registration Endpoint: %s", credential.endpoints.registration)
@@ -876,15 +868,7 @@ def sync_authenticate_credential(
         log.debug("Token Endpoint: %s", credential.endpoints.token)
 
         device = sync_register(str(credential.endpoints.registration), client)
-        try:
-            identity = device["client_id"]
-            client_secret = device["client_secret"]
-        except (KeyError, TypeError):
-            msg = "OIDC device authorization failed: malformed client response"
-            raise ValueError(msg) from None
-        if not isinstance(identity, str) or not isinstance(client_secret, str):
-            msg = "OIDC device authorization failed: malformed client response"
-            raise TypeError(msg)
+        identity, client_secret = _client_credentials(device)
         credential.client.identity = identity
         credential.client.secret = SecretStr(client_secret)
 
@@ -923,16 +907,8 @@ def sync_authenticate_credential(
         _install_tokens(credential, tokens)
 
         url: str = response["userinfo_endpoint"]
-        headers = {
-            "Authorization": (
-                f"Bearer {credential.token.access.get_secret_value()}"
-                if credential.token.access
-                else ""
-            ),
-        }
-        user = client.get(url, headers=headers)
-        user.raise_for_status()
-        username = user.json().get("preferred_username")
+        user = client.get(url, headers=_userinfo_headers(credential))
+        username = _userinfo_username(user)
         if on_authenticated is not None:
             on_authenticated(username)
         return credential

--- a/canfar/auth/oidc.py
+++ b/canfar/auth/oidc.py
@@ -8,7 +8,7 @@ import socket
 import time
 from collections.abc import Awaitable, Callable, Generator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, NoReturn, cast
 
 import httpx
 from authlib.integrations.base_client.errors import OAuthError
@@ -18,7 +18,7 @@ from pydantic import SecretStr, ValidationError
 from canfar.models.auth import DeviceAuthorization, Expiry, OIDCCredential, Token
 
 if TYPE_CHECKING:
-    from authlib.integrations.httpx_client import AsyncOAuth2Client
+    from authlib.integrations.httpx_client import AsyncOAuth2Client, OAuth2Client
 
     from canfar.models.config import Configuration
 
@@ -29,6 +29,11 @@ DeviceFlow = Callable[
     [str, str, str, str, "AsyncOAuth2Client"],
     Awaitable[dict[str, Any]],
 ]
+SyncDeviceFlow = Callable[
+    [str, str, str, str, "OAuth2Client"],
+    dict[str, Any],
+]
+ChallengePresenter = Callable[[DeviceAuthorization], None]
 
 
 class AuthPendingError(Exception):
@@ -37,6 +42,90 @@ class AuthPendingError(Exception):
 
 class SlowDownError(Exception):
     """Exception raised when the client should slow down its requests."""
+
+
+def _validate_discovery_data(data: Any, expected_issuer: str) -> dict[str, Any]:
+    """Validate the provider metadata shared by sync and async discovery."""
+    if not isinstance(data, dict) or data.get("issuer") != expected_issuer:
+        msg = "OIDC discovery issuer mismatch"
+        raise ValueError(msg)
+
+    required = {
+        "device_authorization_endpoint",
+        "registration_endpoint",
+        "token_endpoint",
+        "userinfo_endpoint",
+    }
+    missing = sorted(field for field in required if not data.get(field))
+    if missing:
+        msg = f"OIDC discovery missing required metadata: {', '.join(missing)}"
+        raise ValueError(msg)
+    return data
+
+
+def _registration_payload() -> dict[str, Any]:
+    """Build the dynamic registration request shared by both transports."""
+    hostname = socket.gethostname()
+    date = time.strftime("%Y-%m-%d %H:%M", time.gmtime())
+    return {
+        "client_name": f"Science Platform CLI @ {hostname} {date}",
+        "grant_types": [
+            "urn:ietf:params:oauth:grant-type:device_code",
+            "refresh_token",
+        ],
+        "response_types": ["token"],
+        "token_endpoint_auth_method": _BASIC_AUTH_METHOD,
+        "scope": "openid profile email offline_access",
+    }
+
+
+def _parse_device_authorization(response: httpx.Response) -> DeviceAuthorization:
+    """Parse one provider challenge without exposing malformed secrets."""
+    try:
+        return DeviceAuthorization.model_validate(response.json())
+    except ValidationError:
+        msg = "Invalid OIDC device authorization response"
+        raise ValueError(msg) from None
+
+
+def _raise_poll_oauth_error(error: OAuthError) -> NoReturn:
+    """Translate an OAuth device-poll error into the public protocol errors."""
+    if error.error == "authorization_pending":
+        raise AuthPendingError from None
+    if error.error == "slow_down":
+        raise SlowDownError from None
+    if error.error == "access_denied":
+        msg = "OIDC device authorization was denied"
+        raise PermissionError(msg) from None
+    if error.error == "expired_token":
+        msg = "OIDC device authorization expired"
+        raise TimeoutError(msg) from None
+    msg = "OIDC device authorization failed"
+    raise ValueError(msg) from None
+
+
+def _validate_poll_token(token: Any) -> dict[str, Any]:
+    """Validate one successful device token response."""
+    if not isinstance(token, dict) or "access_token" not in token:
+        msg = "OIDC device authorization failed: malformed token response"
+        raise ValueError(msg)
+    return token
+
+
+def _install_tokens(credential: OIDCCredential, tokens: dict[str, Any]) -> None:
+    """Install validated token data on a credential for both auth paths."""
+    try:
+        token = Token(
+            access=tokens["access_token"],
+            refresh=tokens.get("refresh_token"),
+            token_type=tokens.get("token_type"),
+            scope=tokens.get("scope"),
+        )
+        expiry = Expiry(access=tokens.get("expires_at"), refresh=None)
+    except (KeyError, TypeError, ValidationError):
+        msg = "OIDC device authorization failed: malformed token response"
+        raise ValueError(msg) from None
+    credential.token, credential.expiry = token, expiry
 
 
 async def discover(
@@ -66,21 +155,7 @@ async def discover(
         response.raise_for_status()
         data = response.json()
 
-    if data.get("issuer") != expected_issuer:
-        msg = "OIDC discovery issuer mismatch"
-        raise ValueError(msg)
-
-    required = {
-        "device_authorization_endpoint",
-        "registration_endpoint",
-        "token_endpoint",
-        "userinfo_endpoint",
-    }
-    missing = sorted(field for field in required if not data.get(field))
-    if missing:
-        msg = f"OIDC discovery missing required metadata: {', '.join(missing)}"
-        raise ValueError(msg)
-
+    data = _validate_discovery_data(data, expected_issuer)
     log.debug("OIDC Discovery Data: %s", data)
     return data
 
@@ -96,18 +171,7 @@ async def register(url: str, client: httpx.AsyncClient | None = None) -> dict[st
     Returns:
         dict[str, Any]: Client registration details.
     """
-    hostname = socket.gethostname()
-    date = time.strftime("%Y-%m-%d %H:%M", time.gmtime())
-    payload: dict[str, Any] = {
-        "client_name": f"Science Platform CLI @ {hostname} {date}",
-        "grant_types": [
-            "urn:ietf:params:oauth:grant-type:device_code",
-            "refresh_token",
-        ],
-        "response_types": ["token"],
-        "token_endpoint_auth_method": "client_secret_basic",
-        "scope": "openid profile email offline_access",
-    }
+    payload = _registration_payload()
 
     if client is None:
         async with httpx.AsyncClient() as http:
@@ -146,28 +210,14 @@ async def _poll_token(url: str, code: str, client: AsyncOAuth2Client) -> dict[st
             device_code=code,
         )
     except OAuthError as error:
-        if error.error == "authorization_pending":
-            raise AuthPendingError from None
-        if error.error == "slow_down":
-            raise SlowDownError from None
-        if error.error == "access_denied":
-            msg = "OIDC device authorization was denied"
-            raise PermissionError(msg) from None
-        if error.error == "expired_token":
-            msg = "OIDC device authorization expired"
-            raise TimeoutError(msg) from None
-        msg = "OIDC device authorization failed"
-        raise ValueError(msg) from None
+        _raise_poll_oauth_error(error)
     except httpx.HTTPStatusError:
         msg = "OIDC device authorization failed"
         raise ValueError(msg) from None
     except ValueError:
         msg = "OIDC device authorization failed: malformed token response"
         raise ValueError(msg) from None
-    if not isinstance(token, dict) or "access_token" not in token:
-        msg = "OIDC device authorization failed: malformed token response"
-        raise ValueError(msg)
-    return token
+    return _validate_poll_token(token)
 
 
 @contextmanager
@@ -333,6 +383,8 @@ async def authflow(
     identity: str,
     secret: str,
     client: AsyncOAuth2Client | None = None,
+    *,
+    on_challenge: ChallengePresenter | None = None,
 ) -> dict[str, Any]:
     """OIDC Authorization Flow.
 
@@ -343,6 +395,7 @@ async def authflow(
         secret (str): Client secret.
         client: Optional Authlib async OAuth client.
             If None, creates a new one. Defaults to None.
+        on_challenge: Optional callback invoked after device authorization.
 
     Returns:
         dict[str, Any]: OIDC tokens including access and refresh tokens.
@@ -358,7 +411,12 @@ async def authflow(
             token_endpoint_auth_method=_BASIC_AUTH_METHOD,
         ) as http_client:
             return await _authflow_impl(
-                device_auth_url, token_url, identity, secret, http_client
+                device_auth_url,
+                token_url,
+                identity,
+                secret,
+                http_client,
+                on_challenge=on_challenge,
             )
     else:
         return await _authflow_impl(
@@ -367,6 +425,7 @@ async def authflow(
             identity,
             secret,
             client,
+            on_challenge=on_challenge,
         )
 
 
@@ -396,11 +455,7 @@ async def start_device_authorization(
         auth=(identity, secret),
     )
     response.raise_for_status()
-    try:
-        challenge = DeviceAuthorization.model_validate(response.json())
-    except ValidationError:
-        msg = "Invalid OIDC device authorization response"
-        raise ValueError(msg) from None
+    challenge = _parse_device_authorization(response)
     log.debug("OIDC device authorization challenge received")
     return challenge
 
@@ -477,6 +532,8 @@ async def _authflow_impl(
     identity: str,
     secret: str,
     client: AsyncOAuth2Client,
+    *,
+    on_challenge: ChallengePresenter | None = None,
 ) -> dict[str, Any]:
     """Implementation of the auth flow with an existing client.
 
@@ -486,6 +543,7 @@ async def _authflow_impl(
         identity (str): Client identity.
         secret (str): Client secret.
         client: Authlib async OAuth client.
+        on_challenge: Optional callback invoked after device authorization.
 
     Returns:
         dict[str, Any]: OIDC tokens including access and refresh tokens.
@@ -499,6 +557,8 @@ async def _authflow_impl(
         secret,
         client,
     )
+    if on_challenge is not None:
+        on_challenge(challenge)
 
     return await poll_device_token(token_url, challenge, client)
 
@@ -509,6 +569,7 @@ async def authenticate_credential(
     expected_issuer: str,
     timeout: int | None = None,
     device_flow: DeviceFlow | None = None,
+    on_challenge: ChallengePresenter | None = None,
     on_authenticated: Callable[[str | None], None] | None = None,
 ) -> OIDCCredential:
     """Authenticate using OIDC Device Authorization Flow.
@@ -519,6 +580,8 @@ async def authenticate_credential(
         timeout: HTTP timeout in seconds for OIDC HTTP requests.
         device_flow: Device authorization coordinator. Defaults to the
             presentation-free protocol flow.
+        on_challenge: Optional callback invoked by the default protocol flow
+            after device authorization.
         on_authenticated: Optional observer for the authenticated username.
 
     Returns:
@@ -571,27 +634,25 @@ async def authenticate_credential(
             )
 
         async with oauth_context as oauth_client:
-            authorize = device_flow or authflow
-            tokens = await authorize(
-                str(credential.endpoints.device),
-                str(credential.endpoints.token),
-                str(credential.client.identity),
-                client_secret,
-                oauth_client,
-            )
+            if device_flow is None:
+                tokens = await authflow(
+                    str(credential.endpoints.device),
+                    str(credential.endpoints.token),
+                    str(credential.client.identity),
+                    client_secret,
+                    oauth_client,
+                    on_challenge=on_challenge,
+                )
+            else:
+                tokens = await device_flow(
+                    str(credential.endpoints.device),
+                    str(credential.endpoints.token),
+                    str(credential.client.identity),
+                    client_secret,
+                    oauth_client,
+                )
 
-        try:
-            token = Token(
-                access=tokens["access_token"],
-                refresh=tokens.get("refresh_token"),
-                token_type=tokens.get("token_type"),
-                scope=tokens.get("scope"),
-            )
-            expiry = Expiry(access=tokens.get("expires_at"), refresh=None)
-        except (KeyError, TypeError, ValidationError):
-            msg = "OIDC device authorization failed: malformed token response"
-            raise ValueError(msg) from None
-        credential.token, credential.expiry = token, expiry
+        _install_tokens(credential, tokens)
 
         url: str = response["userinfo_endpoint"]
         headers = {
@@ -602,6 +663,274 @@ async def authenticate_credential(
             ),
         }
         user = await client.get(url, headers=headers)
+        user.raise_for_status()
+        username = user.json().get("preferred_username")
+        if on_authenticated is not None:
+            on_authenticated(username)
+        return credential
+
+
+def sync_discover(
+    url: str,
+    client: httpx.Client | None = None,
+    *,
+    expected_issuer: str,
+) -> dict[str, Any]:
+    """Discover OIDC provider configuration with a synchronous HTTP client."""
+    if client is None:
+        with httpx.Client() as http_client:
+            response = http_client.get(url)
+            response.raise_for_status()
+            data: dict[str, Any] = response.json()
+    else:
+        response = client.get(url)
+        response.raise_for_status()
+        data = response.json()
+
+    data = _validate_discovery_data(data, expected_issuer)
+    log.debug("OIDC Discovery Data: %s", data)
+    return data
+
+
+def sync_register(
+    url: str,
+    client: httpx.Client | None = None,
+) -> dict[str, Any]:
+    """Register a device-flow client with a synchronous HTTP client."""
+    payload = _registration_payload()
+
+    if client is None:
+        with httpx.Client() as http_client:
+            response = http_client.post(url, json=payload)
+            response.raise_for_status()
+            data: dict[str, Any] = response.json()
+    else:
+        response = client.post(url, json=payload)
+        response.raise_for_status()
+        data = response.json()
+
+    log.debug("OIDC dynamic client registration succeeded.")
+    return data
+
+
+def sync_start_device_authorization(
+    url: str,
+    identity: str,
+    secret: str,
+    client: httpx.Client,
+) -> DeviceAuthorization:
+    """Request an OIDC device authorization challenge synchronously."""
+    response = client.post(
+        url,
+        data={
+            "client_id": identity,
+            "scope": "openid profile email offline_access",
+        },
+        auth=(identity, secret),
+    )
+    response.raise_for_status()
+    challenge = _parse_device_authorization(response)
+    log.debug("OIDC device authorization challenge received")
+    return challenge
+
+
+def _sync_poll_token(
+    url: str,
+    code: str,
+    client: OAuth2Client,
+) -> dict[str, Any]:
+    """Exchange a device code for tokens with a synchronous OAuth client."""
+    try:
+        token: dict[str, Any] = client.fetch_token(
+            url,
+            grant_type=DEVICE_CODE_GRANT_TYPE,
+            device_code=code,
+        )
+    except OAuthError as error:
+        _raise_poll_oauth_error(error)
+    except httpx.HTTPStatusError:
+        msg = "OIDC device authorization failed"
+        raise ValueError(msg) from None
+    except ValueError:
+        msg = "OIDC device authorization failed: malformed token response"
+        raise ValueError(msg) from None
+    return _validate_poll_token(token)
+
+
+def sync_poll_device_token(
+    token_url: str,
+    challenge: DeviceAuthorization,
+    client: OAuth2Client,
+) -> dict[str, Any]:
+    """Poll for OIDC tokens with the RFC 8628 interval using sync I/O."""
+    interval = challenge.interval
+    deadline = time.monotonic() + challenge.expires_in
+    code = challenge.device_code.get_secret_value()
+
+    while time.monotonic() < deadline:
+        try:
+            return _sync_poll_token(token_url, code, client)
+        except AuthPendingError:
+            pass
+        except SlowDownError:
+            interval += 5
+        except httpx.TransportError:
+            interval *= 2
+        remaining = deadline - time.monotonic()
+        if remaining > 0:
+            time.sleep(min(interval, remaining))
+
+    msg = "Device flow timed out"
+    raise TimeoutError(msg)
+
+
+def sync_authflow(
+    device_auth_url: str,
+    token_url: str,
+    identity: str,
+    secret: str,
+    client: OAuth2Client | None = None,
+    *,
+    on_challenge: ChallengePresenter | None = None,
+) -> dict[str, Any]:
+    """Run the presentation-free OIDC device flow with native sync I/O."""
+    if client is None:
+        from authlib.integrations.httpx_client import OAuth2Client  # noqa: PLC0415
+
+        with OAuth2Client(
+            identity,
+            secret,
+            token_endpoint_auth_method=_BASIC_AUTH_METHOD,
+        ) as http_client:
+            return _sync_authflow_impl(
+                device_auth_url,
+                token_url,
+                identity,
+                secret,
+                http_client,
+                on_challenge=on_challenge,
+            )
+    return _sync_authflow_impl(
+        device_auth_url,
+        token_url,
+        identity,
+        secret,
+        client,
+        on_challenge=on_challenge,
+    )
+
+
+def _sync_authflow_impl(
+    device_auth_url: str,
+    token_url: str,
+    identity: str,
+    secret: str,
+    client: OAuth2Client,
+    *,
+    on_challenge: ChallengePresenter | None = None,
+) -> dict[str, Any]:
+    """Run one synchronous device challenge and token exchange."""
+    challenge = sync_start_device_authorization(
+        device_auth_url,
+        identity,
+        secret,
+        client,
+    )
+    if on_challenge is not None:
+        on_challenge(challenge)
+    return sync_poll_device_token(token_url, challenge, client)
+
+
+def sync_authenticate_credential(
+    credential: OIDCCredential,
+    *,
+    expected_issuer: str,
+    timeout: int | None = None,
+    device_flow: SyncDeviceFlow | None = None,
+    on_challenge: ChallengePresenter | None = None,
+    on_authenticated: Callable[[str | None], None] | None = None,
+) -> OIDCCredential:
+    """Authenticate an OIDC record with native synchronous HTTP operations."""
+    request_timeout = None if timeout is None else httpx.Timeout(timeout)
+
+    from authlib.integrations.httpx_client import OAuth2Client  # noqa: PLC0415
+
+    if request_timeout is None:
+        client_context = httpx.Client()
+    else:
+        client_context = httpx.Client(timeout=request_timeout)
+
+    with client_context as client:
+        response = sync_discover(
+            str(credential.endpoints.discovery),
+            client,
+            expected_issuer=expected_issuer,
+        )
+        credential.endpoints.device = response["device_authorization_endpoint"]
+        credential.endpoints.registration = response["registration_endpoint"]
+        credential.endpoints.token = response["token_endpoint"]
+
+        log.debug("Discovered OIDC configuration:")
+        log.debug("Device Registration Endpoint: %s", credential.endpoints.registration)
+        log.debug("Device Authorization Endpoint: %s", credential.endpoints.device)
+        log.debug("Token Endpoint: %s", credential.endpoints.token)
+
+        device = sync_register(str(credential.endpoints.registration), client)
+        try:
+            identity = device["client_id"]
+            client_secret = device["client_secret"]
+        except (KeyError, TypeError):
+            msg = "OIDC device authorization failed: malformed client response"
+            raise ValueError(msg) from None
+        if not isinstance(identity, str) or not isinstance(client_secret, str):
+            msg = "OIDC device authorization failed: malformed client response"
+            raise TypeError(msg)
+        credential.client.identity = identity
+        credential.client.secret = SecretStr(client_secret)
+
+        if request_timeout is None:
+            oauth_context = OAuth2Client(
+                identity,
+                client_secret,
+                token_endpoint_auth_method=_BASIC_AUTH_METHOD,
+            )
+        else:
+            oauth_context = OAuth2Client(
+                identity,
+                client_secret,
+                token_endpoint_auth_method=_BASIC_AUTH_METHOD,
+                timeout=request_timeout,
+            )
+        with oauth_context as oauth_client:
+            if device_flow is None:
+                tokens = sync_authflow(
+                    str(credential.endpoints.device),
+                    str(credential.endpoints.token),
+                    identity,
+                    client_secret,
+                    oauth_client,
+                    on_challenge=on_challenge,
+                )
+            else:
+                tokens = device_flow(
+                    str(credential.endpoints.device),
+                    str(credential.endpoints.token),
+                    identity,
+                    client_secret,
+                    oauth_client,
+                )
+
+        _install_tokens(credential, tokens)
+
+        url: str = response["userinfo_endpoint"]
+        headers = {
+            "Authorization": (
+                f"Bearer {credential.token.access.get_secret_value()}"
+                if credential.token.access
+                else ""
+            ),
+        }
+        user = client.get(url, headers=headers)
         user.raise_for_status()
         username = user.json().get("preferred_username")
         if on_authenticated is not None:

--- a/canfar/authentication.py
+++ b/canfar/authentication.py
@@ -2,15 +2,26 @@
 
 from __future__ import annotations
 
+import asyncio
+import sys
 from typing import TYPE_CHECKING, NoReturn
 
+import httpx
+
 import canfar.server as server_service
+from canfar.auth import oidc
 from canfar.errors import ErrorCode, StructuredError
 from canfar.idp import IdpInfo, get_idp
 from canfar.models.auth import (
     Authentication,
     AuthenticationCredential,
     AuthMode,
+    Client,
+    DeviceAuthorization,
+    Endpoint,
+    Expiry,
+    OIDCCredential,
+    Token,
     X509Credential,
 )
 from canfar.models.config import (
@@ -86,6 +97,39 @@ def login(idp: str, force: bool = False) -> None:
     config.editor.set(f"authentication.{credential.idp}", credential)
     server_service.discover(idp, config=config, save=False)
     config.editor.save()
+
+
+async def alogin(idp: str, force: bool = False) -> None:
+    """Authenticate an IDP from an existing asynchronous event loop.
+
+    The OIDC protocol uses native asynchronous HTTP and polling. Synchronous
+    X.509 inspection and Science Platform discovery run in worker threads so
+    this API does not block the caller's event loop.
+
+    Args:
+        idp: Canonical Identity Provider key.
+        force: Re-authenticate and rediscover when true.
+
+    Raises:
+        KeyError: Unknown IDP key.
+        AuthenticationError: Credential or discovery failure.
+    """
+    idp_info = get_idp(idp)
+    config = Configuration()  # ty: ignore[missing-argument]
+
+    if _has_authentication(config, idp) and not force:
+        return
+
+    credential = await _authenticate_async(idp_info)
+    editor = config.editor
+    editor.set(f"authentication.{credential.idp}", credential)
+    await asyncio.to_thread(
+        server_service.discover,
+        idp,
+        config=config,
+        save=False,
+    )
+    await asyncio.to_thread(editor.save)
 
 
 def use(idp: str) -> None:
@@ -331,10 +375,15 @@ def _credential_expiry(credential: AuthenticationCredential) -> float | None:
 
 def _authenticate(idp_info: IdpInfo) -> AuthenticationCredential:
     if idp_info.auth_mode == "x509":
-        credential = _authenticate_x509(idp_info.key)
-    else:
-        _authenticate_oidc(idp_info.key)
-    return credential
+        return _authenticate_x509(idp_info.key)
+    return _authenticate_oidc(idp_info)
+
+
+async def _authenticate_async(idp_info: IdpInfo) -> AuthenticationCredential:
+    """Acquire one Authentication Record without blocking an event loop."""
+    if idp_info.auth_mode == "x509":
+        return await asyncio.to_thread(_authenticate_x509, idp_info.key)
+    return await _authenticate_oidc_async(idp_info)
 
 
 def _authenticate_x509(idp: str) -> X509Credential:
@@ -356,18 +405,88 @@ def _authenticate_x509(idp: str) -> X509Credential:
     )
 
 
-def _authenticate_oidc(idp: str) -> NoReturn:
-    _fail(
-        code=ErrorCode.AUTHENTICATION_CREDENTIAL_MISSING,
-        message=f"OIDC authentication for IDP '{idp}' requires interactive login.",
-        hint="Use the CLI login flow for first-time OIDC authentication.",
+def _print_device_challenge(challenge: DeviceAuthorization) -> None:
+    """Print only user-facing device authorization data to the terminal."""
+    lines = [f"Verification URL: {challenge.verification_uri}"]
+    if challenge.verification_uri_complete is not None:
+        lines.append(
+            f"Verification URL (complete): {challenge.verification_uri_complete}"
+        )
+    lines.append(f"Device code: {challenge.user_code.get_secret_value()}")
+    sys.stdout.write(
+        "\n".join(lines) + "\n",
     )
+    sys.stdout.flush()
+
+
+def _oidc_credential(idp: str, info: IdpInfo) -> OIDCCredential:
+    """Build an empty OIDC Authentication Record from IDP metadata."""
+    if info.oidc_discovery_url is None:
+        msg = f"OIDC discovery URL is not configured for IDP '{idp}'."
+        raise RuntimeError(msg)
+    if info.oidc_issuer is None:
+        msg = f"OIDC issuer is not configured for IDP '{idp}'."
+        raise RuntimeError(msg)
+    return OIDCCredential(
+        idp=idp,
+        endpoints=Endpoint(discovery=str(info.oidc_discovery_url)),
+        client=Client(),
+        token=Token(),
+        expiry=Expiry(),
+    )
+
+
+def _authenticate_oidc(info: IdpInfo) -> OIDCCredential:
+    """Acquire one OIDC Authentication Record with native sync I/O."""
+    credential = _oidc_credential(info.key, info)
+    try:
+        return oidc.sync_authenticate_credential(
+            credential,
+            expected_issuer=str(info.oidc_issuer),
+            on_challenge=_print_device_challenge,
+        )
+    except (
+        PermissionError,
+        TimeoutError,
+        TypeError,
+        ValueError,
+        httpx.HTTPError,
+    ) as exc:
+        raise _authentication_error(
+            code=ErrorCode.AUTHENTICATION_CREDENTIAL_MISSING,
+            message=f"OIDC authentication failed: {exc}",
+            hint="Complete the device authorization before it expires.",
+        ) from exc
+
+
+async def _authenticate_oidc_async(info: IdpInfo) -> OIDCCredential:
+    """Acquire one OIDC Authentication Record with native async I/O."""
+    credential = _oidc_credential(info.key, info)
+    try:
+        return await oidc.authenticate_credential(
+            credential,
+            expected_issuer=str(info.oidc_issuer),
+            on_challenge=_print_device_challenge,
+        )
+    except (
+        PermissionError,
+        TimeoutError,
+        TypeError,
+        ValueError,
+        httpx.HTTPError,
+    ) as exc:
+        raise _authentication_error(
+            code=ErrorCode.AUTHENTICATION_CREDENTIAL_MISSING,
+            message=f"OIDC authentication failed: {exc}",
+            hint="Complete the device authorization before it expires.",
+        ) from exc
 
 
 __all__ = [
     "AuthMode",
     "Authentication",
     "AuthenticationError",
+    "alogin",
     "list",
     "login",
     "purge",

--- a/canfar/cli/login.py
+++ b/canfar/cli/login.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
+import httpx
 import typer
 
 from canfar import CONFIG_PATH
@@ -67,7 +68,13 @@ def _login_flow(
     idp_info = get_idp(idp)
     try:
         credential = authenticate_for_cli(idp_info, timeout=timeout, force=force)
-    except (ValueError, RuntimeError) as exc:
+    except (
+        PermissionError,
+        TimeoutError,
+        ValueError,
+        RuntimeError,
+        httpx.HTTPError,
+    ) as exc:
         get_console(stderr=True).print(f"[bold red]{exc}[/bold red]")
         raise typer.Exit(1) from exc
 

--- a/docs/client/get-started.md
+++ b/docs/client/get-started.md
@@ -43,7 +43,8 @@ This prints the verification URL and device code and waits for approval. In an
 existing async event loop, await the native counterpart instead:
 
 ```python
-await canfar.alogin("srcnet")
+async def authenticate():
+    await canfar.alogin("srcnet")
 ```
 
 Use the CLI for browser opening, QR output, and progress presentation.

--- a/docs/client/get-started.md
+++ b/docs/client/get-started.md
@@ -31,6 +31,23 @@ For SRCNet:
 canfar login srcnet
 ```
 
+Python can also start the SRCNet device flow directly:
+
+```python
+import canfar
+
+canfar.login("srcnet")
+```
+
+This prints the verification URL and device code and waits for approval. In an
+existing async event loop, await the native counterpart instead:
+
+```python
+await canfar.alogin("srcnet")
+```
+
+Use the CLI for browser opening, QR output, and progress presentation.
+
 Force a fresh login when credentials expire or you want to replace saved state:
 
 ```bash

--- a/docs/client/quick-start.md
+++ b/docs/client/quick-start.md
@@ -23,7 +23,8 @@ The call prints the verification URL and device code, then waits for approval.
 Inside an existing async event loop, use the native async counterpart:
 
 ```python
-await canfar.alogin("srcnet")
+async def authenticate():
+    await canfar.alogin("srcnet")
 ```
 
 Use the CLI when you want browser opening, QR output, or progress presentation.

--- a/docs/client/quick-start.md
+++ b/docs/client/quick-start.md
@@ -11,6 +11,23 @@ canfar login cadc
 
 Use `canfar login srcnet` for SRCNet.
 
+Python callers can run the same device flow without CLI presentation machinery:
+
+```python
+import canfar
+
+canfar.login("srcnet")
+```
+
+The call prints the verification URL and device code, then waits for approval.
+Inside an existing async event loop, use the native async counterpart:
+
+```python
+await canfar.alogin("srcnet")
+```
+
+Use the CLI when you want browser opening, QR output, or progress presentation.
+
 ## 2. Create a notebook
 
 ```python

--- a/tests/test_auth_oidc_sync.py
+++ b/tests/test_auth_oidc_sync.py
@@ -1,0 +1,230 @@
+"""Contract tests for the native synchronous OIDC device flow."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call, patch
+
+import httpx
+import pytest
+from authlib.integrations.httpx_client import OAuth2Client
+from pydantic import SecretStr
+
+from canfar.auth.oidc import sync_authenticate_credential, sync_poll_device_token
+from canfar.models.auth import Client, DeviceAuthorization, Endpoint, OIDCCredential
+
+
+def _challenge(
+    *,
+    expires_in: int = 60,
+    interval: int = 5,
+    device_code: str = "device_code_123",
+) -> DeviceAuthorization:
+    """Return a deterministic RFC 8628 challenge."""
+    return DeviceAuthorization(
+        verification_uri="https://example.com/device",
+        user_code="ABC123",
+        expires_in=expires_in,
+        interval=interval,
+        device_code=device_code,
+    )
+
+
+def _oauth_client(
+    *responses: httpx.Response | Exception,
+) -> tuple[OAuth2Client, list[httpx.Request]]:
+    """Return an Authlib client backed by deterministic token responses."""
+    remaining = iter(responses)
+    requests: list[httpx.Request] = []
+
+    def token_endpoint(request: httpx.Request) -> httpx.Response:
+        """Return the next deterministic token response."""
+        requests.append(request)
+        response = next(remaining)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    return (
+        OAuth2Client(
+            "client_id",
+            "client_secret",
+            token_endpoint_auth_method="client_secret_basic",
+            transport=httpx.MockTransport(token_endpoint),
+        ),
+        requests,
+    )
+
+
+def test_sync_poll_device_token_waits_at_protocol_interval() -> None:
+    """A pending authorization waits before the next token request."""
+    client, requests = _oauth_client(
+        httpx.Response(400, json={"error": "authorization_pending"}),
+        httpx.Response(200, json={"access_token": "access-token"}),
+    )
+
+    with client, patch("canfar.auth.oidc.time.sleep") as sleep:
+        tokens = sync_poll_device_token(
+            "https://example.com/token",
+            _challenge(),
+            client,
+        )
+
+    assert tokens["access_token"] == "access-token"
+    assert len(requests) == 2
+    assert sleep.call_args_list == [call(5)]
+
+
+def test_sync_poll_device_token_expires_at_challenge_deadline() -> None:
+    """Pending authorization stops at the challenge expiry deadline."""
+    client, requests = _oauth_client(
+        httpx.Response(400, json={"error": "authorization_pending"}),
+        httpx.Response(400, json={"error": "authorization_pending"}),
+        httpx.Response(200, json={"access_token": "too-late"}),
+    )
+    clock = 0.0
+
+    def monotonic() -> float:
+        return clock
+
+    def advance(seconds: float) -> None:
+        nonlocal clock
+        clock += seconds
+
+    with (
+        client,
+        patch("canfar.auth.oidc.time.monotonic", side_effect=monotonic),
+        patch("canfar.auth.oidc.time.sleep", side_effect=advance) as sleep,
+        pytest.raises(TimeoutError, match="Device flow timed out"),
+    ):
+        sync_poll_device_token(
+            "https://example.com/token",
+            _challenge(expires_in=6),
+            client,
+        )
+
+    assert len(requests) == 2
+    assert sleep.call_args_list == [call(5), call(1)]
+
+
+def test_sync_poll_device_token_reports_denial_without_secrets() -> None:
+    """Terminal denial is reported without echoing provider response data."""
+    client, requests = _oauth_client(
+        httpx.Response(
+            400,
+            json={
+                "error": "access_denied",
+                "error_description": "secret-error-description",
+            },
+        )
+    )
+
+    with client, pytest.raises(PermissionError, match="authorization was denied"):
+        sync_poll_device_token(
+            "https://example.com/token",
+            _challenge(device_code="secret-device-code"),
+            client,
+        )
+
+    assert len(requests) == 1
+
+
+def test_sync_poll_device_token_retries_transport_failure() -> None:
+    """A transport failure backs off and retries before succeeding."""
+    client, _ = _oauth_client(
+        httpx.ConnectTimeout("network timeout"),
+        httpx.Response(200, json={"access_token": "access-token"}),
+    )
+
+    with client, patch("canfar.auth.oidc.time.sleep") as sleep:
+        tokens = sync_poll_device_token(
+            "https://example.com/token",
+            _challenge(),
+            client,
+        )
+
+    assert tokens["access_token"] == "access-token"
+    sleep.assert_called_once_with(10)
+
+
+def test_sync_authenticate_credential_runs_complete_native_flow() -> None:
+    """Sync authentication performs discovery, registration, device, and userinfo."""
+    credential = OIDCCredential(
+        idp="srcnet",
+        endpoints=Endpoint(
+            discovery="https://example.com/.well-known/openid-configuration"
+        ),
+        client=Client(),
+    )
+    discovery = httpx.Response(
+        200,
+        request=httpx.Request(
+            "GET", "https://example.com/.well-known/openid-configuration"
+        ),
+        json={
+            "issuer": "https://example.com",
+            "device_authorization_endpoint": "https://example.com/device",
+            "registration_endpoint": "https://example.com/register",
+            "token_endpoint": "https://example.com/token",
+            "userinfo_endpoint": "https://example.com/userinfo",
+        },
+    )
+    registration = httpx.Response(
+        200,
+        request=httpx.Request("POST", "https://example.com/register"),
+        json={"client_id": "client-id", "client_secret": "client-secret"},
+    )
+    challenge = httpx.Response(
+        200,
+        request=httpx.Request("POST", "https://example.com/device"),
+        json={
+            "verification_uri": "https://example.com/device",
+            "user_code": "ABC123",
+            "expires_in": 600,
+            "interval": 5,
+            "device_code": "device-code",
+        },
+    )
+    userinfo = httpx.Response(
+        200,
+        request=httpx.Request("GET", "https://example.com/userinfo"),
+        json={"preferred_username": "test-user"},
+    )
+    sync_client = MagicMock()
+    sync_client.get.side_effect = [discovery, userinfo]
+    sync_client.post.return_value = registration
+    oauth_client = MagicMock()
+    oauth_client.post.return_value = challenge
+    oauth_client.fetch_token.return_value = {
+        "access_token": "access-token",
+        "refresh_token": "refresh-token",
+        "token_type": "Bearer",
+        "scope": "openid profile",
+        "expires_at": 1893456000,
+    }
+    presented: list[DeviceAuthorization] = []
+
+    with (
+        patch("canfar.auth.oidc.httpx.Client") as client_class,
+        patch("authlib.integrations.httpx_client.OAuth2Client") as oauth_client_class,
+        patch("canfar.auth.oidc.time.sleep"),
+    ):
+        client_class.return_value.__enter__.return_value = sync_client
+        oauth_client_class.return_value.__enter__.return_value = oauth_client
+        result = sync_authenticate_credential(
+            credential,
+            expected_issuer="https://example.com",
+            on_challenge=presented.append,
+        )
+
+    assert result.client.identity == "client-id"
+    assert result.client.secret == SecretStr("client-secret")
+    assert result.token.access == SecretStr("access-token")
+    assert result.token.refresh == SecretStr("refresh-token")
+    assert presented[0].user_code == SecretStr("ABC123")
+    sync_client.get.assert_any_call(
+        "https://example.com/.well-known/openid-configuration"
+    )
+    sync_client.get.assert_any_call(
+        "https://example.com/userinfo",
+        headers={"Authorization": "Bearer access-token"},
+    )

--- a/tests/test_authentication_oidc_login.py
+++ b/tests/test_authentication_oidc_login.py
@@ -1,0 +1,135 @@
+"""Contract tests for public synchronous and asynchronous OIDC login."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import canfar
+from canfar.models.auth import (
+    Client,
+    DeviceAuthorization,
+    Endpoint,
+    Expiry,
+    OIDCCredential,
+    Token,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _patch_config(path: Path):
+    return patch("canfar.models.config.CONFIG_PATH", path)
+
+
+def _credential() -> OIDCCredential:
+    """Return a saved-ready SRCNet Authentication Record."""
+    return OIDCCredential(
+        idp="srcnet",
+        endpoints=Endpoint(
+            discovery="https://example.com/.well-known/openid-configuration"
+        ),
+        client=Client(identity="client-id", secret="client-secret"),
+        token=Token(
+            access="access-token",
+            refresh="refresh-token",
+            token_type="Bearer",
+            scope="openid profile",
+        ),
+        expiry=Expiry(access=1893456000, refresh=None),
+    )
+
+
+def _challenge() -> DeviceAuthorization:
+    """Return the presentation data exposed by the device protocol."""
+    return DeviceAuthorization(
+        verification_uri="https://example.com/device",
+        verification_uri_complete="https://example.com/device?user_code=ABC123",
+        user_code="ABC123",
+        expires_in=600,
+        interval=5,
+        device_code="secret-device-code",
+    )
+
+
+def test_login_runs_plain_sync_oidc_flow_and_persists_record(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The sync Python API presents a challenge without CLI presentation tools."""
+    config_path = tmp_path / "config.yaml"
+    coordinator = MagicMock()
+
+    def authenticate(credential: OIDCCredential, **kwargs) -> OIDCCredential:
+        """Expose the challenge through the API's plain terminal callback."""
+        assert credential.idp == "srcnet"
+        kwargs["on_challenge"](_challenge())
+        coordinator(**kwargs)
+        return _credential()
+
+    with (
+        _patch_config(config_path),
+        patch(
+            "canfar.authentication.oidc.sync_authenticate_credential",
+            side_effect=authenticate,
+        ) as authenticate_credential,
+        patch("canfar.authentication.server_service.discover", return_value=[]),
+    ):
+        canfar.login("srcnet")
+
+    output = capsys.readouterr().out
+    assert "https://example.com/device" in output
+    assert "ABC123" in output
+    assert "secret-device-code" not in output
+    authenticate_credential.assert_called_once()
+    with _patch_config(config_path):
+        saved = canfar.models.config.Configuration()
+    credential = saved.get_credential("srcnet")
+    assert isinstance(credential, OIDCCredential)
+    assert credential.token.access is not None
+    assert credential.token.access.get_secret_value() == "access-token"
+
+
+@pytest.mark.asyncio
+async def test_alogin_uses_native_async_flow_without_asyncio_run(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The async API awaits native protocol work inside an existing event loop."""
+    config_path = tmp_path / "config.yaml"
+
+    async def authenticate(credential: OIDCCredential, **kwargs) -> OIDCCredential:
+        """Expose the challenge through the async terminal callback."""
+        assert credential.idp == "srcnet"
+        kwargs["on_challenge"](_challenge())
+        await asyncio.sleep(0)
+        return _credential()
+
+    with (
+        _patch_config(config_path),
+        patch(
+            "canfar.authentication.oidc.authenticate_credential",
+            new=AsyncMock(side_effect=authenticate),
+        ) as authenticate_credential,
+        patch("canfar.authentication.server_service.discover", return_value=[]),
+        patch(
+            "asyncio.run", side_effect=AssertionError("library API used asyncio.run")
+        ),
+    ):
+        await canfar.alogin("srcnet")
+
+    output = capsys.readouterr().out
+    assert "https://example.com/device" in output
+    assert "ABC123" in output
+    assert "secret-device-code" not in output
+    authenticate_credential.assert_awaited_once()
+    with _patch_config(config_path):
+        saved = canfar.models.config.Configuration()
+    credential = saved.get_credential("srcnet")
+    assert isinstance(credential, OIDCCredential)
+    assert credential.token.access is not None
+    assert credential.token.access.get_secret_value() == "access-token"

--- a/tests/test_authentication_oidc_login.py
+++ b/tests/test_authentication_oidc_login.py
@@ -88,7 +88,7 @@ def test_login_runs_plain_sync_oidc_flow_and_persists_record(
     authenticate_credential.assert_called_once()
     with _patch_config(config_path):
         saved = canfar.models.config.Configuration()
-    credential = saved.get_credential("srcnet")
+    credential = saved.authentication["srcnet"]
     assert isinstance(credential, OIDCCredential)
     assert credential.token.access is not None
     assert credential.token.access.get_secret_value() == "access-token"
@@ -129,7 +129,7 @@ async def test_alogin_uses_native_async_flow_without_asyncio_run(
     authenticate_credential.assert_awaited_once()
     with _patch_config(config_path):
         saved = canfar.models.config.Configuration()
-    credential = saved.get_credential("srcnet")
+    credential = saved.authentication["srcnet"]
     assert isinstance(credential, OIDCCredential)
     assert credential.token.access is not None
     assert credential.token.access.get_secret_value() == "access-token"

--- a/tests/test_cli_login.py
+++ b/tests/test_cli_login.py
@@ -247,3 +247,22 @@ def test_login_existing_without_force_exits_nonzero(tmp_path: Path) -> None:
 
     assert result.exit_code == 1
     assert "already exists" in result.stderr
+
+
+def test_login_presents_device_flow_failure_on_terminal(tmp_path: Path) -> None:
+    """CLI login renders terminal device-flow failures on stderr."""
+    config_path = tmp_path / "config.yaml"
+
+    with (
+        _patch_config(config_path),
+        patch("canfar.cli.login.CONFIG_PATH", config_path),
+        patch("canfar.models.config.CONFIG_PATH", config_path),
+        patch(
+            "canfar.cli.login.authenticate_for_cli",
+            side_effect=PermissionError("OIDC device authorization was denied"),
+        ),
+    ):
+        result = runner.invoke(cli, ["login", "srcnet"])
+
+    assert result.exit_code == 1
+    assert "OIDC device authorization was denied" in result.stderr


### PR DESCRIPTION
## Summary

- expose blocking canfar.login and awaitable canfar.alogin Python APIs
- share device-authorization protocol policy while retaining native sync and async HTTP/sleep loops
- reuse the same coordinator from the richer CLI login adapter
- persist Authentication Records through the authentication operation and config.editor
- document Python and CLI flows

## Validation

- 65 focused OIDC/auth/CLI tests
- 865 deterministic non-slow tests
- zero callers of the Configuration methods removed by #258
- Ruff, changed-file format, ty, MkDocs, and diff checks

Implements #256.