### PR TITLE
chore(quality): close Wave 6 review findings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,8 +222,6 @@ max-args = 8
 docstring-code-format = true
 
 # ty configuration (replaces mypy)
-[tool.ty]
-
 [tool.ty.rules]
 unused-ignore-comment = "ignore"
 
@@ -289,7 +287,6 @@ exclude_lines = [
     "if False:",
 ]
 show_missing = true
-skip_covered = false
 precision = 2
 
 [tool.interrogate]

--- a/tests/test_data_dependencies.py
+++ b/tests/test_data_dependencies.py
@@ -2,18 +2,17 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
-_PYPROJECT = Path(__file__).parent.parent / "pyproject.toml"
+from importlib.metadata import distribution
 
 
 def test_tagged_data_dependencies_are_standard_dependencies() -> None:
     """A standard CANFAR install includes both immutable upstream releases."""
-    pyproject = _PYPROJECT.read_text(encoding="utf-8")
+    dist = distribution("canfar")
+    requirements = dist.requires or []
 
-    assert "vosfs @ git+https://github.com/shinybrar/vosfs@v0.8.0" in pyproject
+    assert "vosfs @ git+https://github.com/shinybrar/vosfs@v0.8.0" in requirements
     assert (
         "fsspec-cli @ git+https://github.com/shinybrar/vosfs@fsspec-cli-v0.7.0"
-        "#subdirectory=src/fsspec-cli" in pyproject
+        "#subdirectory=src/fsspec-cli" in requirements
     )
-    assert "[project.optional-dependencies]" not in pyproject
+    assert "data" not in (dist.metadata.get_all("Provides-Extra") or [])


### PR DESCRIPTION
## Summary

- verify the two VOSpace requirements through installed distribution metadata rather than raw pyproject substrings
- preserve the original narrow no-data-extra contract through Provides-Extra metadata
- remove the empty ty parent table and Coverage's default skip-covered setting

## Review findings addressed

- Wave 6 Specification blocker and Standards finding: raw text could false-pass outside project dependencies and banned unrelated future extras
- Wave 6 Simplify findings: empty tool.ty table and repeated Coverage default

## Validation

- Focused metadata test passed.
- Deterministic non-slow suite: 854 passed.
- Ruff and Ruff format passed.
- ty passed.
- pre-commit passed.
- uv lock check passed; lockfile unchanged.
- Wheel and sdist build plus wheel metadata inspection passed.
- git diff check passed.

2 files: +6 / -10 lines.

Follow-up to #290 and #260.
