### PR TITLE
test: close Wave 5 review findings

### DIFF
--- a/tests/test_sessions_create_errors.py
+++ b/tests/test_sessions_create_errors.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import httpx
@@ -11,6 +12,9 @@ from pydantic import SecretStr, ValidationError
 
 from canfar.models.session import CreateRequest
 from canfar.sessions import AsyncSession, Session
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
 
 _BASE_URL = "https://example.test/skaha/v1/"
 _SERIALIZED_REQUEST = [
@@ -39,6 +43,40 @@ _SERIALIZED_REQUEST_REPLICA_TWO = [
     ("env", "REPLICA_ID=2"),
     ("env", "REPLICA_COUNT=2"),
 ]
+_FAILURE_CASES = (
+    pytest.param(frozenset({"batch-2"}), ("batch-1-id",), id="partial"),
+    pytest.param(frozenset({"batch-1", "batch-2"}), (), id="total"),
+)
+_INVALID_REQUEST_CASES = (
+    pytest.param(
+        (("kind", "invalid"), ("image", "skaha/terminal:latest")),
+        id="invalid-kind",
+    ),
+    pytest.param(
+        (
+            ("kind", "notebook"),
+            ("image", "skaha/terminal:latest"),
+            ("cmd", "python"),
+        ),
+        id="notebook-command",
+    ),
+    pytest.param(
+        (
+            ("kind", "headless"),
+            ("image", "skaha/terminal:latest"),
+            ("replicas", 0),
+        ),
+        id="zero-replicas",
+    ),
+    pytest.param(
+        (
+            ("kind", "headless"),
+            ("image", "skaha/terminal:latest"),
+            ("replicas", 513),
+        ),
+        id="too-many-replicas",
+    ),
+)
 
 
 def _create_request() -> CreateRequest:
@@ -111,7 +149,7 @@ async def test_async_create_serializes_the_public_request_contract() -> None:
     assert sent[1] == _SERIALIZED_REQUEST_REPLICA_TWO
 
 
-def _failure_responder(failed_names: set[str]):
+def _failure_responder(failed_names: Collection[str]):
     """Return a transport handler for partial or total replica failures."""
 
     def respond(request: httpx.Request) -> httpx.Response:
@@ -134,10 +172,10 @@ def _failure_responder(failed_names: set[str]):
 
 @pytest.mark.parametrize(
     ("failed_names", "expected"),
-    [({"batch-2"}, ["batch-1-id"]), ({"batch-1", "batch-2"}, [])],
+    _FAILURE_CASES,
 )
 def test_sync_create_omits_failed_replicas(
-    failed_names: set[str], expected: list[str]
+    failed_names: frozenset[str], expected: tuple[str, ...]
 ) -> None:
     """Sync create omits failed replicas and returns an empty total failure."""
     request = CreateRequest(
@@ -154,16 +192,16 @@ def test_sync_create_omits_failed_replicas(
         ),
         Session(token=SecretStr("token"), url=_BASE_URL) as session,
     ):
-        assert session.create(request) == expected
+        assert session.create(request) == list(expected)
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("failed_names", "expected"),
-    [({"batch-2"}, ["batch-1-id"]), ({"batch-1", "batch-2"}, [])],
+    _FAILURE_CASES,
 )
 async def test_async_create_omits_failed_replicas(
-    failed_names: set[str], expected: list[str]
+    failed_names: frozenset[str], expected: tuple[str, ...]
 ) -> None:
     """Async create omits failed replicas and returns an empty total failure."""
     request = CreateRequest(
@@ -178,22 +216,18 @@ async def test_async_create_omits_failed_replicas(
         ),
     ):
         async with AsyncSession(token=SecretStr("token"), url=_BASE_URL) as session:
-            assert await session.create(request) == expected
+            assert await session.create(request) == list(expected)
 
 
 @pytest.mark.parametrize(
-    "request_kwargs",
-    [
-        {"kind": "invalid", "image": "skaha/terminal:latest"},
-        {"kind": "notebook", "image": "skaha/terminal:latest", "cmd": "python"},
-        {"kind": "headless", "image": "skaha/terminal:latest", "replicas": 0},
-        {"kind": "headless", "image": "skaha/terminal:latest", "replicas": 513},
-    ],
+    "request_items",
+    _INVALID_REQUEST_CASES,
 )
 def test_sync_create_rejects_invalid_requests(
-    request_kwargs: dict[str, object],
+    request_items: tuple[tuple[str, object], ...],
 ) -> None:
     """Invalid create requests fail before the synchronous HTTP boundary."""
