### PR TITLE
refactor: address wave 4 review findings

### DIFF
--- a/canfar/auth/oidc.py
+++ b/canfar/auth/oidc.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 _BASIC_AUTH_METHOD = "client_secret_basic"
+_OIDC_SCOPE = "openid profile email offline_access"
 
 DeviceFlow = Callable[
     [str, str, str, str, "AsyncOAuth2Client"],
@@ -45,7 +46,7 @@ class SlowDownError(Exception):
 
 
 def _validate_discovery_data(data: Any, expected_issuer: str) -> dict[str, Any]:
-    """Validate the provider metadata shared by sync and async discovery."""
+    """Validate OIDC Identity Provider metadata shared by discovery paths."""
     if not isinstance(data, dict) or data.get("issuer") != expected_issuer:
         msg = "OIDC discovery issuer mismatch"
         raise ValueError(msg)
@@ -75,12 +76,17 @@ def _registration_payload() -> dict[str, Any]:
         ],
         "response_types": ["token"],
         "token_endpoint_auth_method": _BASIC_AUTH_METHOD,
-        "scope": "openid profile email offline_access",
+        "scope": _OIDC_SCOPE,
     }
 
 
+def _device_authorization_payload(identity: str) -> dict[str, str]:
+    """Build the device authorization request shared by both transports."""
+    return {"client_id": identity, "scope": _OIDC_SCOPE}
+
+
 def _parse_device_authorization(response: httpx.Response) -> DeviceAuthorization:
-    """Parse one provider challenge without exposing malformed secrets."""
+    """Parse one OIDC Identity Provider challenge without exposing secrets."""
     try:
         return DeviceAuthorization.model_validate(response.json())
     except ValidationError:
@@ -129,7 +135,7 @@ def _install_tokens(credential: OIDCCredential, tokens: dict[str, Any]) -> None:
 
 
 def _client_credentials(device: Any) -> tuple[str, str]:
-    """Extract a valid dynamic client pair without exposing provider data."""
+    """Extract a dynamic client pair without exposing Identity Provider data."""
     if not isinstance(device, dict):
         msg = "OIDC device authorization failed: malformed client response"
         raise TypeError(msg)
@@ -161,7 +167,7 @@ def _set_discovered_endpoints(
     credential: OIDCCredential,
     discovery: dict[str, Any],
 ) -> None:
-    """Install provider endpoints while preserving the credential object."""
+    """Install Identity Provider endpoints while preserving the credential object."""
     credential.endpoints.device = discovery["device_authorization_endpoint"]
     credential.endpoints.registration = discovery["registration_endpoint"]
     credential.endpoints.token = discovery["token_endpoint"]
@@ -173,7 +179,7 @@ async def discover(
     *,
     expected_issuer: str,
 ) -> dict[str, Any]:
-    """Discover OIDC provider configuration.
+    """Discover OIDC Identity Provider configuration.
 
     Args:
         url (str): OIDC Discovery URL.
@@ -182,7 +188,7 @@ async def discover(
         expected_issuer: Exact issuer configured for the Identity Provider.
 
     Returns:
-        dict[str, Any]: OIDC provider configuration.
+        dict[str, Any]: OIDC Identity Provider configuration.
     """
     if client is None:
         async with httpx.AsyncClient() as http_client:
@@ -200,7 +206,7 @@ async def discover(
 
 
 async def register(url: str, client: httpx.AsyncClient | None = None) -> dict[str, Any]:
-    """Register a new client with the OIDC provider.
+    """Register a new client with the OIDC Identity Provider.
 
     Args:
         url (str): OIDC Registration URL.
@@ -487,10 +493,7 @@ async def start_device_authorization(
     """
     response = await client.post(
         url,
-        data={
-            "client_id": identity,
-            "scope": "openid profile email offline_access",
-        },
+        data=_device_authorization_payload(identity),
         auth=(identity, secret),
     )
     response.raise_for_status()
@@ -705,7 +708,7 @@ def sync_discover(
     *,
     expected_issuer: str,
 ) -> dict[str, Any]:
-    """Discover OIDC provider configuration with a synchronous HTTP client."""
+    """Discover OIDC Identity Provider configuration with sync HTTP."""
     response = client.get(url)
     response.raise_for_status()
     data: dict[str, Any] = response.json()
@@ -736,10 +739,7 @@ def sync_start_device_authorization(
     """Request an OIDC device authorization challenge synchronously."""
     response = client.post(
         url,
-        data={
-            "client_id": identity,
-            "scope": "openid profile email offline_access",
-        },
+        data=_device_authorization_payload(identity),
         auth=(identity, secret),
     )
     response.raise_for_status()

--- a/canfar/authentication.py
+++ b/canfar/authentication.py
@@ -51,6 +51,15 @@ class AuthenticationError(Exception):
         super().__init__(self.error.message)
 
 
+_OIDC_DEVICE_LOGIN_ERRORS = (
+    PermissionError,
+    TimeoutError,
+    TypeError,
+    ValueError,
+    httpx.HTTPError,
+)
+
+
 def _authentication_error(
     *,
     code: ErrorCode,
@@ -436,6 +445,15 @@ def _oidc_credential(idp: str, info: IdpInfo) -> OIDCCredential:
     )
 
 
+def _raise_oidc_authentication_error(exc: Exception) -> NoReturn:
+    """Translate an OIDC device-login failure into a structured error."""
+    raise _authentication_error(
+        code=ErrorCode.AUTHENTICATION_CREDENTIAL_MISSING,
+        message=f"OIDC authentication failed: {exc}",
+        hint="Complete the device authorization before it expires.",
+    ) from exc
+
+
 def _authenticate_oidc(info: IdpInfo) -> OIDCCredential:
     """Acquire one OIDC Authentication Record with native sync I/O."""
     credential = _oidc_credential(info.key, info)
@@ -445,18 +463,8 @@ def _authenticate_oidc(info: IdpInfo) -> OIDCCredential:
             expected_issuer=str(info.oidc_issuer),
             on_challenge=_print_device_challenge,
         )
-    except (
-        PermissionError,
-        TimeoutError,
-        TypeError,
-        ValueError,
-        httpx.HTTPError,
-    ) as exc:
-        raise _authentication_error(
-            code=ErrorCode.AUTHENTICATION_CREDENTIAL_MISSING,
-            message=f"OIDC authentication failed: {exc}",
-            hint="Complete the device authorization before it expires.",
-        ) from exc
+    except _OIDC_DEVICE_LOGIN_ERRORS as exc:
+        _raise_oidc_authentication_error(exc)
 
 
 async def _authenticate_oidc_async(info: IdpInfo) -> OIDCCredential:
@@ -468,18 +476,8 @@ async def _authenticate_oidc_async(info: IdpInfo) -> OIDCCredential:
             expected_issuer=str(info.oidc_issuer),
             on_challenge=_print_device_challenge,
         )
