### PR TITLE
docs(client): audit Python API documentation

### DIFF
--- a/docs/client/advanced-examples.md
+++ b/docs/client/advanced-examples.md
@@ -1,274 +1,122 @@
 # Advanced Examples
 
-Complex use cases and power-user examples for CANFAR Science Platform.
+These patterns combine the public Session API with
+`canfar.helpers.distributed`. They assume that the Session's Container Image
+contains the application code and that the caller has already authenticated.
 
-!!! info
-    `canfar` automatically sets these environment variables in each container:
+## Replicated headless processing
 
-    - `REPLICA_ID`: Current container ID (1, 2, 3, ...)
-    - `REPLICA_COUNT`: Total number of containers
-
-## Massively Parallel Processing
-
-Let's assume you have a large dataset of 1000 FITS files that you want to process in parallel. You have a Python script that can process a single FITS file, and you want to run this script in parallel on 100 different CANFAR sessions, with each container processing a subset of the files. This is a common pattern for distributed computing on CANFAR, and can be achieved with a few lines of code.
-
-```python title="Batch Processing Script"
-from canfar.helpers import distributed
-from glob import glob
-from your.code import analysis
-
-# Find all FITS files to process
-datafiles = glob("/path/to/data/files/*.fits")
-
-# Each replica processes its assigned chunk of files
-# The chunk function automatically handles 1-based REPLICA_ID values
-for datafile in distributed.chunk(datafiles):
-    analysis(datafile)
-```
-
-### Large Scale Parallel Processing
-
-=== ":material-language-python: Flexible Mode (Recommended)"
-
-    ```python
-    from canfar.sessions import AsyncSession
-
-    async with AsyncSession() as session:
-        # Flexible resource allocation - adapts to cluster availability
-        sessions = await session.create(
-            name="fits-processing",
-            image="images.canfar.net/your/analysis-container:latest",
-            kind="headless",
-            cmd="python",
-            args="/path/to/batch_processing.py",
-            replicas=100,
-        )
-        return sessions
-    ```
-
-=== ":material-language-python: Fixed Mode"
-
-    ```python
-    from canfar.sessions import AsyncSession
-
-    async with AsyncSession() as session:
-        # Fixed resource allocation - guaranteed resources
-        sessions = await session.create(
-            name="fits-processing",
-            image="images.canfar.net/your/analysis-container:latest",
-            kind="headless",
-            cores=8,
-            ram=32,
-            cmd="python",
-            args="/path/to/batch_processing.py",
-            replicas=100,
-        )
-        return sessions
-    ```
-
-=== ":simple-gnubash: CLI Flexible Mode"
-
-    ```bash
-    # Flexible resource allocation (default)
-    canfar create -r 100 -n fits-processing headless images.canfar.net/your/analysis-container:latest -- python /path/to/batch_processing.py
-    ```
-
-=== ":simple-gnubash: CLI Fixed Mode"
-
-    ```bash
-    # Fixed resource allocation
-    canfar create -c 8 -m 32 -r 100 -n fits-processing headless images.canfar.net/your/analysis-container:latest -- python /path/to/batch_processing.py
-    ```
-
-## Advanced Resource Allocation Strategies
-
-For complex workflows, choosing the right resource allocation mode can significantly impact performance:
-
-### Mixed Resource Allocation
-
-You can combine flexible and fixed modes within the same workflow:
+`replicas` creates multiple headless Sessions. Each container receives
+`REPLICA_ID` (1-based) and `REPLICA_COUNT`:
 
 ```python
 from canfar.sessions import AsyncSession
 
-async def mixed_workflow():
+
+async def launch_batch() -> list[str]:
     async with AsyncSession() as session:
-        # Use flexible mode for data preprocessing (variable workload)
-        preprocessing_sessions = await session.create(
-            name="preprocess",
-            image="images.canfar.net/your/preprocessing:latest",
+        return await session.create(
+            name="fits-processing",
+            image="images.canfar.net/project/analysis:latest",
             kind="headless",
             cmd="python",
-            args="preprocess.py",
-            replicas=50,
+            args="/app/process_observations.py",
+            replicas=100,
         )
+```
 
