### PR TITLE
fix(config): preserve source-isolated editor validation

### DIFF
--- a/canfar/config/editor.py
+++ b/canfar/config/editor.py
@@ -69,11 +69,11 @@ def get_value(config: Configuration, path: str) -> Any:
 def _validated_copy(config: Configuration, **updates: Any) -> Configuration:
     """Validate a source-isolated copy of a complete Configuration."""
     data = {**config.model_dump(mode="python"), **updates}
-    candidate = config.__class__.model_validate(data)
-    for field, value in data.items():
-        current = getattr(candidate, field, None)
-        if isinstance(value, dict) and isinstance(current, dict):
-            setattr(candidate, field, {key: current[key] for key in value})
+    candidate = config.__class__.model_construct()
+    config.__class__.__pydantic_validator__.validate_python(
+        data,
+        self_instance=candidate,
+    )
     return candidate
 
 

--- a/canfar/config/editor.py
+++ b/canfar/config/editor.py
@@ -7,7 +7,6 @@ import tempfile
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
-from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
 import yaml
@@ -70,8 +69,12 @@ def get_value(config: Configuration, path: str) -> Any:
 def _validated_copy(config: Configuration, **updates: Any) -> Configuration:
     """Validate a source-isolated copy of a complete Configuration."""
     data = {**config.model_dump(mode="python"), **updates}
-    # Avoid BaseSettings merging the persisted YAML source into this copy.
-    return config.__class__.model_validate(MappingProxyType(data))
+    candidate = config.__class__.model_validate(data)
+    for field, value in data.items():
+        current = getattr(candidate, field, None)
+        if isinstance(value, dict) and isinstance(current, dict):
+            setattr(candidate, field, {key: current[key] for key in value})
+    return candidate
 
 
 def set_value(config: Configuration, path: str, value: Any) -> Configuration:

--- a/canfar/config/editor.py
+++ b/canfar/config/editor.py
@@ -70,6 +70,7 @@ def _validated_copy(config: Configuration, **updates: Any) -> Configuration:
     """Validate a source-isolated copy of a complete Configuration."""
     data = {**config.model_dump(mode="python"), **updates}
     candidate = config.__class__.model_construct()
+    # Full validation must not re-enter BaseSettings persisted sources.
     config.__class__.__pydantic_validator__.validate_python(
         data,
         self_instance=candidate,

--- a/tests/test_config_editor.py
+++ b/tests/test_config_editor.py
@@ -133,6 +133,9 @@ def test_editor_rejects_auth_replacement_with_active_idp_reference(
                 {"cadc": config.authentication["cadc"]},
             )
 
+        assert config.active.authentication == "srcnet"
+        assert set(config.authentication) == {"cadc", "srcnet"}
+
 
 def test_editor_rejects_list_indexing(tmp_path: Path) -> None:
     """Dotted paths may retrieve a whole list but cannot address its items."""

--- a/tests/test_config_editor.py
+++ b/tests/test_config_editor.py
@@ -106,6 +106,34 @@ def test_editor_seeds_idp_for_mapping_form_credentials(tmp_path: Path) -> None:
     assert config.authentication["second"].idp == "second"
 
 
+def test_editor_rejects_auth_replacement_with_active_idp_reference(
+    tmp_path: Path,
+) -> None:
+    """Replacing records cannot invalidate the persisted active IDP reference."""
+    config_path = tmp_path / "config.yaml"
+    with patch("canfar.models.config.CONFIG_PATH", config_path):
+        config = Configuration()
+        config.editor.set(
+            "authentication.srcnet",
+            {
+                "mode": "x509",
+                "path": str(tmp_path / "srcnet.pem"),
+                "expiry": 0,
+            },
+        )
+        config.editor.set(
+            "active",
+            config.active.model_copy(update={"authentication": "srcnet"}),
+        )
+        config.editor.save()
+
+        with pytest.raises(ValidationError):
+            config.editor.set(
+                "authentication",
+                {"cadc": config.authentication["cadc"]},
+            )
+
+
 def test_editor_rejects_list_indexing(tmp_path: Path) -> None:
     """Dotted paths may retrieve a whole list but cannot address its items."""
     config_path = tmp_path / "config.yaml"

--- a/tests/test_config_editor.py
+++ b/tests/test_config_editor.py
@@ -89,6 +89,23 @@ def test_editor_replaces_top_level_mapping_without_reloading_saved_state(
     assert set(config.authentication) == {"cadc"}
 
 
+def test_editor_seeds_idp_for_mapping_form_credentials(tmp_path: Path) -> None:
+    """Mapping-form Authentication records inherit their Identity Provider key."""
+    config_path = tmp_path / "config.yaml"
+    with patch("canfar.models.config.CONFIG_PATH", config_path):
+        config = Configuration()
+        config.editor.set(
+            "authentication.second",
+            {
+                "mode": "x509",
+                "path": str(tmp_path / "second.pem"),
+                "expiry": 0,
+            },
+        )
+
+    assert config.authentication["second"].idp == "second"
+
+
 def test_editor_rejects_list_indexing(tmp_path: Path) -> None:
     """Dotted paths may retrieve a whole list but cannot address its items."""
     config_path = tmp_path / "config.yaml"


### PR DESCRIPTION
## Summary

- retain the narrow constructed-self Pydantic validator seam required to bypass BaseSettings YAML sources
- preserve mapping-form Authentication Record IDP seeding
- reject active-IDP-invalidating replacements without mutating the bound Configuration

Public model_validate and TypeAdapter both re-enter persisted settings sources for this BaseSettings subclass, while post-validation pruning can violate cross-field invariants.

## Validation

- 25 focused config/editor tests
- 867 deterministic non-slow tests
- Ruff format and lint
- ty and diff check

Final Wave 4 re-review correction for #258.