-    except (
-        PermissionError,
-        TimeoutError,
-        TypeError,
-        ValueError,
-        httpx.HTTPError,
-    ) as exc:
-        raise _authentication_error(
-            code=ErrorCode.AUTHENTICATION_CREDENTIAL_MISSING,
-            message=f"OIDC authentication failed: {exc}",
-            hint="Complete the device authorization before it expires.",
-        ) from exc
+    except _OIDC_DEVICE_LOGIN_ERRORS as exc:
+        _raise_oidc_authentication_error(exc)
 
 
 __all__ = [

--- a/canfar/config/editor.py
+++ b/canfar/config/editor.py
@@ -7,6 +7,7 @@ import tempfile
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
 import yaml
@@ -69,12 +70,8 @@ def get_value(config: Configuration, path: str) -> Any:
 def _validated_copy(config: Configuration, **updates: Any) -> Configuration:
     """Validate a source-isolated copy of a complete Configuration."""
     data = {**config.model_dump(mode="python"), **updates}
-    candidate = config.__class__.model_construct()
-    config.__class__.__pydantic_validator__.validate_python(
-        data,
-        self_instance=candidate,
-    )
-    return candidate
+    # Avoid BaseSettings merging the persisted YAML source into this copy.
+    return config.__class__.model_validate(MappingProxyType(data))
 
 
 def set_value(config: Configuration, path: str, value: Any) -> Configuration:

--- a/canfar/utils/logging.py
+++ b/canfar/utils/logging.py
@@ -202,7 +202,6 @@ class CanfarLogger:
 
     def __init__(self) -> None:
         """Initialize per-instance file-handler state."""
-        self._configured = False
         self._rich_handler: RichHandler | None = None
         self._file_handler: logging.handlers.RotatingFileHandler | None = None
 
@@ -249,7 +248,6 @@ class CanfarLogger:
                 )
 
             logger.propagate = False
-            self._configured = True
 
     def _setup_file_logging(
         self,
@@ -285,7 +283,6 @@ class CanfarLogger:
             logger.removeHandler(handler)
         self._rich_handler = None
         self._file_handler = None
-        self._configured = False
 
 
 _canfar_logger = CanfarLogger()

--- a/docs/client/quick-start.md
+++ b/docs/client/quick-start.md
@@ -11,23 +11,7 @@ canfar login cadc
 
 Use `canfar login srcnet` for SRCNet.
 
-Python callers can run the same device flow without CLI presentation machinery:
-
-```python
-import canfar
-
-canfar.login("srcnet")
-```
-
-The call prints the verification URL and device code, then waits for approval.
-Inside an existing async event loop, use the native async counterpart:
-
-```python
-async def authenticate():
-    await canfar.alogin("srcnet")
-```
-
-Use the CLI when you want browser opening, QR output, or progress presentation.
+For direct Python OIDC login, see the detailed [login guidance](get-started.md#log-in).
 
 ## 2. Create a notebook
 

--- a/tests/test_auth_oidc_sync.py
+++ b/tests/test_auth_oidc_sync.py
@@ -107,7 +107,7 @@ def test_sync_poll_device_token_expires_at_challenge_deadline() -> None:
 
 
 def test_sync_poll_device_token_reports_denial_without_secrets() -> None:
-    """Terminal denial is reported without echoing provider response data."""
+    """Terminal denial omits OIDC Identity Provider response data."""
     client, requests = _oauth_client(
         httpx.Response(
             400,

--- a/tests/test_import_isolation.py
+++ b/tests/test_import_isolation.py
@@ -156,10 +156,7 @@ for module in (
 ):
     importlib.import_module(module)
 
-from canfar.utils.logging import _canfar_logger
-
 canfar_logger = logging.getLogger("canfar")
-assert not _canfar_logger._configured
 assert canfar_logger.handlers == []
 assert canfar_logger.level == logging.NOTSET
 assert canfar_logger.propagate


### PR DESCRIPTION
## Summary

- deduplicate OIDC device-authorization payload and error translation policy
- replace private Pydantic validation internals with public model validation
- remove write-only logging configuration state
- align IDP terminology and link duplicated Python login guidance

## Validation

- 63 focused tests
- 865 deterministic non-slow tests
- Ruff format and lint
- ty and diff check
- MkDocs build
- net 44 additions / 71 deletions

Wave 4 standards and simplify corrections for #256, #257, and #258.