+    request_kwargs = dict(request_items)
     with (
         Session(token=SecretStr("token"), url="https://example.test") as session,
         pytest.raises(ValidationError),
@@ -203,18 +237,14 @@ def test_sync_create_rejects_invalid_requests(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "request_kwargs",
-    [
-        {"kind": "invalid", "image": "skaha/terminal:latest"},
-        {"kind": "notebook", "image": "skaha/terminal:latest", "cmd": "python"},
-        {"kind": "headless", "image": "skaha/terminal:latest", "replicas": 0},
-        {"kind": "headless", "image": "skaha/terminal:latest", "replicas": 513},
-    ],
+    "request_items",
+    _INVALID_REQUEST_CASES,
 )
 async def test_async_create_rejects_invalid_requests(
-    request_kwargs: dict[str, object],
+    request_items: tuple[tuple[str, object], ...],
 ) -> None:
     """Invalid create requests fail before the asynchronous HTTP boundary."""
+    request_kwargs = dict(request_items)
     with pytest.raises(ValidationError):
         async with AsyncSession(
             token=SecretStr("token"), url="https://example.test"

--- a/tests/test_sessions_info_logs.py
+++ b/tests/test_sessions_info_logs.py
@@ -13,27 +13,22 @@ from canfar.sessions import AsyncSession, Session
 
 _BASE_URL = "https://example.test/skaha/v1/"
 
-
-@pytest.fixture
-def ids_and_expected(
-    request: pytest.FixtureRequest,
-) -> tuple[str | list[str], list[dict[str, str]], dict[str, str]]:
-    """Provide zero, one, many, and mixed-failure Session records."""
-    cases = {
-        "empty": ([], [], {}),
-        "one": ("one", [{"id": "one"}], {"one": "log-one"}),
-        "many": (
-            ["one", "two"],
-            [{"id": "one"}, {"id": "two"}],
-            {"one": "log-one", "two": "log-two"},
-        ),
-        "mixed": (
-            ["one", "failed", "three"],
-            [{"id": "one"}, {"id": "three"}],
-            {"one": "log-one", "three": "log-three"},
-        ),
-    }
-    return cases[request.param]
+_INFO_LOG_CASES = (
+    pytest.param([], [], {}, id="empty"),
+    pytest.param("one", [{"id": "one"}], {"one": "log-one"}, id="one"),
+    pytest.param(
+        ["one", "two"],
+        [{"id": "one"}, {"id": "two"}],
+        {"one": "log-one", "two": "log-two"},
+        id="many",
+    ),
+    pytest.param(
+        ["one", "failed", "three"],
+        [{"id": "one"}, {"id": "three"}],
+        {"one": "log-one", "three": "log-three"},
+        id="mixed-failure",
+    ),
+)
 
 
 def _respond(request: httpx.Request) -> httpx.Response:
@@ -57,17 +52,16 @@ def _verbose_messages(caplog: pytest.LogCaptureFixture) -> list[str]:
 
 
 @pytest.mark.parametrize(
-    "ids_and_expected",
-    ["empty", "one", "many", "mixed"],
-    indirect=True,
-    ids=["empty", "one", "many", "mixed"],
+    ("ids", "expected_info", "expected_logs"),
+    _INFO_LOG_CASES,
 )
 def test_sync_info_and_logs_share_public_policy(
-    ids_and_expected: tuple[str | list[str], list[dict[str, str]], dict[str, str]],
+    ids: str | list[str],
+    expected_info: list[dict[str, str]],
+    expected_logs: dict[str, str],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Sync info/logs preserve shape, order, failures, and verbose routing."""
-    ids, expected_info, expected_logs = ids_and_expected
     real_client = httpx.Client
     with (
         patch(
@@ -96,17 +90,16 @@ def test_sync_info_and_logs_share_public_policy(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "ids_and_expected",
-    ["empty", "one", "many", "mixed"],
-    indirect=True,
-    ids=["empty", "one", "many", "mixed"],
+    ("ids", "expected_info", "expected_logs"),
+    _INFO_LOG_CASES,
 )
 async def test_async_info_and_logs_share_public_policy(
-    ids_and_expected: tuple[str | list[str], list[dict[str, str]], dict[str, str]],
+    ids: str | list[str],
+    expected_info: list[dict[str, str]],
+    expected_logs: dict[str, str],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Async info/logs preserve shape, order, failures, and verbose routing."""
-    ids, expected_info, expected_logs = ids_and_expected
     real_async_client = httpx.AsyncClient
     with patch(
         "canfar.client.AsyncClient",

--- a/tests/test_sessions_lifecycle.py
+++ b/tests/test_sessions_lifecycle.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from inspect import Parameter, signature
+from inspect import signature
 from typing import Any
 from unittest.mock import patch
 
@@ -16,48 +16,52 @@ _BASE_URL = "https://example.test/skaha/v1/"
 _CONNECT_IDS = ["missing", "stopped", "running", "terminating", "no-url"]
 _EXPECTED_OPEN_URL = "https://example.test/running"
 
+_EXPECTED_SESSION_SIGNATURES: dict[str, str] = {
+    "fetch": (
+        "(self, kind: 'Kind | None' = None, "
+        "status: 'Status | None' = None, "
+        "view: 'View | None' = None) -> 'list[dict[str, str]]'"
+    ),
+    "stats": "(self) -> 'dict[str, Any]'",
+    "info": "(self, ids: 'list[str] | str') -> 'list[dict[str, Any]]'",
+    "logs": (
+        "(self, ids: 'list[str] | str', verbose: 'bool' = False) "
+        "-> 'dict[str, str] | None'"
+    ),
+    "create": (
+        "(self, name: 'str | CreateRequest', image: 'str | None' = None, "
+        "cores: 'int | None' = None, ram: 'int | None' = None, "
+        "kind: 'Kind' = 'headless', gpu: 'int | None' = None, "
+        "cmd: 'str | None' = None, args: 'str | None' = None, "
+        "env: 'dict[str, Any] | None' = None, replicas: 'int' = 1) "
+        "-> 'list[str]'"
+    ),
+    "events": (
+        "(self, ids: 'str | list[str]', verbose: 'bool' = False) "
+        "-> 'list[dict[str, str]] | None'"
+    ),
+    "destroy": "(self, ids: 'str | list[str]') -> 'dict[str, bool]'",
+    "destroy_with": (
+        "(self, prefix: 'str', *, kind: 'Kind' = 'headless', "
+        "status: 'Status' = 'Completed') -> 'dict[str, bool]'"
+    ),
+    "connect": "(self, ids: 'list[str] | str') -> 'None'",
+}
+
 
 @pytest.mark.parametrize(
     ("method", "expected"),
-    [
-        ("fetch", ["kind", "status", "view"]),
-        ("stats", []),
-        ("info", ["ids"]),
-        ("logs", ["ids", "verbose"]),
-        (
-            "create",
-            [
-                "name",
-                "image",
-                "cores",
-                "ram",
-                "kind",
-                "gpu",
-                "cmd",
-                "args",
-                "env",
-                "replicas",
-            ],
-        ),
-        ("events", ["ids", "verbose"]),
-        ("destroy", ["ids"]),
-        ("destroy_with", ["prefix", "kind", "status"]),
-        ("connect", ["ids"]),
-    ],
+    list(_EXPECTED_SESSION_SIGNATURES.items()),
+    ids=list(_EXPECTED_SESSION_SIGNATURES),
 )
 def test_session_signatures_are_stable_and_parallel(
-    method: str, expected: list[str]
+    method: str,
+    expected: str,
 ) -> None:
-    """Sync and async Session methods keep the released parameter contract."""
-    for client_type in (Session, AsyncSession):
-        parameters = list(signature(getattr(client_type, method)).parameters.values())[
-            1:
-        ]
-        assert [parameter.name for parameter in parameters] == expected
-        if method == "destroy_with":
-            assert all(
-                parameter.kind is Parameter.KEYWORD_ONLY for parameter in parameters[1:]
-            )
+    """Sync and async Session methods keep the complete released contract."""
+    sync_signature = signature(getattr(Session, method))
+    assert str(sync_signature) == expected
+    assert signature(getattr(AsyncSession, method)) == sync_signature
 
 
 @pytest.mark.parametrize(
@@ -284,20 +288,3 @@ async def test_async_destroy_with_passes_kind_and_status_filters() -> None:
         ("type", "headless"),
         ("status", "Running"),
     ]
-
-
-def test_sync_destroy_with_kind_and_status_are_keyword_only() -> None:
-    """Sync destroy_with keeps kind and status keyword-only."""
-    with (
-        Session(token=SecretStr("token"), url=_BASE_URL) as session,
-        pytest.raises(TypeError),
-    ):
-        session.destroy_with("prefix", "headless", "Completed")
-
-
-@pytest.mark.asyncio
-async def test_async_destroy_with_kind_and_status_are_keyword_only() -> None:
-    """Async destroy_with keeps kind and status keyword-only."""
-    async with AsyncSession(token=SecretStr("token"), url=_BASE_URL) as session:
-        with pytest.raises(TypeError):
-            await session.destroy_with("prefix", "headless", "Completed")

--- a/tests/test_utils_logging.py
+++ b/tests/test_utils_logging.py
@@ -81,7 +81,6 @@ def test_reconfigure_replaces_handlers(canfar_logger: CanfarLogger) -> None:
         if isinstance(handler, RichHandler)
     )
     assert second is not first
-    assert second in canfar_logger.logger.handlers
     assert first not in canfar_logger.logger.handlers
 
 


### PR DESCRIPTION
## Summary

- lock all nine released Session method signatures exactly, including kinds, defaults, annotations, and return annotations, and require AsyncSession parity
- delete duplicate runtime keyword-only tests now covered by the exact signature contract
- replace indirect info/log case lookup and repeated create-case tables with shared direct immutable cases
- remove a tautological logger-handler assertion

## Review findings addressed

- Wave 5 Specification blocker: incomplete Session signature enforcement
- Wave 5 Simplify findings: duplicate keyword-only checks, indirect case fixture, repeated parameter tables, and tautological handler assertion

## Validation

- Focused tests: 55 passed.
- Deterministic non-slow suite: 858 passed.
- Ruff passed.
- ty passed.
- git diff check passed.

## Churn

4 test files: +120 / -111 lines. No production changes.

Follow-up to #287 and #259.