-        # Use fixed mode for intensive analysis (predictable workload)
-        analysis_sessions = await session.create(
-            name="analysis",
-            image="images.canfar.net/your/analysis:latest",
+Pass `cores` and `ram` when every replica needs fixed resources:
+
+```python
+from canfar.sessions import AsyncSession
+
+
+async def launch_fixed_batch() -> list[str]:
+    async with AsyncSession() as session:
+        return await session.create(
+            name="fits-processing",
+            image="images.canfar.net/project/analysis:latest",
             kind="headless",
-            cores=16,
-            ram=64,
+            cores=8,
+            ram=32,
             cmd="python",
-            args="analyze.py",
-            replicas=10,
+            args="/app/process_observations.py",
+            replicas=100,
         )
-
-        return preprocessing_sessions + analysis_sessions
 ```
 
-### Resource Allocation Guidelines for Advanced Workflows
+The return value contains only successfully launched Session IDs. Check for an
+empty list before treating the batch as submitted.
 
-| Workflow Type | Recommended Mode | Reasoning |
-|---------------|------------------|-----------|
-| **Data Preprocessing** | Flexible | Variable I/O patterns, benefits from burst capacity |
-| **Machine Learning Training** | Fixed | Consistent performance needed for convergence |
-| **Monte Carlo Simulations** | Flexible | Independent tasks, can handle variable performance |
-| **Image Processing Pipelines** | Fixed | Memory-intensive, predictable resource needs |
-| **Interactive Development** | Flexible | Exploratory work, cost-effective |
-| **Production Batch Jobs** | Fixed | Reliable performance for scheduled workflows |
+## Partition work inside a container
 
-## Distributed Processing Strategies
+Use `chunk()` for contiguous ranges and `stripe()` for round-robin assignment:
 
-The `canfar.helpers.distributed` module provides two main strategies for distributing data across replicas:
-
-### Chunking (`distributed.chunk`)
-
-The `chunk` function divides your data into contiguous blocks, with each replica processing a consecutive chunk. The function uses 1-based replica IDs (matching `canfar` `REPLICA_ID` environment variable):
-
-```python title="Chunking Example"
-from canfar.helpers import distributed
-from glob import glob
-
-# With 1000 files and 100 replicas:
-# - Replica 1 processes files 0-9
-# - Replica 2 processes files 10-19  
-# - Replica 3 processes files 20-29
-# - And so on...
-
-datafiles = glob("/path/to/data/*.fits")
-for datafile in distributed.chunk(datafiles):
-    process_datafile(datafile)
-```
-
-### Striping (`distributed.stripe`)
-
-The `stripe` function distributes data in a round-robin fashion, which is useful when file sizes vary significantly:
-
-```python title="Striping Example"
-from canfar.helpers import distributed
-from glob import glob
-
-# With 1000 files and 100 replicas:
-# - Replica 1 processes files 0, 100, 200, 300, ...
-# - Replica 2 processes files 1, 101, 201, 301, ...
-# - Replica 3 processes files 2, 102, 202, 302, ...
-# - And so on...
-
-datafiles = glob("/path/to/data/*.fits")
-for datafile in distributed.stripe(datafiles):
-    process_datafile(datafile)
-```
-
-### When to Use Each Strategy
-
-- **Use `chunk`** when files are similar in size and you want each replica to process a contiguous block of data
-- **Use `stripe`** when file sizes vary significantly, as it distributes the workload more evenly across replicas
-
-## Real-World Example: Processing Astronomical Data
-
-```python
-import os
-import json
-from pathlib import Path
-from canfar.helpers.distributed import chunk
-
-def process_observations():
-    """Process FITS files across multiple containers."""
-
-    # Get all observation files
-    fits_files = list(Path("/data/observations").glob("*.fits"))
-    my_files = list(chunk(fits_files))
-
-    if not my_files:
-        print("No files assigned to this container")
-        return
-
-    replica_id = os.environ.get('REPLICA_ID')
-    print(f"Container {replica_id} processing {len(my_files)} files")
-
-    # Process each file
-    results = []
-    for fits_file in my_files:
-        # Your analysis code here
-        result = {"file": fits_file.name, "stars_detected": analyze_fits(fits_file)}
-        results.append(result)
-
-    # Save results with container ID
-    output_file = f"/results/container_{replica_id}_results.json"
-    with open(output_file, 'w') as f:
-        json.dump(results, f, indent=2)
-
-    print(f"Saved {len(results)} results to {output_file}")
-
-def analyze_fits(fits_path):
-    """Your FITS analysis logic here."""
-    return 42  # Placeholder
-```
-
-## Best Practices
-
-**Choose the right function:**
-- Use `chunk()` when you need contiguous data blocks
-- Use `stripe()` for round-robin distribution
-
-**Handle empty containers:**
-```python
-my_data = list(chunk(data))
-if not my_data:
-    print("No data for this container")
-    return
-```
-
-**Save results with container ID:**
-```python
-import os
-replica_id = os.environ.get('REPLICA_ID')
-output_file = f"/results/container_{replica_id}_results.json"
-```
-
-**Combine results from all containers:**
 ```python
 from pathlib import Path
-import json
 
-def combine_results():
-    """Merge results from all containers."""
-    all_results = []
-    for result_file in Path("/results").glob("container_*_results.json"):
-        with open(result_file) as f:
-            all_results.extend(json.load(f))
+from canfar.helpers import distributed
 
-    with open("/results/final_results.json", 'w') as f:
-        json.dump(all_results, f, indent=2)
+files = list(Path("/data/observations").glob("*.fits"))
+
+for path in distributed.chunk(files):
+    print(path)
+
+for path in distributed.stripe(files):
+    print(path)
 ```
 
-## Common Issues
+When `replica` and `total` are omitted, both helpers read `REPLICA_ID` and
+`REPLICA_COUNT` at call time. They default to one replica when those variables
+are absent. Explicit arguments override the environment:
 
-**Some containers get no data**
-This happens when you have more containers than data items. Handle it gracefully:
 ```python
-my_data = list(chunk(data))
-if not my_data:
-    print("No data assigned to this container")
-    return
+from canfar.helpers import distributed
+
+items = list(range(10))
+assert list(distributed.chunk(items, replica=1, total=4)) == [0, 1]
+assert list(distributed.chunk(items, replica=4, total=4)) == [6, 7, 8, 9]
+assert list(distributed.stripe(items, replica=2, total=4)) == [1, 5, 9]
 ```
 
-**Debugging distribution**
+`chunk()` raises `ValueError` for invalid replica settings. `stripe()` keeps its
+legacy empty result for an out-of-range replica, but raises `ValueError` when
+`total` is non-positive. See the [Helpers API](helpers.md) for the exact
+contract.
+
+## Process a VOSpace Service in each replica
+
+Use the explicit Storage Identifier API inside a Session. The same identifier
+and path remain separate Python arguments; no dynamic fsspec scheme is needed:
+
 ```python
-import os
-replica_id = os.environ.get('REPLICA_ID')
-replica_count = os.environ.get('REPLICA_COUNT')
-print(f"Container {replica_id} of {replica_count} processing {len(my_data)} items")
+from canfar.storage import filesystem
+
+from canfar.helpers import distributed
+
+paths = ["/project/observations/a.fits", "/project/observations/b.fits"]
+
+with filesystem("vault") as vault:
+    for path in distributed.chunk(paths):
+        raw = vault.cat_file(path)
+        print(path, len(raw))
+```
+
+For staged or memory-mapped access, use an explicit fsspec cache or
+`get_file()` destination; see [Data Access](data.md).
+
+## Cleanup a batch
+
+Use the keyword-only filters on `destroy_with()` after the literal prefix:
+
+```python
+from canfar.sessions import Session
+
+with Session() as session:
+    result = session.destroy_with(
+        "fits-processing-",
+        kind="headless",
+        status="Completed",
+    )
+    print(result)
 ```

--- a/docs/client/async_session.md
+++ b/docs/client/async_session.md
@@ -1,28 +1,85 @@
 # Asynchronous Sessions
 
-!!! info "Overview"
-    `canfar` supports asynchronous sessions using the `AsyncSession` class while maintaining 1-to-1 compatibility with the `Session` class.
+`AsyncSession` is the native asynchronous counterpart to `Session`. It uses a
+native `httpx.AsyncClient`; it is not a synchronous client wrapped in an event
+loop. Use it inside an existing async application and close it with `async with`.
 
-## Creating sessions
+## Return shapes and parity
 
-`AsyncSession.create` matches `Session.create`: it returns a `list` of session
-IDs, omits failed launches without raising, and returns an empty list if every
-attempt fails. Check the list after awaiting the call. HTTP and timeout details
-are logged when the application configures logging. Call
-`canfar.configure_logging()` at the Python application entry point; it honors
-`CANFAR_LOGLEVEL`. In the CLI, use a root control such as
-`canfar --log-level debug create ...`. See
-[Logging](../cli/logging.md).
+The async methods preserve the synchronous result contracts:
+
+| Method | Result |
+| --- | --- |
+| `await fetch(kind=None, status=None, view=None)` | `list[dict[str, str]]` |
+| `await create(...)` | `list[str]` containing the IDs that launched successfully |
+| `await info(ids)` | `list[dict[str, Any]]` |
+| `await logs(ids, verbose=False)` | `dict[str, str]`, or `None` when `verbose=True` |
+| `await events(ids, verbose=False)` | `list[dict[str, str]]`, or `None` when `verbose=True` |
+| `await destroy(ids)` / `await destroy_with(...)` | `dict[str, bool]` |
+| `await connect(ids)` | `None`; opens ready Session URLs |
+
+`create()` omits failed launches and returns `[]` when every launch fails.
+Invalid request values raise before the HTTP request. Verbose logs and events
+are sent to the `canfar.sessions` logger and return `None`.
+
+`fetch(view="all")` requests the server's all-Sessions view when authorized,
+and `stats()` returns aggregate Science Platform Server resource statistics.
+
+## Async workflow
+
+```python
+from canfar.sessions import AsyncSession
+
+
+async def main() -> None:
+    async with AsyncSession() as session:
+        ids = await session.create(
+            name="async-analysis",
+            image="images.canfar.net/skaha/astroml:latest",
+            kind="notebook",
+        )
+        if ids:
+            await session.connect(ids)
+            print(await session.fetch(kind="notebook", status="Running"))
+            print(await session.info(ids))
+            print(await session.logs(ids))
+            print(await session.events(ids))
+            print(await session.destroy(ids))
+```
+
+For a headless Session, add `cmd`, `args`, and `env`. `cores` and `ram` request
+fixed resources; omitting them uses the Science Platform Server's flexible
+allocation policy.
+
+## Select Sessions for cleanup
+
+`destroy_with` is keyword-only after `prefix`:
+
+```python
+async with AsyncSession() as session:
+    result = await session.destroy_with(
+        "batch-",
+        kind="headless",
+        status="Completed",
+    )
+```
+
+Its signature is `destroy_with(prefix, *, kind="headless", status="Completed")`.
+Literal prefixes are anchored at the beginning; prefixes containing regular
+expression metacharacters are treated as regular expressions.
 
 ::: canfar.sessions.AsyncSession
     handler: python
     selection:
       members:
         - fetch
+        - stats
         - create
         - info
         - logs
+        - events
         - destroy
+        - destroy_with
         - connect
     rendering:
       members_order: source

--- a/docs/client/client.md
+++ b/docs/client/client.md
@@ -1,43 +1,11 @@
 # HTTPClient
 
-The `canfar.client` module provides a comprehensive HTTP client for interacting with CANFAR Science Platform services. Built on the powerful [`httpx`](https://www.python-httpx.org/) library, it offers both synchronous and asynchronous interfaces with advanced authentication capabilities.
+`canfar.client.HTTPClient` is the lower-level transport used by the Session,
+Image, Context, and Overview clients. It composes native synchronous and
+asynchronous `httpx` clients and is useful when an application needs a CANFAR
+request outside those higher-level modules.
 
-
-
-## Features
-
-!!! tip "Key Capabilities"
-    - **Multiple Authentication Methods**: X.509 certificates, OIDC tokens, and bearer tokens
-    - **Automatic SSL Configuration**: Seamless certificate-based authentication
-    - **Async/Sync Support**: Both synchronous and asynchronous HTTP clients
-    - **Connection Pooling**: Optimized for concurrent requests
-    - **Application Logging**: Explicit, secret-safe runtime configuration
-    - **Context Managers**: Proper resource management
-
-*This is a low-level client that is used by all other API clients in CANFAR. It is not intended to be used directly by users, but rather as a building block for other clients and contributors.*
-
-## Authentication Modes
-
-The client supports multiple authentication modes that can be configured through the authentication system:
-
-## Logging
-
-```python
-from canfar import configure_logging
-from canfar.client import HTTPClient
-
-# Configure the application once, then construct clients normally.
-configure_logging(loglevel="debug")
-client = HTTPClient()
-```
-
-Logging is an application concern rather than an `HTTPClient` constructor
-setting. See [Logging](../cli/logging.md) for environment precedence, stream
-separation, and the optional `--log-file` JSON Lines sink.
-
-## Configuration
-
-The client composes a `Configuration` object through its `config` field:
+## Construct a client
 
 ```python
 from canfar.client import HTTPClient
@@ -45,30 +13,96 @@ from canfar.models.config import Configuration
 
 client = HTTPClient(
     config=Configuration(),
-    timeout=60,           # Request timeout in seconds
-    concurrency=64,       # Max concurrent connections
+    timeout=60,
+    concurrency=64,
 )
 ```
 
-Runtime `token` or `certificate` arguments take precedence over saved
-Authentication Records, including authentication hook selection. Without
-runtime credentials, `authentication_idp` selects an Authentication Record for
-that client; otherwise the active Authentication Record and Server Selection
-from `Configuration` are used.
+The main settings are:
 
-## Error Handling
+- `url`: an explicit Science Platform Server URL.
+- `config`: the persisted `Configuration` to resolve by default.
+- `authentication_idp`: a transient Identity Provider selector for this client.
+- `token`: a runtime bearer token.
+- `certificate`: a runtime X.509 certificate path.
+- `timeout`: request timeout in seconds (1–300).
+- `concurrency`: maximum async connection count (1–128).
 
-The client includes built-in error handling for HTTP responses:
+When no explicit `url` is supplied, the active Server Selection in
+`Configuration` supplies the Science Platform Server. Without a runtime
+credential, `authentication_idp` selects a saved Authentication Record for this
+client; otherwise the active Authentication Record is used.
+
+## Credential precedence and lifecycle
+
+Runtime credentials take precedence over saved Authentication Records. A
+non-empty runtime `token` wins over a saved X.509 or OIDC record; a runtime
+`certificate` likewise wins. An empty runtime token is treated as absent and
+falls back to saved state. Runtime credentials are not persisted.
+
+Without runtime credentials, the client resolves the selected saved record when
+its sync or async HTTPX client is first created. An expired OIDC record is
+refreshed through the saved Authentication Record and the refreshed token is
+persisted. If the record cannot refresh or an X.509 certificate is invalid,
+client construction/request setup raises the established authentication error
+instead of silently sending an unauthenticated request.
+
+Use the native context manager that matches the transport:
+
+```python
+from canfar.client import HTTPClient
+
+with HTTPClient(token="runtime-token", url="https://example.test/skaha/v1") as client:
+    response = client.client.get("context")
+
+
+async def request() -> None:
+    async with HTTPClient(
+        token="runtime-token",
+        url="https://example.test/skaha/v1",
+    ) as client:
+        response = await client.asynclient.get("context")
+```
+
+`client` is the native `httpx.Client`; `asynclient` is the native
+`httpx.AsyncClient`. They are created lazily and closed by their matching
+context manager. Do not use the async client from synchronous code or expect a
+sync client to run through an event loop.
+
+## Errors and logging
+
+HTTP response hooks raise `httpx.HTTPStatusError` by default for unsuccessful
+responses. Catch it at the application boundary when a request can fail:
 
 ```python
 from httpx import HTTPStatusError
 
-try:
-    response = client.client.get("/invalid-endpoint")
-    response.raise_for_status()
-except HTTPStatusError as e:
-    print(f"HTTP error: {e.response.status_code}")
+from canfar.client import HTTPClient
+
+with HTTPClient(token="runtime-token", url="https://example.test/skaha/v1") as client:
+    try:
+        response = client.client.get("invalid-endpoint")
+    except HTTPStatusError as exc:
+        print(exc.response.status_code)
 ```
+
+Authentication and configuration failures use CANFAR's authentication/error
+types. Do not log tokens, certificates, or raw credential records. Configure
+the application logger explicitly when diagnostics are needed:
+
+```python
+from canfar import configure_logging
+
+configure_logging("debug")
+```
+
+## Configuration editing
+
+`HTTPClient` consumes the persisted `Configuration`; it does not own edits or
+alternate configuration services. Use `config.editor.get()`, `set()`, and
+`save()` to make validated, atomic changes while preserving the stable
+`version`/`active`/`authentication`/`servers`/`registry`/`console` shape. See
+[Install and set up](get-started.md#edit-and-save-configuration).
 
 ## API Reference
 
@@ -78,6 +112,9 @@ except HTTPStatusError as e:
       members:
         - client
         - asynclient
+        - uses_runtime_credentials
+        - authentication_record
+        - build
       show_root_heading: true
       show_source: false
       heading_level: 3

--- a/docs/client/context.md
+++ b/docs/client/context.md
@@ -1,37 +1,21 @@
 # Context API
 
-!!! info "Overview"
-
-    The Context API allows the user to get information about the resources available to be requested for a session on the CANFAR Science Platform. This information can be used to configure the session to request the appropriate resources for your session.
-
-```python title="Get context information"
-from canfar.context import Context
-
-context = Context()
-context.resources()
-```
+`Context` reads the resource information advertised by a Science Platform
+Server. The returned mapping can guide `Session.create()` resource requests.
 
 ```python
-{
-    "cores": {
-        "default": 1,
-        "defaultRequest": 1,
-        "defaultLimit": 16,
-        "defaultHeadless": 1,
-        "options": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-    },
-    "memoryGB": {
-        "default": 2,
-        "defaultRequest": 4,
-        "defaultLimit": 192,
-        "defaultHeadless": 4,
-        "options": [1, 2, ..., 192],
-    },
-    "gpus": {
-        "options": [1, ..., 8],
-    },
-}
+from canfar.context import Context
+
+with Context() as context:
+    resources = context.resources()
+    print(resources["cores"])
+    print(resources.get("memoryGB"))
+    print(resources.get("gpus"))
 ```
+
+The response is a `dict[str, Any]` whose keys and values are supplied by the
+server; common keys include `cores`, `memoryGB`, and `gpus`. Resource limits are
+server metadata, not a second Configuration model.
 
 ::: canfar.context.Context
     handler: python
@@ -42,4 +26,4 @@ context.resources()
       members_order: source
       show_root_heading: true
       show_source: true
-      heading_level: 3
+      heading_level: 2

--- a/docs/client/data.md
+++ b/docs/client/data.md
@@ -1,232 +1,153 @@
 # Data Access
 
-Read and write CANFAR VOSpace Services from Python. `canfar` resolves the
-endpoints and credentials; [`vosfs`](https://github.com/shinybrar/vosfs) is the
-[fsspec](https://filesystem-spec.readthedocs.io/) filesystem that talks to them,
-so every tool that already speaks fsspec — astropy, pandas, dask, zarr — works
-without an adapter.
+The Python data API gives explicit access to configured VOSpace Services through
+standard [fsspec](https://filesystem-spec.readthedocs.io/) filesystems. A
+**Storage Identifier** names one VOSpace Service; a path is the path inside that
+service. `canfar` does not register Storage Identifiers as fsspec protocols,
+module attributes, or dynamic schemes.
 
-Storage lookup is explicit. `canfar` does not register configured names as
-fsspec protocols and does not turn them into module attributes. This keeps
-fsspec's built-in `local` protocol untouched and makes filesystem ownership and
-cleanup visible to the caller.
+## Find and open a Storage Identifier
 
-## Open a VOSpace Service
-
-Run `canfar login` first; the credential resolution is the same one the CLI
-uses. To see which Storage Identifiers are available:
+Authenticate first, for example with `canfar login cadc`. Then pass the
+Storage Identifier to `identifiers()` or `filesystem()`:
 
 ```python
-from canfar.storage import identifiers
+from canfar.storage import filesystem, identifiers
 
-identifiers()      # ['arc', 'vault', 'local']
+available = identifiers()          # e.g. ["arc", "vault", "local"]
+
+with filesystem("vault") as vault:
+    path = "/ALMA/test-data/cutouts/test-4d-cube-cutout.fits"
+    print(vault.info(path)["size"])
+    raw = vault.cat_file(path)
+
+local = filesystem("local")        # the machine running this code
 ```
 
-Build one explicitly — including the reserved local filesystem, overriding a
-credential, or naming an identifier held in a variable — with `filesystem`:
+`local` is always available and does not require a credential. Every other
+identifier must be present in the saved Configuration. The returned object is a
+normal synchronous fsspec filesystem; use its standard methods rather than a
+CANFAR-specific wrapper.
+
+`filesystem()` accepts runtime credentials when a caller must override saved
+state. A non-empty `token` takes precedence over a saved Authentication Record;
+`certificate` supplies a runtime X.509 certificate. Runtime credentials are
+used only for that filesystem and do not rewrite the saved Configuration.
 
 ```python
 from canfar.storage import filesystem
 
-vault = filesystem("vault")
-staging = filesystem("vault", token="...")        # runtime bearer token
-archive = filesystem("arc", certificate="/path/to/proxy.pem")
-local = filesystem("local")
+vault = filesystem("vault", token="runtime-bearer-token")
+archive = filesystem("arc", certificate="/path/to/cadcproxy.pem")
 ```
 
-`filesystem(identifier)` returns the ordinary upstream fsspec object. Close a
-remote filesystem when the operation is complete; `local` needs no credential.
+An unknown Storage Identifier raises `KeyError`. If a saved credential is
+missing, expired, invalid, or cannot be materialized, `filesystem()` raises
+`AuthContextError` with a login hint; credential contents are not included in
+the error.
 
-## Filesystem operations
+## Standard fsspec operations
 
-The object is a standard fsspec filesystem, so the usual verbs apply:
+Storage operations use the ordinary fsspec vocabulary:
 
 ```python
-cutouts = "/ALMA/test-data/cutouts"
-target = f"{cutouts}/test-4d-cube-cutout.fits"
+from canfar.storage import filesystem
 
-vault.ls(cutouts, detail=False)      # ['/ALMA/.../test-4d-cube-cutout.fits', ...]
-vault.info(target)["size"]           # 169920
-vault.exists(target)                 # True
-vault.isdir(cutouts)                 # True
-vault.glob(f"{cutouts}/*cutout.fits")
-vault.find(cutouts)                  # recursive listing
-vault.du(cutouts)                    # 3712320
+with filesystem("vault") as vault:
+    directory = "/ALMA/test-data/cutouts"
+    target = f"{directory}/test-4d-cube-cutout.fits"
+
+    names = vault.ls(directory, detail=False)
+    metadata = vault.info(target)
+    assert vault.exists(target)
+    matches = vault.glob(f"{directory}/*cutout.fits")
+    all_names = vault.find(directory)
+
+    whole = vault.cat_file(target)
+    header = vault.cat_file(target, 0, 2880)
+    ranges = vault.cat_ranges([target, target], [0, 100], [80, 180])
+
+    with vault.open(target, "rb") as handle:
+        first_bytes = handle.read(80)
 ```
 
-Reads come in whole-object, ranged, and file-like forms:
+`cat_file(path, start, end)` returns the requested slice. Whether the VOSpace
+Service transfers only that slice or downloads the object and slices it locally
+depends on the service and its deployed data endpoint. `open()` provides a
+seekable file-like object and may stage the complete object locally. Do not
+assume that a partial read reduces network traffic.
+
+VOSpace writes use the corresponding fsspec methods (`put_file`, `pipe_file`,
+`mkdir`, and `rm`) when the authenticated account has permission:
 
 ```python
-whole = vault.cat_file(target)                       # 169920 bytes
-header = vault.cat_file(target, 0, 2880)             # first 2880 bytes only
-first, second = vault.cat_ranges([target, target], [0, 100], [80, 180])
-
-with vault.open(target, "rb") as handle:
-    handle.read(80)
-
-vault.head(target, 100)
-vault.tail(target, 100)
+with filesystem("vault") as vault:
+    vault.pipe_file("/tmp/example.txt", b"hello CANFAR\n")
+    vault.rm("/tmp/example.txt")
 ```
 
-Writes use `put_file`, `pipe_file`, `mkdir`, and `rm`. Directory listings are
-cached in memory for the lifetime of the filesystem object, so a long-lived
-object can serve a stale listing; build a fresh filesystem when you need to
-observe another writer's changes.
+Directory listings use an in-memory fsspec listing cache for the lifetime of
+the filesystem. Create a new filesystem when another writer's changes must be
+observed.
 
-## Get a local path
+## Materialize a local file
 
-Some libraries want a real path rather than a file object — anything that
-memory-maps, or a C extension that opens by name. Materialise the file:
+Libraries that require a pathname can use the standard fsspec `get_file()`
+operation. The destination is explicit and its cleanup is the caller's
+responsibility:
 
 ```python
-vault.get_file(target, "/scratch/cutout.fits")
+from canfar.storage import filesystem
+
+with filesystem("vault") as vault:
+    vault.get_file(
+        "/ALMA/test-data/cutouts/test-4d-cube-cutout.fits",
+        "/scratch/cutout.fits",
+    )
 ```
 
-`get_file` is the standard fsspec verb; `put_file` is its counterpart for
-uploads.
-
-## Cache
-
-`filesystem()` never enables a persistent content cache. Directory-listing
-caching is an in-memory fsspec option on the returned object; it is not a byte
-cache. If you choose to cache object contents, construct one fsspec cache
-wrapper explicitly and own its directory, freshness policy, and cleanup. The
-presence of `/scratch` or any `skaha_*` environment variable does not enable
-caching.
-
-On a CANFAR Session `/scratch` is fast local NVMe, is not backed up, and is
-cleared when the Session ends. It is a useful explicit location for ephemeral
-staging or caching, but it is never selected implicitly.
-
-### Whole files
-
-```python
-from fsspec.implementations.cached import WholeFileCacheFileSystem
-
-cached = WholeFileCacheFileSystem(fs=vault, cache_storage="/scratch/vault-cache")
-
-cached.cat_file(target)   # cold: fetched over the network
-cached.cat_file(target)   # warm: served from /scratch
-```
-
-The first read fetches the complete object; subsequent reads can come from the
-explicit cache directory.
-
-Use `SimpleCacheFileSystem` when you do not need the expiry and staleness
-metadata `WholeFileCacheFileSystem` keeps. Passing `cache_storage` a list of
-directories tries each in order and treats only the last as writable, so a
-shared read-only cache can back your own.
-
-### Byte ranges
-
-For an explicit partial read, `vosfs` sends an HTTP `Range` request and uses a
-validated `206` response. If the byte endpoint returns the whole object with
-`200`, `vosfs` falls back to downloading that object and slicing it locally.
-Range support is therefore deployment-specific; do not infer it from a
-Storage Identifier's spelling or assume that a partial call saves bytes.
-
-```python
-header = vault.cat_file(target, 0, 2880)
-```
-
-The result is correct in either case. `open()` is a separate path: `vosfs`
-stages the complete object into a seekable local file before returning the
-file-like object. Use an explicit whole-file cache or `get_file()` when a
-scientific tool will read the same object more than once.
-
-### What does not work
-
-`blockcache` (`CachingFileSystem`) cannot wrap a VOSpace Service. Range is
-negotiated for explicit byte reads, not through the staged file-object path:
-
-```text
-AttributeError: 'StagedReadFile' object has no attribute 'blocksize'
-```
-
-Use one explicit cache layer, on a local directory you own; do not silently
-stack caches or select one from environment variables.
-
-## Scientific tools
-
-### astropy
-
-Read a header through the explicit byte-read path. Depending on the negotiated
-backend, this may transfer only the requested slice or the whole object:
+For example, a local path can then be opened by a memory-mapping library:
 
 ```python
 from astropy.io import fits
 
-raw = vault.cat_file(target, 0, 2880)
-header = fits.Header.fromstring(raw.decode("latin-1"))
-header["NAXIS"], header["OBJECT"]    # 4, 'hers1'
-```
-
-Or hand the file object straight to astropy:
-
-```python
-with vault.open(target, "rb") as handle, fits.open(handle) as hdul:
-    hdul[0].data.shape      # (1, 96, 26, 16)
-```
-
-To memory-map, materialise the file first — `memmap=True` needs a real path:
-
-```python
-vault.get_file(target, "/scratch/cutout.fits")
-
 with fits.open("/scratch/cutout.fits", memmap=True) as hdul:
-    data = hdul[0].data     # paged in on demand, not loaded up front
+    data = hdul[0].data
 ```
 
-### numpy
+## Content caching
+
+`canfar.storage.filesystem()` does not configure a persistent content cache.
+The `/scratch` volume on a Science Platform Server Session is useful for
+ephemeral staging, but it is not selected implicitly and is cleared with the
+Session. If a workflow needs whole-file caching, compose one standard fsspec
+cache wrapper and choose its directory explicitly:
 
 ```python
-import numpy as np
+from fsspec.implementations.cached import SimpleCacheFileSystem
 
-raw = vault.cat_file(target)
-values = np.frombuffer(raw[2880:2880 + 64], dtype=">f4")
+from canfar.storage import filesystem
+
+remote = filesystem("vault")
+cached = SimpleCacheFileSystem(
+    fs=remote,
+    cache_storage="/scratch/canfar-vault",
+)
+cached.cat_file("/ALMA/test-data/cutouts/test-4d-cube-cutout.fits")
 ```
 
-### pandas
+One whole-file cache layer is the supported simple choice. Do not stack cache
+wrappers, pass a URL as `cache_storage`, or advertise `blockcache`: the staged
+VOSpace file object does not provide the fsspec block-cache interface.
 
-Astronomy tables usually arrive as FITS rather than CSV. Read one remotely and
-convert:
+## Python API boundary
+
+The public Python storage surface is deliberately small:
 
 ```python
-from astropy.table import Table
-
-with vault.open("/APASS/north/091106/n091106.0101.cat", "rb") as handle:
-    table = Table.read(handle, format="fits")
-
-frame = table.to_pandas()    # 2373 rows
-frame.columns[:3]            # ['NUMBER', 'MAG_AUTO', 'MAGERR_AUTO']
+from canfar.storage import filesystem, identifiers
 ```
 
-For delimited text, pass the file object to pandas directly:
-
-```python
-import pandas as pd
-
-with vault.open("/path/to/table.csv", "rb") as handle:
-    frame = pd.read_csv(handle)
-```
-
-### dask
-
-Memory-map a materialised cube and chunk it, so only the blocks a computation
-touches are paged in:
-
-```python
-import dask.array as da
-from astropy.io import fits
-
-with fits.open("/scratch/cutout.fits", memmap=True) as hdul:
-    array = da.from_array(hdul[0].data, chunks=(1, 24, 26, 16))
-    array.mean().compute()
-```
-
-## Async
-
-`filesystem(identifier)` intentionally returns the synchronous fsspec object.
-The embedded `canfar data` command owns its asynchronous source lifecycle. For
-Python scientific tools, use the synchronous object above; it is also the form
-that composes with fsspec's content caches and file-like readers.
+The fsspec-cli source mapping is private. There is no configuration helper,
+automatic `vos://` scheme, or module member for each configured identifier.
+Keep the Storage Identifier and the path as separate arguments.

--- a/docs/client/examples.md
+++ b/docs/client/examples.md
@@ -1,37 +1,25 @@
 # Python Client Examples
 
-These examples show the sync and async Session interfaces.
+The examples assume that an Authentication Record exists:
 
-!!! note "Assumption"
-      ```bash title="Authenticated via CLI"
-      canfar login cadc
-      ```
+```bash
+canfar login cadc
+```
+
+They use the public `Session` and `AsyncSession` classes directly. Both clients
+preserve the same result shapes.
 
 ## Create Sessions
 
 ### Notebook
 
-=== "Flexible Mode (Default)"
+Omit `cores` and `ram` for the server's flexible allocation policy, or pass them
+for a fixed resource request:
 
-    ```python
-    from canfar.sessions import Session
+```python
+from canfar.sessions import Session
 
-    session = Session()
-    ids = session.create(
-        name="my-notebook",
-        image="images.canfar.net/skaha/astroml:latest",
-        kind="notebook",
-    )
-    print(ids)  # ["d1tsqexh"]
-    session.connect(ids)
-    ```
-
-=== "Fixed Mode"
-
-    ```python
-    from canfar.sessions import Session
-
-    session = Session()
+with Session() as session:
     ids = session.create(
         name="my-notebook",
         image="images.canfar.net/skaha/astroml:latest",
@@ -39,317 +27,149 @@ These examples show the sync and async Session interfaces.
         cores=2,
         ram=4,
     )
-    print(ids)  # ["d1tsqexh"]
-    session.connect(ids)
-    ```
-
-=== "`async`"
-
-    ```python
-    from canfar.sessions import AsyncSession
-
-    session = AsyncSession()
-    ids = await session.create(
-        name="my-notebook",
-        image="images.canfar.net/skaha/astroml:latest",
-        kind="notebook",
-    )
-    print(ids)  # ["d1tsqexh"]
-    await session.connect(ids)
-    ```
+    print(ids)  # list[str]
+    if ids:
+        session.connect(ids)
+```
 
 ### Headless
 
-- Headless Sessions are containers that execute a command and exit when complete without user interaction.
-- They are useful for batch processing and distributed computing.
+Headless Sessions run a command and exit. `cmd`, `args`, and `env` are valid
+for headless Sessions:
 
+```python
+from canfar.sessions import Session
 
-=== "Replicated Headless Sessions"
-
-    ```python
-    from canfar.sessions import Session
-
-    session = Session()
+with Session() as session:
     ids = session.create(
         name="my-headless",
-        image="images.canfar.net/skaha/astroml:latest",
+        image="images.canfar.net/skaha/terminal:latest",
         kind="headless",
-        cmd="echo",
-        args="Hello, World!",
+        cmd="python",
+        args="/arc/projects/demo/run.py",
+        env={"DATASET": "example"},
+        replicas=3,
     )
-    print(ids)  # ["d1tsqexh"]
-    ```
+    print(ids)  # successful Session IDs only
+```
 
-=== "`async`"
+If one replica fails, `create()` logs the failure and omits that ID. If all
+replicas fail, it returns `[]`.
 
-    ```python
-    from canfar.sessions import AsyncSession
+## Discover and filter Sessions
 
-    session = AsyncSession()
-    ids = await session.create(
-        name="my-headless",
-        image="images.canfar.net/skaha/astroml:latest",
-        kind="headless",
-        cmd="echo",
-        args="Hello, World!",
-    )
-    print(ids)  # ["d1tsqexh"]
-    ```
+`fetch()` returns the server's list of dictionaries as
+`list[dict[str, str]]`:
+
+```python
+from canfar.sessions import Session
+
+with Session() as session:
+    all_sessions = session.fetch()
+    running = session.fetch(kind="notebook", status="Running")
+    print(len(all_sessions), running)
+```
+
+Supported kind values are `desktop`, `notebook`, `carta`, `headless`, `firefly`,
+`desktop-app`, and `contributed`. Status filters include `Pending`, `Running`,
+`Terminating`, `Succeeded`, `Completed`, `Error`, and `Failed`.
+
+## Inspect, events, and logs
+
+```python
+from canfar.sessions import Session
+
+with Session() as session:
+    ids = ["session-id"]
+    details = session.info(ids)       # list[dict[str, Any]]
+    events = session.events(ids)      # list[dict[str, str]]
+    logs = session.logs(ids)          # dict[str, str]
+    print(details, events, logs)
+```
+
+Passing `verbose=True` to `events()` or `logs()` sends the result through the
+`canfar.sessions` logger and returns `None`. Configure logging with
+`canfar.configure_logging()` when an application needs to display it.
+
+## Async workflow
+
+`AsyncSession` uses the native asynchronous transport. Keep the work inside an
+async function and close the client with `async with`:
+
+```python
+from canfar.sessions import AsyncSession
 
 
-!!! example "Replica Environment Variables"
-    All containers receive the following environment variables:
-    - `REPLICA_COUNT` — common total number of replicas
-    - `REPLICA_ID` — 1-based index of the replica (1..N)
-
-    Use these to partition work deterministically. See [Helpers API Reference](helpers.md) for `chunk` and `stripe`.
-
-!!! warning "Private Container Registry Access"
-    Use a private Harbor image by providing registry credentials via configuration.
-    ```python
-    import asyncio
-    from canfar.sessions import AsyncSession
-    from canfar.models.registry import ContainerRegistry
-    from canfar.models.config import Configuration
-
-    async def main():
-        cfg = Configuration(registry=ContainerRegistry(username="username", secret="CLI_SECRET"))
-        session = AsyncSession(config=cfg)
+async def main() -> None:
+    async with AsyncSession() as session:
         ids = await session.create(
-            name="private-job",
-            image="images.canfar.net/your/private-image:latest",
+            name="async-headless",
+            image="images.canfar.net/skaha/terminal:latest",
             kind="headless",
             cmd="python",
-            args="/app/run.py",
+            args="/arc/projects/demo/run.py",
         )
-        print(ids)
+        if ids:
+            running = await session.fetch(kind="headless", status="Running")
+            details = await session.info(ids)
+            events = await session.events(ids)
+            logs = await session.logs(ids)
+            print(running, details, events, logs)
+```
 
-    asyncio.run(main())
-    ```
+## Cleanup
 
-## Resource Allocation Modes
+`destroy()` returns a `dict[str, bool]` keyed by requested Session ID. The
+filters after `prefix` in `destroy_with()` are keyword-only:
 
-CANFAR supports two resource allocation modes for your sessions. See the [resource allocation guide](../platform/concepts.md#resource-allocation-modes) for more information.
+```python
+from canfar.sessions import Session
 
-### Examples
-
-=== "Flexible Mode (Default)"
-    ```python
-    from canfar.sessions import Session
-
-    session = Session()
-    # No cores/ram specification - uses flexible allocation
-    ids = session.create(
-        name="flexible-notebook",
-        image="images.canfar.net/skaha/astroml:latest",
-        kind="notebook"
+with Session() as session:
+    print(session.destroy("session-id"))
+    print(
+        session.destroy_with(
+            "my-headless-",
+            kind="headless",
+            status="Completed",
+        )
     )
-    ```
+```
 
-=== "Fixed Mode"
-    ```python
-    from canfar.sessions import Session
+The equivalent async call is:
 
-    session = Session()
-    # Specify exact resources for guaranteed allocation
+```python
+from canfar.sessions import AsyncSession
+
+
+async def cleanup() -> None:
+    async with AsyncSession() as session:
+        result = await session.destroy_with(
+            "my-headless-",
+            kind="headless",
+            status="Completed",
+        )
+        print(result)
+```
+
+## Private Container Registry
+
+Use the Configuration data model when an image is private:
+
+```python
+from canfar.models.config import Configuration
+from canfar.models.registry import ContainerRegistry
+from canfar.sessions import Session
+
+config = Configuration(
+    registry=ContainerRegistry(username="username", secret="CLI_SECRET")
+)
+with Session(config=config) as session:
     ids = session.create(
-        name="fixed-notebook",
-        image="images.canfar.net/skaha/astroml:latest",
-        kind="notebook",
-        cores=4,
-        ram=8
+        name="private-job",
+        image="images.canfar.net/project/private-image:latest",
+        kind="headless",
+        cmd="python",
+        args="/app/run.py",
     )
-    ```
-
-## Discover and Filter Sessions
-
-=== "Fetch All Sessions"
-
-    ```python
-    from canfar.sessions import Session
-
-    session = Session()
-    all_sessions = session.fetch()
-    print(len(all_sessions))
-    ```
-
-=== "`async`"
-
-    ```python
-    from canfar.sessions import AsyncSession
-
-    async with AsyncSession() as session:
-        all_sessions = await session.fetch()
-        print(len(all_sessions))
-    ```
-<br>
-
-=== "Fetch Running Notebooks"
-
-    ```python
-    from canfar.sessions import Session
-
-    session = Session()
-    running = session.fetch(kind="notebook", status="Running")
-    print(running)
-    session.connect([item["id"] for item in running])
-    ```
-
-=== "`async`"
-
-    ```python
-    from canfar.sessions import AsyncSession
-
-    async with AsyncSession() as session:
-        running = await session.fetch(kind="notebook", status="Running")
-        print(running)
-        await session.connect([item["id"] for item in running])
-    ```
-<br>
-
-=== "Fetch Completed Headless Sessions"
-
-    ```python
-    from canfar.sessions import Session
-
-    session = Session()
-    completed = session.fetch(kind="headless", status="Succeeded")
-    print(completed)
-    ```
-
-=== "`async`"
-
-    ```python
-    from canfar.sessions import AsyncSession
-
-    async with AsyncSession() as session:
-        completed = await session.fetch(kind="headless", status="Succeeded")
-        print(completed)
-    ```
-
-!!! success "Kinds & Status"
-
-    You can use any combination of the following kinds and status to filter sessions:
-
-    - Kinds: `desktop`, `notebook`, `carta`, `headless`, `firefly`, `desktop-app`, `contributed`
-    - Statuses: `Pending`, `Running`, `Terminating`, `Succeeded`, `Error`, `Failed`
-
-
-## Inspect Sessions
-
-Detailed information about the session, including resource usage, user IDs, and more.
-
-=== "Detailed Session Information"
-
-    ```python
-    from canfar.sessions import Session
-
-    session = Session()
-    info = session.info(ids)
-    print(info)
-    ```
-
-=== "`async`"
-
-    ```python
-    from canfar.sessions import AsyncSession
-
-    async with AsyncSession() as session:
-        info = await session.info(ids)
-        print(info)
-    ```
-
-## Events
-
-Events describe the steps taken by the Science Platform to launch your session
-
-=== "Session Events"
-
-    ```python
-    from canfar.sessions import Session
-
-    session = Session()
-    events = session.events(ids, verbose=True)
-    print(events)
-    ```
-
-=== "`async`"
-
-    ```python
-    from canfar.sessions import AsyncSession
-
-    async with AsyncSession() as session:
-        events = await session.events(ids, verbose=True)
-        print(events)
-    ```
-
-## Logs
-
-Logs contain the output from your session's containers. 
-
-!!! tip "Log Retention"
-    Logs are retained until your session is deleted. A completed session, i.e., `Succeeded`, `Failed`, or `Error` is kept for 24 hours before being deleted.
-
-=== "Session Logs"
-
-    ```python
-    from canfar.sessions import Session
-
-    session = Session()
-    logs = session.logs(ids, verbose=True)
-    ```
-
-=== "`async`"
-
-    ```python
-    from canfar.sessions import AsyncSession
-
-    async with AsyncSession() as session:
-        logs = await session.logs(ids, verbose=True)
-    ```
-
-## Cleanup Sessions
-
-!!! warning "Permanent Action"
-
-    Deleted sessions cannot be recovered.
-
-=== "Destroy Session(s)"
-
-    ```python
-    from canfar.sessions import Session
-
-    session = Session()
-    result = session.destroy(ids)
-    print(result)  # {"id": True, ...}
-    ```
-
-=== "`async`"
-
-    ```python
-    from canfar.sessions import AsyncSession
-
-    async with AsyncSession() as session:
-        result = await session.destroy(ids)
-        print(result)  # {"id": True, ...}
-    ```
-<br>
-=== "Bulk Destroy"
-
-    ```python
-    from canfar.sessions import Session
-
-    session = Session()
-    result = session.destroy_with(prefix="test-", kind="headless", status="Succeeded")
-    print(result)  # {"id": True, ...}
-    ```
-
-=== "`async`"
-
-    ```python
-    from canfar.sessions import AsyncSession
-
-    async with AsyncSession() as session:
-        result = await session.destroy_with(prefix="test-", kind="headless", status="Succeeded")
-        print(result)  # {"id": True, ...}
-    ```
+```

--- a/docs/client/get-started.md
+++ b/docs/client/get-started.md
@@ -1,13 +1,13 @@
 # Install and Set Up
 
-Use the CANFAR Python package when you want to automate Science Platform work:
+Use the CANFAR Python package to automate work on a Science Platform Server:
 launch Sessions, list Container Images, fetch logs, inspect state, and clean up
-resources from Python.
+resources.
 
 ## Install
 
 ```bash
-pip install canfar --upgrade
+pip install --upgrade canfar
 ```
 
 With `uv`:
@@ -16,106 +16,100 @@ With `uv`:
 uv add canfar
 ```
 
-## Log in
+## Authenticate
 
-Authenticate once from the CLI. Python then uses the active Authentication and
-Server selection.
+The simplest path is to authenticate with the CLI. Python then uses the saved
+Authentication Record and Server Selection:
 
 ```bash
 canfar login cadc
 ```
 
-For SRCNet:
+Use `canfar login srcnet` for an OIDC Identity Provider.
 
-```bash
-canfar login srcnet
-```
-
-Python can also start the SRCNet device flow directly:
+Python also exposes native synchronous and asynchronous login functions:
 
 ```python
 import canfar
 
-canfar.login("srcnet")
+canfar.login("srcnet", force=True)
 ```
 
-This prints the verification URL and device code and waits for approval. In an
-existing async event loop, await the native counterpart instead:
+For OIDC, Python login prints only the device-flow presentation data to the
+terminal, then waits for approval. The output has this shape:
+
+```text
+Verification URL: https://example.com/device
+Verification URL (complete): https://example.com/device?user_code=ABC123
+Device code: ABC123
+```
+
+The device code above is the user-facing code; the private OAuth device token is
+never printed. The Python API does not open a browser, render a QR code, or show
+CLI progress. The CLI login command owns those interactive presentation
+features.
+
+Inside an existing event loop, use `alogin()`; it performs native asynchronous
+OIDC I/O and does not call `asyncio.run()`:
 
 ```python
-async def authenticate():
-    await canfar.alogin("srcnet")
+import canfar
+
+
+async def authenticate() -> None:
+    await canfar.alogin("srcnet", force=True)
 ```
 
-Use the CLI for browser opening, QR output, and progress presentation.
-
-Force a fresh login when credentials expire or you want to replace saved state:
-
-```bash
-canfar login cadc --force
-```
-
-Check what Python will use:
-
-```bash
-canfar auth show
-canfar server ls
-```
+Both functions save the Authentication Record and discovered Science Platform
+Servers but do not change the active Authentication or Server Selection. They
+return `None`; an unknown Identity Provider raises `KeyError`, and credential or
+discovery failures raise `canfar.authentication.AuthenticationError`.
 
 ## Create a Session
 
 ```python
 from canfar.sessions import Session
 
-session = Session()
-ids = session.create(
-    kind="notebook",
-    image="images.canfar.net/skaha/astroml:latest",
-    name="my-analysis",
-)
-print(ids)
-```
-
-Open it in your browser:
-
-```python
-session.connect(ids)
-```
-
-## Use fixed resources
-
-Omit resources for flexible allocation. Pass `cores`, `ram`, and `gpus` when
-you need fixed resources.
-
-```python
-ids = session.create(
-    kind="headless",
-    image="images.canfar.net/skaha/astroml:latest",
-    name="batch-job",
-    cmd="python",
-    args="/arc/projects/demo/run.py",
-    cores=4,
-    ram=16,
-)
-```
-
-## Use async workflows
-
-```python
-from canfar.sessions import AsyncSession
-
-async with AsyncSession() as session:
-    ids = await session.create(
+with Session() as session:
+    ids = session.create(
         kind="notebook",
         image="images.canfar.net/skaha/astroml:latest",
-        name="async-analysis",
+        name="my-analysis",
     )
-    await session.connect(ids)
+    print(ids)
 ```
+
+`create()` returns `list[str]`. A failed replica is omitted and a total HTTP or
+network failure returns `[]`; request validation errors still raise.
+
+## Edit and save Configuration
+
+`Configuration` is the persisted data shape. Its top-level fields are
+`version`, `active`, `authentication`, `servers`, `registry`, and `console`.
+Authentication Records are keyed by Identity Provider, Science Platform Servers
+by Server Name, and `active` stores the selected references. The bound
+`config.editor` is the supported editing surface:
+
+```python
+from canfar.models.config import Configuration
+
+config = Configuration()
+width = config.editor.get("console.width")
+config.editor.set("console.width", 132)
+config.editor.set("servers.canfar.auths", ["x509", "oidc"])
+config.editor.save()
+```
+
+`get()` can return a scalar, mapping, or whole list through a dotted path. List
+indices are not supported. `set()` validates before mutating the bound model;
+invalid updates leave it unchanged. `save()` persists the validated
+Configuration atomically. The editor itself is not part of the serialized
+Configuration shape.
 
 ## Private Container Images
 
-Configure Container Registry credentials when you need private images.
+Pass a `ContainerRegistry` in the Configuration when creating a Session from a
+private image:
 
 ```python
 from canfar.models.config import Configuration
@@ -125,18 +119,18 @@ from canfar.sessions import Session
 config = Configuration(
     registry=ContainerRegistry(username="username", secret="CLI_SECRET")
 )
-session = Session(config=config)
-
-ids = session.create(
-    kind="notebook",
-    image="images.canfar.net/my-project/private-image:latest",
-    name="private-image-test",
-)
+with Session(config=config) as session:
+    ids = session.create(
+        kind="notebook",
+        image="images.canfar.net/my-project/private-image:latest",
+        name="private-image-test",
+    )
 ```
 
 ## Read next
 
 - [Python quickstart](quick-start.md)
 - [Examples](examples.md)
+- [Data access](data.md)
 - [Authentication and Servers](../cli/authentication-contexts.md)
 - [Session API](session.md)

--- a/docs/client/helpers.md
+++ b/docs/client/helpers.md
@@ -40,8 +40,13 @@ for item in distributed.chunk(work):
 ```
 
 ### Validation and errors
-- `replica` must be >= 1 and <= `total`
-- `total` must be > 0
+
+`chunk()` requires `total > 0` and `1 <= replica <= total`, raising
+`ValueError` otherwise. `stripe()` intentionally keeps a looser compatibility
+contract: an out-of-range replica yields no items, while a non-positive `total`
+raises `ValueError`. Both functions use `REPLICA_ID` and `REPLICA_COUNT` when
+their corresponding arguments are omitted, defaulting to one replica when the
+environment is absent.
 
 ## API Reference
 

--- a/docs/client/home.md
+++ b/docs/client/home.md
@@ -1,14 +1,18 @@
 # Python Client
 
-The CANFAR Python client wraps the Science Platform APIs for Sessions,
-Container Images, Authentication-aware HTTP clients, and automation scripts.
+The CANFAR Python client provides authenticated access to Sessions, Container
+Images, VOSpace Services, and Science Platform metadata.
 
 ## Install and authenticate
 
 ```bash
-pip install canfar --upgrade
+pip install --upgrade canfar
 canfar login cadc
 ```
+
+The CLI stores the Authentication Record and Server Selection used by default
+by Python clients. Python OIDC login is also available as `canfar.login()` and
+`canfar.alogin()`; see [Install and set up](get-started.md).
 
 ## Core workflows
 
@@ -17,60 +21,58 @@ canfar login cadc
 -   **Create Sessions**
 
     Launch notebooks, desktops, CARTA, Firefly, contributed apps, or headless
-    jobs.
+    workloads with `Session` or `AsyncSession`.
 
     [:octicons-arrow-right-16: Quickstart](quick-start.md)
 
--   **Automate jobs**
+-   **Read data**
 
-    Use `Session` or `AsyncSession` to create, inspect, log, and destroy
-    Sessions from Python.
+    Address VOSpace Services through explicit Storage Identifiers and standard
+    fsspec methods.
 
-    [:octicons-arrow-right-16: Examples](examples.md)
+    [:octicons-arrow-right-16: Data access](data.md)
 
--   **Choose Servers**
+-   **Inspect platform state**
 
-    Authenticate with an IDP, select a Science Platform Server, and keep scripts
-    noninteractive.
+    Query available resources, Container Images, and Science Platform
+    availability.
 
-    [:octicons-arrow-right-16: Auth and Servers](../cli/authentication-contexts.md)
-
--   **Use references**
-
-    Jump to generated API pages for method signatures and model details.
-
-    [:octicons-arrow-right-16: API reference](session.md)
+    [:octicons-arrow-right-16: Python API reference](session.md)
 
 </div>
 
-## Minimal example
+## Minimal synchronous example
 
 ```python
 from canfar.sessions import Session
 
-session = Session()
-ids = session.create(
-    kind="notebook",
-    image="images.canfar.net/skaha/astroml:latest",
-    name="my-analysis",
-)
-session.connect(ids)
+with Session() as session:
+    ids = session.create(
+        kind="notebook",
+        image="images.canfar.net/skaha/astroml:latest",
+        name="my-analysis",
+    )
+    if ids:
+        session.connect(ids)
 ```
 
-## Async example
+## Minimal asynchronous example
 
 ```python
 from canfar.sessions import AsyncSession
 
-async with AsyncSession() as session:
-    ids = await session.create(
-        kind="headless",
-        image="images.canfar.net/skaha/astroml:latest",
-        name="batch-job",
-        cmd="python",
-        args="/arc/projects/demo/run.py",
-    )
-    await session.events(ids, verbose=True)
+
+async def main() -> None:
+    async with AsyncSession() as session:
+        ids = await session.create(
+            kind="headless",
+            image="images.canfar.net/skaha/astroml:latest",
+            name="batch-job",
+            cmd="python",
+            args="/arc/projects/demo/run.py",
+        )
+        if ids:
+            await session.events(ids)
 ```
 
 ## Main modules
@@ -78,14 +80,17 @@ async with AsyncSession() as session:
 | Module | Use |
 | --- | --- |
 | `canfar.sessions` | Create, fetch, inspect, connect, log, and destroy Sessions. |
-| `canfar.images` | List and inspect available Container Images. |
-| `canfar.authentication` | Noninteractive Authentication helpers. |
-| `canfar.server` | Server discovery, validation, and selection helpers. |
-| `canfar.client` | Lower-level HTTP client composition. |
+| `canfar.images` | List Container Images or fetch parsed image details. |
+| `canfar.storage` | List Storage Identifiers and build explicit fsspec filesystems. |
+| `canfar.context` | Read resource limits advertised by a Science Platform Server. |
+| `canfar.overview` | Check Science Platform availability. |
+| `canfar.authentication` | Login and manage saved Authentication Records. |
+| `canfar.client` | Compose lower-level synchronous or asynchronous HTTP clients. |
 
 ## Read next
 
 - [Install and set up](get-started.md)
 - [Python quickstart](quick-start.md)
 - [Examples](examples.md)
+- [Data access](data.md)
 - [Migration guide](migration.md)

--- a/docs/client/images.md
+++ b/docs/client/images.md
@@ -1,45 +1,38 @@
-# Images API
+# Container Images API
 
-!!! info "Overview"
-    The Image API allows you to get information about the **publicly available** images on the CANFAR Science Platform through the CANFAR Harbor Registry. It can be used to get information about all images, or filter by a specific image kind.
+`Images` lists the Container Images advertised by a CANFAR Science Platform
+Server. It inherits `HTTPClient`, so the same saved or runtime credential
+selection applies.
 
-## Getting Image Information
-
-```python title="Get image information"
-from canfar.images import Images
-
-images = Images()
-images.fetch()
-[
-    "images.canfar.net/canfar/base-3.12:v0.4.1",
-    "images.canfar.net/canucs/test:1.2.5",
-    "images.canfar.net/canucs/canucs:1.2.9",
-    ...,
-]
-```
-
-But most of the time, you are only interested in images of a particular type. For example, if you want to get all the images that are available for `headless` sessions, you can do the following:
-
-```python title="Get headless image information"
-images.fetch(kind="headless")
-```
+## Image identifiers
 
 ```python
-[
-    "images.canfar.net/chimefrb/testing:keep",
-    "images.canfar.net/lsst/lsst_v19_0_0:0.1",
-    "images.canfar.net/skaha/lensfit:22.11",
-    "images.canfar.net/skaha/lensfit:22.10",
-    "images.canfar.net/skaha/lensingsim:22.07",
-    "images.canfar.net/skaha/phosim:5.6.11",
-    "images.canfar.net/skaha/terminal:1.1.2",
-    "images.canfar.net/skaha/terminal:1.1.1",
-    "images.canfar.net/uvickbos/pycharm:0.1",
-    "images.canfar.net/uvickbos/swarp:0.1",
-    "images.canfar.net/uvickbos/isis:2.2",
-    "images.canfar.net/uvickbos/find_moving:0.1",
-]
+from canfar.images import Images
+
+with Images() as images:
+    all_images = images.fetch()                 # list[str]
+    headless = images.fetch(kind="headless")   # list[str]
+    print(headless)
 ```
+
+Each string is an image identifier such as
+`images.canfar.net/skaha/terminal:latest`. The optional `kind` is sent as the
+server's image-type filter.
+
+## Parsed image details
+
+Use `details()` when the digest and supported kinds are needed:
+
+```python
+from canfar.images import Images
+
+with Images() as images:
+    for image in images.details():
+        print(image.id, image.types, image.digest)
+```
+
+`details()` returns `list[canfar.models.containers.Image]`; each model has `id`,
+`types`, and `digest` fields.
 
 ## API Reference
 
@@ -48,6 +41,7 @@ images.fetch(kind="headless")
     selection:
       members:
         - fetch
+        - details
     rendering:
       members_order: source
       show_root_heading: true

--- a/docs/client/migration.md
+++ b/docs/client/migration.md
@@ -1,83 +1,85 @@
-# skaha → canfar
+# `skaha` to `canfar`
 
-In summer 2025, the CANFAR Python client was moved from [shinybrar/skaha](https://github.com/shinybrar/skaha) to [opencadc/canfar](https://github.com/opencadc/canfar) to be officially supported by the Canadian Astronomy Data Centre (CADC). As part of this move, the Python package was renamed from `skaha` to `canfar` to better reflect a unified naming scheme across the CANFAR Science Platform.
+The supported Python package is now `canfar`, published from
+[opencadc/canfar](https://github.com/opencadc/canfar). The service endpoints
+and the historical `X-Skaha-*` request headers remain server-side contracts.
 
-This guide helps you migrate from the `skaha` Python package to `canfar`.
+## Imports
 
-## Summary of changes
+| Old import | Current import |
+| --- | --- |
+| `from skaha.session import Session` | `from canfar.sessions import Session` |
+| `from skaha.session import AsyncSession` | `from canfar.sessions import AsyncSession` |
+| `from skaha.client import SkahaClient` | `from canfar.client import HTTPClient` |
 
-- Package name: `skaha` → `canfar`.
-- **Breaking Changes**
-  - `skaha.session` → `canfar.sessions`.
-  - `headless` session `kind` parameter is no longer required.
-  - `session.info()` query now returns `Completed` instead of `Succeeded`.
-- Configuration path: `~/.skaha/config.yaml` → `~/.canfar/config.yaml`.
-- Logger name: `canfar`. Current releases write no default log file; file output
-  is explicit through root `--log-file` or a `pathlib.Path` passed to
-  `canfar.configure_logging()`. See
-  [Logging](../cli/logging.md).
-- Environment variables: prefix change `SKAHA_…` → `CANFAR_…`.
-- CLI entry point: `canfar` (single entry point).
-- User-Agent header: `python-canfar/{version}`.
-- Protocol contracts: server URLs and custom headers remain unchanged (see notes below).
+`Session` and `AsyncSession` are separate native clients with equivalent public
+operations. `create()` returns `list[str]`; `fetch()` returns
+`list[dict[str, str]]`. The filters after `destroy_with(prefix)` are
+keyword-only in both clients.
 
-## Code Examples
+```python
+from canfar.sessions import Session
 
-- Python client session
-
-    ```python title="Before"
-    from skaha.session import AsyncSession, Session
-    ```
-    
-    ```python title="After"
-    from canfar.sessions import AsyncSession, Session
-    ```
-
-- Client composition
-
-    ```python title="Before"
-    from skaha.client import SkahaClient
-
-    client = SkahaClient(...)
-    ```
-
-    ```python title="After"
-    from canfar.client import HTTPClient
-
-    client = HTTPClient(...)
-    ```
-
-## Environment variables
-
-```bash title="Before"
-SKAHA_TIMEOUT, SKAHA_CONCURRENCY, SKAHA_TOKEN, SKAHA_URL, SKAHA_LOGLEVEL
+with Session() as session:
+    ids = session.create(
+        name="migrated-job",
+        image="images.canfar.net/skaha/terminal:latest",
+    )
 ```
-```bash title="After"
-CANFAR_TIMEOUT, CANFAR_CONCURRENCY, CANFAR_TOKEN, CANFAR_URL, CANFAR_LOGLEVEL
-```
+
+`kind` defaults to `"headless"` when it is omitted. For headless Sessions,
+`cmd`, `args`, and `env` remain available; interactive kinds do not accept
+headless command fields.
 
 ## Configuration
 
-- The default config file moves from `~/.skaha/config.yaml` to `~/.canfar/config.yaml`.
-- Current config files are versioned with `version: 1`.
-- Authentication records and Science Platform Servers are stored separately.
-- Active routing is stored under `active.authentication` and `active.server`.
-- Legacy or unsupported config files are backed up to
-  `<config-path>.<timestamp>.back` before a default config is written.
+The default file moves from `~/.skaha/config.yaml` to
+`~/.canfar/config.yaml`. The current persisted shape separates:
 
-After a legacy reset, run:
+- `authentication`: Authentication Records keyed by Identity Provider;
+- `servers`: Science Platform Servers keyed by Server Name; and
+- `active.authentication` / `active.server`: the active references.
 
-```bash
-canfar login cadc
+Use the bound `Configuration.editor` for validated dotted updates and atomic
+persistence. Do not call the removed Configuration service methods:
+
+```python
+from canfar.models.config import Configuration
+
+config = Configuration()
+config.editor.set("console.width", 132)
+config.editor.save()
 ```
 
-## Documentation and links
+See [Install and set up](get-started.md#edit-and-save-configuration) for the
+full editor contract.
 
-- Repo: `https://github.com/opencadc/canfar`
-- Docs: `https://opencadc.github.io/canfar/`
-- Changelog: `https://opencadc.github.io/canfar/changelog/`
+## Authentication and data
 
-## Notes on protocol stability
+Use `canfar login` or the Python `canfar.login()` / `canfar.alogin()` helpers to
+create Authentication Records. Python OIDC login prints the verification URL
+and user-facing device code to the terminal; the CLI owns browser, QR, and
+progress presentation. See [Install and set up](get-started.md#authenticate).
 
-- Server base path segments under `/skaha` are server-side contracts and remain unchanged (for example, `https://ws-uv.canfar.net/skaha`).
-- Historical header names remain unchanged (for example, `X-Skaha-Authentication-Type`, `X-Skaha-Registry-Auth`).
+For VOSpace access, replace implicit or package-specific storage helpers with
+explicit Storage Identifiers:
+
+```python
+from canfar.storage import filesystem, identifiers
+
+print(identifiers())
+with filesystem("vault") as vault:
+    data = vault.cat_file("/project/observations/example.fits")
+```
+
+Storage Identifiers are not dynamic module members or fsspec schemes. See
+[Data Access](data.md) for standard fsspec operations.
+
+## Runtime configuration and logging
+
+The package-level `canfar.configure_logging()` function configures application
+logging. `HTTPClient` accepts runtime `token` and `certificate` values, which
+take precedence over saved Authentication Records for that client only.
+
+For CLI command names and output, use the [CLI documentation](../cli/cli-help.md)
+rather than the Python migration guide.

--- a/docs/client/overview.md
+++ b/docs/client/overview.md
@@ -1,5 +1,20 @@
-!!! info "Overview API"
-    The Overview API provides information about the availability of the CANFAR Science Platform.
+# Overview API
+
+`Overview` checks whether a Science Platform Server reports itself as
+available. It inherits `HTTPClient` and uses the selected or explicitly supplied
+credentials.
+
+```python
+from canfar.overview import Overview
+
+with Overview() as overview:
+    if overview.availability():
+        print("Science Platform Server is available")
+```
+
+`availability()` returns `True` only when the VOSI availability response says
+the server is available. Empty or malformed availability data returns `False`
+and is logged.
 
 ::: canfar.overview.Overview
     handler: python
@@ -10,4 +25,4 @@
       members_order: source
       show_root_heading: true
       show_source: true
-      heading_level: 1
+      heading_level: 2

--- a/docs/client/quick-start.md
+++ b/docs/client/quick-start.md
@@ -1,60 +1,80 @@
 # Python Quickstart
 
-This guide creates a notebook Session, inspects it, and deletes it from Python.
+This guide creates a notebook Session, checks its state, and deletes it from
+Python.
 
 ## 1. Authenticate
 
 ```bash
-pip install canfar --upgrade
+pip install --upgrade canfar
 canfar login cadc
 ```
 
-Use `canfar login srcnet` for SRCNet.
-
-For direct Python OIDC login, see the detailed [login guidance](get-started.md#log-in).
+Use `canfar login srcnet` for an SRCNet Identity Provider. For direct Python
+OIDC login, see [login and device flow](get-started.md#authenticate).
 
 ## 2. Create a notebook
 
 ```python
 from canfar.sessions import Session
 
-session = Session()
-ids = session.create(
-    kind="notebook",
-    image="images.canfar.net/skaha/astroml:latest",
-    name="quickstart-notebook",
-    cores=2,
-    ram=4,
-)
-print(ids)
+with Session() as session:
+    ids = session.create(
+        kind="notebook",
+        image="images.canfar.net/skaha/astroml:latest",
+        name="quickstart-notebook",
+        cores=2,
+        ram=4,
+    )
+    print(ids)
 ```
 
-`create()` returns a list of Session IDs.
+`create()` returns `list[str]`; it contains only successfully launched Session
+IDs.
 
-## 3. Open the notebook
+## 3. Inspect and connect
 
 ```python
-session.connect(ids)
+with Session() as session:
+    running = session.fetch(kind="notebook", status="Running")
+    print(running)                 # list[dict[str, str]]
+    session.connect([item["id"] for item in running])
 ```
 
-The notebook can take a minute or two to become reachable. Check status:
+`connect()` opens the `connectURL` for Sessions that are ready. It returns
+`None`; a Session that is not running is logged and skipped.
+
+## 4. Read events and logs
 
 ```python
-running = session.fetch(kind="notebook", status="Running")
-print(running)
+with Session() as session:
+    events = session.events("session-id")
+    logs = session.logs("session-id")
+    print(events)
+    print(logs)
 ```
 
-## 4. Inspect events and logs
-
-```python
-session.events(ids, verbose=True)
-session.logs(ids, verbose=True)
-```
+The default return values are `list[dict[str, str]]` for events and
+`dict[str, str]` for logs. With `verbose=True`, both methods log their output
+through `canfar.sessions` and return `None`.
 
 ## 5. Clean up
 
 ```python
-session.destroy(ids)
+with Session() as session:
+    result = session.destroy("session-id")
+    print(result)                 # dict[str, bool]
+```
+
+For bulk cleanup, the filters after `prefix` are keyword-only:
+
+```python
+with Session() as session:
+    result = session.destroy_with(
+        "quickstart-",
+        kind="notebook",
+        status="Completed",
+    )
 ```
 
 ## Async version
@@ -62,25 +82,23 @@ session.destroy(ids)
 ```python
 from canfar.sessions import AsyncSession
 
-async with AsyncSession() as session:
-    ids = await session.create(
-        kind="notebook",
-        image="images.canfar.net/skaha/astroml:latest",
-        name="quickstart-notebook",
-    )
-    await session.connect(ids)
-    await session.events(ids, verbose=True)
-    await session.destroy(ids)
+
+async def main() -> None:
+    async with AsyncSession() as session:
+        ids = await session.create(
+            kind="notebook",
+            image="images.canfar.net/skaha/astroml:latest",
+            name="async-notebook",
+        )
+        if ids:
+            await session.connect(ids)
+            print(await session.fetch(kind="notebook", status="Running"))
+            print(await session.events(ids))
+            print(await session.logs(ids))
+            print(await session.destroy(ids))
+
 ```
 
-## Troubleshooting
-
-| Symptom | Check |
-| --- | --- |
-| Authentication fails | Run `canfar --log-level debug login cadc --force`. |
-| Session does not start | Run `canfar stats`, then try smaller `cores` or `ram`. |
-| Browser URL fails | Wait 60-120 seconds and confirm the Session is `Running`. |
-| Script needs stable output | Use CLI machine output such as `canfar ps -o json`. |
-
-See [Logging](../cli/logging.md) for the CLI and Python
-logging controls.
+For CLI diagnostics, see [Logging](../cli/logging.md). Authentication-dependent
+full integration tests are separate from the deterministic Python examples;
+see [Testing](testing.md).

--- a/docs/client/session.md
+++ b/docs/client/session.md
@@ -1,27 +1,103 @@
 # Session API
 
-!!! info "Overview"
-    The `Session` API is the core of canfar, enabling you to create, manage, and destroy sessions on the CANFAR Science Platform.
+`Session` is the native synchronous Python client for user-owned Sessions on a
+Science Platform Server. It inherits the HTTP and credential behavior of
+`HTTPClient`.
 
-## Creating sessions
+## Return shapes and failure behavior
 
-`Session.create` returns a `list` of session IDs (strings) for each successful launch. If the platform rejects a request or
-the call hits a network or HTTP error, that launch is skipped and logging records the failure. If every launch fails, you get an
-empty list. The method does not raise for those errors, so callers can check `if not ids:` (or compare the length to `replicas`)
-after the call. For details in Python, call `canfar.configure_logging()` at the
-application entry point; it honors `CANFAR_LOGLEVEL`. In the CLI, use a root
-control such as `canfar --log-level debug create ...`. See
-[Logging](../cli/logging.md).
+The released Python contracts are:
+
+| Method | Result |
+| --- | --- |
+| `fetch(kind=None, status=None, view=None)` | `list[dict[str, str]]` |
+| `create(...)` | `list[str]` containing the IDs that launched successfully |
+| `info(ids)` | `list[dict[str, Any]]` |
+| `logs(ids, verbose=False)` | `dict[str, str]`, or `None` when `verbose=True` |
+| `events(ids, verbose=False)` | `list[dict[str, str]]`, or `None` when `verbose=True` |
+| `destroy(ids)` / `destroy_with(...)` | `dict[str, bool]` |
+| `connect(ids)` | `None`; opens ready Session URLs |
+
+`create()` skips an individual launch after an HTTP or network failure and logs
+the failure without raising. If all requested launches fail, it returns `[]`.
+Validation errors in the request are raised before the HTTP call.
+
+`fetch(view="all")` requests the server's all-Sessions view when the caller is
+authorized; the response remains a list of dictionaries. `stats()` returns the
+Science Platform Server's aggregate resource statistics as a dictionary.
+
+`logs(..., verbose=True)` and `events(..., verbose=True)` route their results to
+the `canfar.sessions` logger and return `None`; configure application logging
+with `canfar.configure_logging()` if the output should be visible.
+
+## Create and manage a Session
+
+```python
+from canfar.sessions import Session
+
+with Session() as session:
+    ids = session.create(
+        name="my-analysis",
+        image="images.canfar.net/skaha/astroml:latest",
+        kind="notebook",
+    )
+    if ids:
+        session.connect(ids)
+        print(session.fetch(kind="notebook", status="Running"))
+        print(session.info(ids))
+        print(session.logs(ids))
+        print(session.events(ids))
+        print(session.destroy(ids))
+```
+
+When `kind="headless"`, pass `cmd`, `args`, and `env` for the command. `cores`
+and `ram` request fixed resources; omitting them uses the server's flexible
+allocation policy. `replicas` requests multiple Sessions and the return value
+contains the successful IDs only.
+
+```python
+from canfar.sessions import Session
+
+with Session() as session:
+    ids = session.create(
+        name="batch",
+        image="images.canfar.net/skaha/terminal:latest",
+        kind="headless",
+        cmd="python",
+        args="/arc/projects/demo/run.py",
+        replicas=3,
+    )
+```
+
+## Select Sessions for cleanup
+
+`destroy_with` has a keyword-only filter contract:
+
+```python
+session.destroy_with(
+    "batch-",
+    kind="headless",
+    status="Completed",
+)
+```
+
+Its signature is `destroy_with(prefix, *, kind="headless", status="Completed")`.
+A prefix is matched literally unless it contains regular-expression
+metacharacters; such a value is treated as a regular expression.
 
 ::: canfar.sessions.Session
     handler: python
     selection:
       members:
         - fetch
+        - stats
         - create
         - info
         - logs
+        - events
         - destroy
+        - destroy_with
+        - connect
     rendering:
       members_order: source
       show_root_heading: true

--- a/docs/client/testing.md
+++ b/docs/client/testing.md
@@ -1,167 +1,70 @@
 # Testing
 
-This document provides comprehensive information about testing [opencadc/canfar](https://github.com/opencadc/canfar).
-
-## Overview
-
-Canfar uses [pytest](https://pytest.org/) as its testing framework. The test suite includes unit tests, integration tests, and end-to-end tests that verify the functionality of the client library.
+CANFAR uses [pytest](https://pytest.org/). Tests mirror the `canfar/` module
+layout and include deterministic unit/contract tests plus
+Authentication-dependent integration tests.
 
 ## Prerequisites
 
-To run tests for Canfar, you need:
+Install the project environment with `uv`. Full integration coverage requires a
+valid CANFAR Authentication Record and X.509 certificate/configuration. Do not
+run that suite against a real account unless the test workflow is explicitly
+intended to create or clean up platform resources.
 
-1. **Valid CANFAR Account**: Access to the CANFAR Science Platform
-2. **X.509 Certificate**: For authentication with CANFAR services
-3. **Python Environment**: Set up with uv
+## Local validation
 
-For certificate generation, refer to the [get started](get-started.md) section.
+The default local test gate excludes slow tests and avoids external
+Authentication:
 
-## Running Tests
-
-### Basic Test Execution
-
-Run all tests:
 ```bash
-uv run pytest
+uv run --no-sync pytest tests -m "not slow" --no-cov -q \
+  -o cache_dir=/tmp/canfar-pytest-cache
 ```
 
-Run tests with verbose output:
+Useful focused checks include:
+
 ```bash
-uv run pytest -v
+uv run --no-sync pytest tests/test_sessions_fetch.py tests/test_sessions_lifecycle.py \
+  tests/test_storage.py tests/test_config_editor.py -q
+uv run --no-sync ruff check . --no-cache
+uv run ty check canfar
+uv run --group docs mkdocs build
 ```
 
-Run tests with coverage report:
+The documentation build is the check for broken navigation, Markdown, and
+generated Python API pages.
+
+## Test markers
+
+Use markers to select known test categories:
+
 ```bash
-uv run pytest --cov
+uv run --no-sync pytest -m unit
+uv run --no-sync pytest -m integration
+uv run --no-sync pytest -m slow
 ```
 
-### Test Categories
+Integration and slow tests may contact CANFAR services and require valid
+credentials. `-m "not slow"` is the deterministic default; it is not a claim
+that every test marked `integration` is safe without Authentication.
 
-Canfar tests are organised with markers to help you run specific subsets:
+## Full suite
 
-#### Slow Tests
+Run the full suite only in an environment prepared for the credentialed gate:
 
-Some tests are marked as "slow" because they involve:
-- Network operations with CANFAR services
-- Waiting for session state changes
-- Authentication timeouts
-- Long-running operations
-
-**Skip slow tests for faster development:**
 ```bash
-uv run pytest -m "not slow"
+uv run --no-sync pytest
 ```
 
-**Run only slow tests:**
-```bash
-uv run pytest -m "slow"
-```
+The full run includes Authentication-dependent tests, Session lifecycle work,
+and network operations. A local failure can therefore indicate missing
+credentials or unavailable Science Platform infrastructure rather than a
+library regression.
 
-#### Integration Tests
+## Adding tests
 
-Tests that interact with external services:
-```bash
-uv run pytest -m "integration"
-```
-
-#### Unit Tests
-
-Fast, isolated tests:
-```bash
-uv run pytest -m "unit"
-```
-
-### Test Methodology
-
-Tests are organised in the `tests/` directory and follow a specific naming convention that mirrors the source code structure. This approach ensures that tests are easy to locate and maintain.
-
-The naming convention is as follows:
-
-- If the source file is `canfar/path/to/file.py`, the corresponding test file will be `tests/test_path_to_file.py`.
-- If the source file is `canfar/module.py`, the corresponding test file will be `tests/test_module.py`.
-
-For example:
-
-- The tests for `canfar/client.py` are located in `tests/test_client.py`.
-- The tests for `canfar/auth/oidc.py` are located in `tests/test_auth_oidc.py`.
-
-This structure makes it straightforward to find the tests associated with a particular module or file.
-
-## Development Workflow
-
-For efficient development, follow this testing workflow:
-
-1. **During Development**: Run fast tests only
-   ```bash
-   uv run pytest -m "not slow"
-   ```
-
-2. **Before Committing**: Run the full test suite
-   ```bash
-   uv run pytest
-   ```
-
-3. **Debugging Specific Issues**: Run individual test files
-   ```bash
-   uv run pytest tests/test_session.py
-   ```
-
-## Test Configuration
-
-Test configuration is defined in `pyproject.toml`:
-
-```toml
-[tool.pytest.ini_options]
-markers = [
-    "integration: marks tests as integration tests",
-    "unit: marks tests as unit tests",
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-]
-```
-
-## Continuous Integration
-
-In CI environments, all tests (including slow ones) are executed to ensure complete validation. The CI pipeline:
-
-1. Sets up authentication with CANFAR
-2. Runs the complete test suite
-3. Generates coverage reports
-4. Cleans up authentication artifacts
-
-## Writing Tests
-
-When contributing new tests:
-
-1. **Follow the naming convention**: Create a test file that mirrors the source file's path and name.
-2. **Mark slow tests**: Add `@pytest.mark.slow` to any test that involves network operations, interacts with external services, or has long execution times. This allows developers to skip these tests for a faster development cycle.
-3. **Use appropriate markers**: Mark tests as `unit`, `integration`, etc.
-4. **Add docstrings**: Document what each test verifies.
-
-Example of a slow test:
-```python
-import pytest
-
-@pytest.mark.slow
-def test_long_running_operation():
-    """Test that involves waiting or network operations."""
-    # Test implementation
-    pass
-```
-
-
-## Troubleshooting
-
-### Authentication Issues
-- Ensure your X.509 certificate is valid and not expired
-- Check that you have access to the CANFAR Science Platform
-- Verify your certificate is in the correct location (`~/.ssl/`)
-
-### Slow Test Timeouts
-- Slow tests have built-in timeouts (typically 60 seconds)
-- If tests consistently timeout, check your network connection
-- Platform availability may affect test execution times
-
-### Test Failures
-- Check if the CANFAR Science Platform is accessible
-- Verify your authentication credentials
-- Review test logs for specific error messages
+- Mirror the source module path under `tests/`.
+- Mark network or long-running tests with `integration` and/or `slow`.
+- Prefer observable public seams such as `httpx.MockTransport`, `CliRunner`,
+  and the public Configuration editor.
+- Keep sync tests synchronous and async tests on the native async path.

--- a/docs/client/updates.md
+++ b/docs/client/updates.md
@@ -1,179 +1,28 @@
 # What's New in CANFAR
 
-Stay up to date with the latest features, improvements, and changes in CANFAR.
+This page highlights the current Python client contracts. For release-by-release
+changes, see the [changelog](../changelog.md) and
+[GitHub Releases](https://github.com/opencadc/canfar/releases).
 
-## Recent Updates
+## Current Python API
 
-!!! tip "New in v1.1+"
+- `Session` and `AsyncSession` are native synchronous and asynchronous clients
+  with equivalent public operations.
+- `Session.create()` and `AsyncSession.create()` return `list[str]`, omitting
+  failed replicas instead of raising for an individual HTTP/network failure.
+- `fetch()` returns the server response as `list[dict[str, str]]`.
+- `destroy_with(prefix, *, kind=..., status=...)` keeps its keyword-only filter
+  contract in both clients.
+- `canfar.login()` and `canfar.alogin()` provide synchronous and asynchronous
+  Python Authentication flows. OIDC device login prints a verification URL and
+  user-facing code to the terminal; browser, QR, and progress presentation stay
+  in the CLI.
+- `config.editor.get()`, `set()`, and `save()` are the supported Configuration
+  editing operations. The persisted Configuration shape remains stable.
+- `canfar.storage.identifiers()` and `canfar.storage.filesystem(identifier)` are
+  the explicit VOSpace Python surface. Storage Identifiers are not dynamic
+  module members or fsspec schemes.
+- `Overview` and `canfar.helpers.distributed` remain supported public APIs.
 
-    ### **🛡️ Improved Session Data Validation**
-
-    The CANFAR CLI now features enhanced resilience when handling session data from the Science Platform API. This update improves the user experience when the API returns incomplete or malformed session information.
-
-    **What Changed:**
-
-    - **Graceful Degradation**: The CLI commands (`canfar info`, `canfar ps`) now continue to work even when the API returns incomplete session data, displaying partial information instead of crashing.
-    - **Better Error Reporting**: Missing or invalid fields are tracked internally and can be viewed with the `--debug` flag for troubleshooting.
-    - **Enhanced Display**: Resource usage metrics for flexible sessions is now reported with better readability.
-    - **Type Safety**: Session type validation has been strengthened using Pydantic's built-in validators.
-
-    **Example:**
-
-    ```bash title="Flexible Session Resource Usage"
-    $ canfar info n2tr1rpf
-
-    CANFAR Session Info for n2tr1rpf
-
-      Session ID    n2tr1rpf
-      Name          spy-panda
-      Status        Running
-      Type          notebook
-      CPU Usage     0.001 core(s)
-      RAM Usage     0.22 GB
-      GPU Usage     Unknown # (GPU not requested)
-    ```
-
-    ```bash title="Debug Mode for Troubleshooting"
-    $ canfar info --debug n2tr1rpf 
-
-    # Shows additional warnings about missing/invalid fields
-    ⚠️  Session Response Warnings:
-        • missing or invalid startTime in response
-        • missing or invalid expiryTime in response
-    ```
-
-!!! success "v1.0"
-
-    :fontawesome-solid-exclamation-triangle: **Breaking Changes**
-
-      - Deprecation of support for Python 3.8 and 3.9.
-      - The Python package has been renamed from `skaha` to `canfar`.
-      - The `skaha.session` API has been deprecated in favor of `canfar.sessions`.
-      - See [Migration guide to migrate from skaha → canfar](migration.md).
-
-    :simple-gnubash: **CLI Support**
-    
-      - Comprehensive CLI support has been added to the client under the `canfar` entry point. See [CLI Reference](../cli/cli-help.md) for more information.
-      - The `canfar` CLI is the recommended way to manage Authentication and Server selection. See [Authentication and Servers](../cli/authentication-contexts.md) for more information.
-    
-    **🌎 SRCnet Support**
-    
-      - CANFAR now supports launching sessions on all the SRCnet CANFAR Science Platform instances worldwide.
-    
-    **:fontawesome-brands-connectdevelop:** OIDC Authentication
-
-      - OpenID Connect (OIDC) authentication is now supported for all SRCnet Science Platform servers where applicable.
-    
-    **:material-book-outline: Documentation**
-    
-      - Complete overhaul to bring all documentation sources under a single roof.
-      - Significant improvements to the Python client and brand new CLI documentation.
-
-!!! info "New in v0.7+"
-
-    ### **🔐 Enhanced Authentication System**
-    Canfar now features a comprehensive authentication system with support for multiple authentication modes and automatic credential management.
-
-    ```python title="Authentication Examples"
-    from canfar.client import HTTPClient
-    from pathlib import Path
-
-    # X.509 certificate authentication
-    client = HTTPClient(certificate=Path("/path/to/cert.pem"))
-
-    # OIDC token authentication (configured)
-    client = HTTPClient()  # Uses auth.mode = "oidc"
-
-    # Bearer token authentication
-    from pydantic import SecretStr
-    client = HTTPClient(token=SecretStr("your-token"))
-    ```
-
-    ### **🚀 Asynchronous Sessions**
-    Canfar now supports asynchronous sessions using the `AsyncSession` class while maintaining 1-to-1 compatibility with the `Session` class.
-
-    ```python title="Asynchronous Session Creation"
-    from canfar.sessions import AsyncSession
-
-    asession = AsyncSession()
-    response = await asession.create(
-        name="test",
-        image="images.canfar.net/skaha/astroml:latest",
-        cores=2,
-        ram=8,
-        gpu=1,
-        kind="headless",
-        cmd="env",
-        env={"KEY": "VALUE"},
-        replicas=3,
-    )
-    ```
-
-    ### **🗄️ Backend Upgrades**
-
-    - 📡 Canfar now uses the `httpx` library for making HTTP requests instead of `requests`. This adds asynchronous support and also to circumvent the `requests` dependence on `urllib3` which was causing SSL issues on MacOS. See [this issue](https://github.com/urllib3/urllib3/issues/3020) for more details.
-    - 🔑 Canfar now supports multiple authentication methods including X.509 certificates, OIDC tokens, and bearer tokens with automatic SSL context management.
-    - 🏎️💨 Added `loglevel` and `concurrency` support to manage the new explosion in functionality!
-    - 🔍 Comprehensive debug logging for authentication flow and client creation troubleshooting.
-
-    ### **🧾 Logs to `stdout`**
-
-    The `[Session|AsyncSession].logs` method now prints colored output to `stdout` instead of returning them as a string with `verbose=True` flag.
-
-    ```python title="Session Logs"
-    from canfar.sessions import AsyncSession
-
-    asession = AsyncSession()
-    await asession.logs(ids=["some-uuid"], verbose=True)
-    ```
-
-    ### **🪰 Firefly Support**
-    Canfar now supports launching `firefly` session on the CANFAR Science Platform.
-
-    ```python title="Firefly Session Creation"
-    session.create(
-        name="firefly",
-        image="images.canfar.net/skaha/firefly:latest",
-        kind="firefly",
-    )
-    ```
-
-!!! info "New in v0.4+"
-
-    ### **🔐 Private Images**
-
-    Starting October 2024, to create a session with a private container image from the [CANFAR Harbor Registry](https://images.canfar.net/), you will need to provide your harbor `username` and the `CLI Secret` through a `ContainerRegistry` object.
-
-    ```python title="Private Image Registry Configuration"
-    from canfar.models import ContainerRegistry
-    from canfar.sessions import Session
-
-    registry = ContainerRegistry(username="username", secret="sUp3rS3cr3t")
-    session = Session(registry=registry)
-    ```
-
-    Alternatively, if you have environment variables, `CANFAR_REGISTRY_USERNAME` and `CANFAR_REGISTRY_SECRET`, you can create a `ContainerRegistry` object without providing the `username` and `secret`.
-
-    ```python title="Private Image Registry with Environment Variables"
-    from canfar.models import ContainerRegistry
-
-    registry = ContainerRegistry()
-    ```
-
-    ### **💣 Destroy Sessions**
-    ```python title="Destroying Sessions"
-    from canfar.sessions import Session
-
-    session = Session()
-    session.destroy_with(prefix="test", kind="headless", status="Running")
-    session.destroy_with(prefix=".*-analysis", kind="headless", status="Pending")
-    ```
-
-## Previous Versions
-
-For a complete history of changes, see the [Changelog](../changelog.md).
-
-## Stay Updated
-
-- 📢 [GitHub Releases](https://github.com/opencadc/canfar/releases)
-- 💬 [Discussions](https://github.com/opencadc/canfar/discussions)
+Start with the [Python quickstart](quick-start.md), then see the [Session API](session.md),
+[Data Access](data.md), and [Migration Guide](migration.md).


### PR DESCRIPTION
## Summary

- audit all Python client documentation against the shipped interfaces
- clarify native Session and AsyncSession contracts, exact return shapes, lifecycle, failure behavior, and keyword-only cleanup filters
- document login/alogin device flow, config.editor, credential precedence, explicit Storage Identifier/filesystem use, Overview, and distributed helpers
- contract stale, duplicated, speculative, and overly verbose examples

## Validation

- 54 Python code fences compiled.
- 102 focused tests passed.
- Deterministic non-slow suite: 854 passed.
- MkDocs build passed.
- git diff check passed.

16 client documentation files: +884 / -1,356 lines.

Partial implementation of #261; the CLI and platform/site lanes are separate Wave 7 PRs.
