### PR TITLE
docs(cli): align command reference with shipped interface

### DIFF
--- a/docs/cli/authentication-contexts.md
+++ b/docs/cli/authentication-contexts.md
@@ -1,41 +1,76 @@
 # Authentication and Servers
 
-CANFAR separates identity from routing:
+CANFAR keeps identity and routing separate:
 
-- **Authentication** answers "who am I?"
-- **Identity Provider (IDP)** names the organization that authenticates you,
-  such as `cadc` or `srcnet`.
-- **Science Platform Server** is the endpoint that runs Sessions.
-- **Server selection** chooses which compatible Server receives new requests.
+- **Authentication** owns the user's identity and credentials.
+- An **Identity Provider (IDP)** issues that identity. The built-in keys are
+  `cadc` (X.509) and `srcnet` (OIDC Device Authorization).
+- A **Science Platform Server** runs Sessions.
+- **Server Selection** chooses the Science Platform Server for new requests.
 
-`canfar login` handles the full interactive path: choose an IDP, authenticate,
-discover compatible Servers, select one, and save the active pair.
+The active Authentication Record and Server Selection are saved together in
+the local Configuration. Existing Sessions remain on the Science Platform
+Server where they were launched.
 
-## Log in
+## Login
 
 ```bash
-canfar login
+canfar login [IDP]
+```
+
+When `IDP` is omitted, the CLI prompts for one. Use these options when needed:
+
+| Option | Effect |
+| --- | --- |
+| `--force`, `-f` | Obtain new credentials and rediscover instead of refusing an existing record. |
+| `--dev` | Include development registries and endpoints during Server Discovery. |
+| `--timeout`, `-t` | HTTP timeout in seconds for login requests; default `10`. |
+
+Login authenticates the selected IDP, discovers compatible Science Platform
+Servers, selects one when necessary, and saves the Authentication Record and
+Server Selection. A saved record causes a repeat login to fail unless
+`--force` is supplied.
+
+### CADC X.509
+
+```bash
 canfar login cadc
+```
+
+The CLI reuses a usable X.509 certificate when possible. Use `--force` to
+obtain a replacement. If the certificate is expired, login reports that and
+continues with certificate acquisition.
+
+### SRCNet OIDC Device Authorization
+
+```bash
 canfar login srcnet
 ```
 
-Useful options:
+The CLI performs OIDC discovery and dynamic client registration, then presents
+the Device Authorization challenge in the terminal:
 
-| Option | Use |
-| --- | --- |
-| `--force`, `-f` | Re-authenticate an IDP that already has saved credentials. |
-| `--dev` | Include development Servers during discovery. |
-| `--timeout`, `-t` | Increase HTTP timeout for login, discovery, and validation. |
+1. It prints a verification URL, user code, and a terminal QR code.
+2. It opens the verification URL in the default browser when possible.
+3. You sign in and approve the request in the browser.
+4. The CLI polls for approval and shows progress until the IDP returns tokens.
 
-Logging controls are root options. Put them before `login` when troubleshooting:
+If the browser cannot be opened, visit the printed URL manually. The device
+challenge has an IDP-provided expiry; `--timeout` controls HTTP requests and
+does not extend that challenge. Denial, expiry, malformed responses, and
+network failures stop login with an error; run the command again after fixing
+the cause.
+
+For troubleshooting, put root logging options before `login`:
 
 ```bash
+canfar --log-level debug login srcnet
 canfar --log-level debug login cadc --force
 ```
 
-See [Logging](logging.md) for level precedence and stream separation.
+See [Logging](logging.md) for precedence and stream routing.
 
-## Inspect authentication
+## Inspect Authentication
 
 ```bash
 canfar auth
@@ -43,73 +78,77 @@ canfar auth show
 canfar auth ls
 ```
 
-`canfar auth` defaults to `canfar auth show`.
-
-Use machine output when a script needs stable stdout:
+Bare `canfar auth` defaults to `auth show`. Human output includes the active
+Server Selection when one is available. For scripts, use machine output on the
+data-producing form:
 
 ```bash
 canfar auth show -o json
 canfar auth ls --output yaml
 ```
 
-## Switch IDP
+The machine payload is an Authentication object or list of Authentication
+objects. It contains the canonical IDP key, display name, Authentication Mode,
+expiry, active state, and associated Server Name; it does not contain raw
+credential material.
+
+## Change or remove state
+
+Switch to a saved Authentication Record by canonical IDP key:
 
 ```bash
 canfar auth use srcnet
 canfar auth use cadc
 ```
 
-When you switch IDP, CANFAR tries to keep routing usable:
+When switching, CANFAR reuses a compatible remembered Server Selection when
+one exists. If several compatible Servers need a choice, the CLI prompts for a
+Server URI or list number.
 
-1. Reuse the current Server when it belongs to the target IDP.
-2. Reuse the remembered Server for that IDP when it is still valid.
-3. Auto-select the only compatible Server.
-4. Prompt when multiple compatible Servers exist.
+Remove one Authentication Record and its associated Servers with:
 
-## Manage Servers
+```bash
+canfar auth rm srcnet
+canfar auth rm srcnet --force
+```
+
+Removing the active Authentication asks for confirmation unless `--force` is
+used. To reset all Authentication and Server state, use the required force
+flag:
+
+```bash
+canfar auth purge --force
+```
+
+The purge restores built-in defaults and preserves unrelated registry and
+console settings.
+
+## Server Selection
 
 ```bash
 canfar server ls
+canfar server ls -o json
+canfar server use SELECTOR
+```
+
+`server ls` lists the saved Servers for the active IDP. If none are saved, it
+runs discovery and persists the result. Its machine payload is a list of
+Server records and is data-only on stdout.
+
+`server use` accepts either a Server Name or an IVOA URI:
+
+```bash
 canfar server use canfar
 canfar server use ivo://cadc.nrc.ca/skaha
 ```
 
-Server names are convenient for humans. Server URIs are stable for scripts.
+The persisted `active.server` value is the Server Name. The IVOA URI is
+discovery metadata and can still be used as a selector.
 
-`canfar server ls` shows Servers for the active IDP. If no saved Servers exist
-for that IDP, the command runs discovery and stores the results.
+## Configuration shape
 
-## Remove saved auth state
-
-```bash
-canfar auth rm srcnet
-canfar auth purge --force
-```
-
-`auth rm <idp>` removes the Authentication record and Servers associated with
-that IDP. Removing the active IDP asks for confirmation unless `--force` is
-passed.
-
-`auth purge --force` resets Authentication and Server state while preserving
-unrelated configuration such as console and Container Registry settings.
-
-## Python equivalents
-
-```python
-import canfar
-
-canfar.login("cadc")
-canfar.server.use("ivo://cadc.nrc.ca/skaha")
-canfar.authentication.use("srcnet")
-```
-
-Python helpers are noninteractive. CLI commands own prompts and human rendering.
-
-## Configuration
-
-The current config shape is versioned with `version: 1`. Authentication
-records are keyed by IDP and Servers are keyed by Server Name; `active.server`
-references a Server by name.
+The persisted shape separates Authentication Records and Science Platform
+Servers. `active.server` refers to a Server Name, not an IVOA URI:
 
 ```yaml
 version: 1
@@ -126,33 +165,19 @@ servers:
     url: https://ws-uv.canfar.net/skaha
 ```
 
-Dict keys make every value reachable with dotted paths:
+Use `canfar config get` and `canfar config set` for dotted configuration
+paths. Values passed to `config set` are parsed as YAML:
 
 ```bash
+canfar config get active.server
 canfar config get servers.canfar.url
-canfar config get authentication.cadc.path
+canfar config set console.banner false
 ```
 
-Environment overrides use nested active fields:
+Environment overrides use the same nested names, for example:
 
 ```bash
-CANFAR_ACTIVE__AUTHENTICATION=srcnet
-CANFAR_ACTIVE__SERVER=canfar
+CANFAR_CONSOLE__BANNER=false canfar auth show
 ```
 
-Legacy or unsupported config files are backed up to
-`<config-path>.<timestamp>.back` before a default config is written.
-
-## Machine output rules
-
-| Rule | Behavior |
-| --- | --- |
-| Output option | `-o/--output` with `json` or `yaml` |
-| Placement | Put the option after the command that emits data, for example `canfar auth ls -o json`. |
-| Unsupported placement | `canfar auth -o json ls` exits 2. |
-| stdout | Data only in machine mode. |
-| stderr | Diagnostics and errors. |
-| Unsupported commands | Leaf commands without machine output do not define `-o/--output`; Click rejects the option with exit 2 and a parser error on stderr. |
-
-Lists have no ordering guarantee. Scripts should select by IDP key, Server
-Name, URI, Session ID, or another stable field.
+The complete command and machine-output contract is in the [CLI reference](cli-help.md).

--- a/docs/cli/cli-help.md
+++ b/docs/cli/cli-help.md
@@ -1,15 +1,29 @@
-# CLI Reference
+# CLI reference
 
-Use `canfar` for Authentication, Science Platform Server selection, Session
-management, Container Images, and client configuration.
+The `canfar` command manages Authentication, Science Platform Server
+selection, Sessions, Container Images, data sources, and client configuration.
+Run `canfar --help` or append `--help` to any command for the installed
+options.
 
-```bash
-canfar --help
-```
+## Canonical command surface
 
-## Root logging controls
+The root keeps Session and information operations as leaves. Authentication,
+Server, data, image, and configuration operations remain grouped:
 
-Put logging options before the command:
+| Area | Commands |
+| --- | --- |
+| Authentication and Server Selection | `login`, `auth`, `server` |
+| Sessions | `create`, `ps`, `events`, `info`, `open`, `logs`, `delete`, `prune` |
+| Platform information | `stats`, `image ls` |
+| Client configuration | `config show`, `config get`, `config set`, `config path`, `version` |
+| Data | `data` and its embedded file commands |
+
+There are no extra command names between the root and these leaves. In
+particular, Session creation is `canfar create`, and login is `canfar login`.
+
+## Root logging options
+
+Root logging options must come before the command:
 
 ```bash
 canfar --log-level debug ps
@@ -17,38 +31,41 @@ canfar -vvv ps
 canfar --log-file ./logs/canfar.jsonl ps
 ```
 
-| Option | Use |
+| Option | Effect |
 | --- | --- |
-| `--log-level LEVEL` | Select `critical`, `error`, `warning`, `info`, or `debug`. |
-| `-v` | Increase verbosity; repeat through `-vvvv` for `debug`. |
+| `--log-level LEVEL` | `critical`, `error`, `warning`, `info`, or `debug`. |
+| `-v` | Increase verbosity; four or more repetitions select `debug`. |
 | `--log-file PATH` | Add the rotating JSON Lines file sink. |
 
-See [Logging](logging.md) for the exact mapping, precedence, streams, file
-schema, and stable error codes.
+See [Logging](logging.md) for precedence, stream routing, file records, and
+setup errors.
 
 ## Authentication and Servers
 
-### `canfar login`
+### Login
 
 ```bash
 canfar login [IDP] [OPTIONS]
 ```
 
-| Option | Use |
-| --- | --- |
-| `--force`, `-f` | Force re-authentication. |
-| `--dev` | Include development Servers during discovery. |
-| `--timeout`, `-t` | HTTP timeout in seconds during login. Default: `10`. |
+`IDP` is an optional canonical Identity Provider key. Without it, the CLI
+prompts for one. The options are:
 
-Examples:
+| Option | Effect |
+| --- | --- |
+| `--force`, `-f` | Re-authenticate an existing Authentication Record. |
+| `--dev` | Include development registries and endpoints during discovery. |
+| `--timeout`, `-t` | HTTP timeout in seconds; default `10`. |
 
 ```bash
-canfar login
 canfar login cadc
 canfar login srcnet --force
 ```
 
-### `canfar auth`
+The interactive credential flow and Server Selection are described in
+[Authentication and Servers](authentication-contexts.md).
+
+### Authentication
 
 ```bash
 canfar auth
@@ -59,168 +76,155 @@ canfar auth rm IDP [--force]
 canfar auth purge --force
 ```
 
-| Command | Use |
-| --- | --- |
-| `auth` / `auth show` | Show active Authentication state. |
-| `auth ls` | List saved Authentication records. |
-| `auth use IDP` | Switch active Authentication by canonical IDP key. |
-| `auth rm IDP` | Remove one Authentication record and its Servers. |
-| `auth purge --force` | Reset Authentication and Server state. |
+`canfar auth` is the same active-Authentication view as `canfar auth show`.
+`auth use` selects a saved Authentication Record; `auth rm` also removes the
+associated Servers; `auth purge --force` resets Authentication and Server state.
 
-Machine output is supported for `auth` / `auth show` and `auth ls`:
-
-```bash
-canfar auth show -o json
-canfar auth ls --output yaml
-```
-
-### `canfar server`
+### Server Selection
 
 ```bash
 canfar server ls
 canfar server use SELECTOR
 ```
 
-| Command | Use |
-| --- | --- |
-| `server ls` | List Servers for the active IDP, discovering them when needed. |
-| `server use SELECTOR` | Select a Server by name or URI. |
-
-Use URIs in scripts because names can be ambiguous:
-
-```bash
-canfar server use ivo://cadc.nrc.ca/skaha
-```
+`SELECTOR` may be a Server Name or an IVOA URI. `server ls` lists Servers for
+the active IDP and discovers them when no saved Servers are available.
 
 ## Sessions
 
-### `canfar create`
+### Create
 
 ```bash
 canfar create [OPTIONS] KIND IMAGE [-- CMD [ARGS]...]
 ```
 
-| Option | Short | Use |
-| --- | --- | --- |
-| `--name` | `-n` | Session name. Defaults to a generated name. |
-| `--cpu` | `-c` | Fixed CPU cores. Omit for flexible allocation. |
-| `--memory` | `-m` | Fixed RAM in GB. Omit for flexible allocation. |
-| `--gpu` | `-g` | GPU count. |
-| `--env` | `-e` | Environment variable as `KEY=VALUE`. |
-| `--replicas` | `-r` | Number of replicas. Default: `1`. |
-| `--debug` | | Print parsed Session request details. |
-| `--dry-run` | | Parse parameters and exit. |
-| `--output FORMAT` | `-o` | Emit created Session IDs as JSON or YAML (`json` or `yaml`). |
+`KIND` is one of `desktop`, `notebook`, `carta`, `headless`, `firefly`, or
+`contributed`. `IMAGE` is a CANFAR Container Image such as
+`skaha/astroml:latest`; the client adds the CANFAR registry and `:latest` when
+they are omitted.
 
-`--output` is recognized before `--`; tokens after `--` are passed verbatim to
-the container command. `--dry-run` is human-output only.
+| Option | Effect |
+| --- | --- |
+| `--name`, `-n` | Session name; a generated name is used by default. |
+| `--cpu`, `-c` | Requested CPU cores. |
+| `--memory`, `-m` | Requested RAM in GB. |
+| `--gpu`, `-g` | Requested GPU count. |
+| `--env`, `-e KEY=VALUE` | Set an environment variable; repeat as needed. |
+| `--replicas`, `-r` | Number of Sessions; default `1`. |
+| `--debug` | Print the parsed Session request. |
+| `--dry-run` | Validate and print the request without creating a Session. |
+| `--output`, `-o` | Emit created Session IDs as `json` or `yaml`. |
 
-Examples:
+Everything after `--` belongs to the container command. The first token is
+the command and the remaining tokens are its arguments, even when they look
+like CANFAR options:
 
 ```bash
-canfar create notebook skaha/astroml:latest
-canfar create --cpu 4 --memory 16 notebook skaha/astroml:latest
 canfar create headless skaha/terminal:1.1.2 -- python /arc/projects/demo/run.py
+canfar create headless skaha/terminal:1.1.2 -- worker --output json -o yaml
 ```
 
-### `canfar ps`
+The `--output` option must appear before `--`. `--dry-run` cannot be combined
+with machine output.
+
+### List Sessions
 
 ```bash
 canfar ps [OPTIONS]
 ```
 
-| Option | Short | Use |
-| --- | --- | --- |
-| `--all` | `-a` | Show all Sessions. Default shows running Sessions. |
-| `--quiet` | `-q` | Print only Session IDs. |
-| `--kind` | `-k` | Filter by Session Kind. |
-| `--status` | `-s` | Filter by status. |
-| `--debug` | | Show Session response warnings. |
+| Option | Effect |
+| --- | --- |
+| `--all`, `-a` | Include all statuses; otherwise show `Pending` and `Running`. |
+| `--quiet`, `-q` | Print matching Session IDs in human mode. |
+| `--kind`, `-k` | Filter by Session Kind. |
+| `--status`, `-s` | Pass a status filter to the Science Platform. |
+| `--debug` | Print Session response warnings. |
+| `--output`, `-o` | Emit the filtered Session response array as `json` or `yaml`. |
 
-Machine output:
-
-```bash
-canfar ps -o json
-canfar ps --output yaml
-```
-
-`--quiet` is a human-output shortcut and is incompatible with machine output.
-
-### Inspect and clean up
-
-```bash
-canfar events SESSION_ID...
-canfar info SESSION_ID...
-canfar logs SESSION_ID...
-canfar open SESSION_ID...
-canfar delete SESSION_ID... [--force]
-canfar prune PREFIX [KIND] [STATUS]
-```
-
-Quote `PREFIX` when it contains shell metacharacters
-(for example `canfar prune 'rabi.*' headless Completed`).
-
-`canfar info SESSION_ID --debug` shows Session response warnings. This is
-a command diagnostic, not a logging-level control.
-
-Common flow:
+`ps` stays a thin operation over `Session.fetch()`: `--kind` and `--status`
+are sent to the fetch call, then the CLI applies the running/default or
+`--all` view to the returned responses. `--quiet` follows that same filter,
+including when combined with `--all`, and is not available with `--output`.
 
 ```bash
 canfar ps
-canfar info $(canfar ps -q)
-canfar open $(canfar ps -q)
-canfar delete $(canfar ps -q)
+canfar ps --all --kind headless
+canfar ps -o json
 ```
 
-## Images and platform state
+### Inspect, open, and remove
+
+These leaves accept one or more Session IDs and produce human-readable output:
+
+| Command | Purpose |
+| --- | --- |
+| `canfar events SESSION_ID...` | List Science Platform events. |
+| `canfar info SESSION_ID...` | Show Session details; `--debug` adds response warnings. |
+| `canfar logs SESSION_ID...` | Show Session logs. |
+| `canfar open SESSION_ID...` | Open ready Sessions in new browser tabs. |
+| `canfar delete SESSION_ID... [--force]` | Delete Sessions, confirming unless `--force` is used. |
+| `canfar prune PREFIX [KIND] [STATUS]` | Delete matching names; defaults to `headless` and `Succeeded`. |
+
+`prune` treats a plain `PREFIX` as a literal prefix. A value containing regex
+metacharacters is treated as a regular expression. Quote such values so the
+shell does not expand them:
 
 ```bash
-canfar image ls
+canfar prune 'notebook.*' notebook Completed
+```
+
+### Platform information
+
+```bash
 canfar stats
-```
-
-Use `canfar image --help` and `canfar stats --help` for command-specific
-options.
-
-## Data
-
-```bash
-canfar data ls -lh arc:/home/[username]
-canfar data cp local:/absolute/path/file.fits arc:/home/[username]/file.fits
-```
-
-Data operands use explicit `storage-identifier:/absolute/path` or
-`local:/absolute/path` syntax. See [Data commands](data.md) for recursive copy,
-cross-source copy and verification, recursive-removal policy, and the exact
-supported boundary.
-
-## Client configuration
-
-```bash
-canfar config show
-canfar config path
-canfar config get console.width
-canfar config get servers.canfar.url
-canfar config set console.width 132
-canfar config set console.banner false
+canfar image ls
+canfar image ls --kind notebook
 canfar version
 canfar version --debug
 ```
 
-`config set` parses values as YAML.
-`console.banner` defaults to `true`. Set it to `false` to hide the
-`@<server-name>` prefix from human-readable CLI output. The banner is always
-disabled for `-o json` and `--output yaml` output.
-`version --debug` shows environment and dependency details for bug reports; it
-does not change the logging level.
+`stats` prints platform usage tables. `image ls` lists Container Images and
+accepts the image-kind filter shown above. `version --debug` prints client,
+Python, operating-system, and dependency details for a bug report; it is not a
+logging control.
 
-## Machine output contract
+## Data and configuration
 
-| Rule | Behavior |
-| --- | --- |
-| Option | `-o/--output` with `json` or `yaml`. |
-| Placement | Put the option after the command, for example `canfar ps -o json`. |
-| stdout | Data payload only. |
-| stderr | Diagnostics and errors. |
-| Unsupported command | Leaf commands without machine output do not define `-o/--output`; Click rejects the option with exit 2 and a parser error on stderr. |
-| Ordering | List ordering is not guaranteed. |
+```bash
+canfar data --help
+canfar config show
+canfar config get console.width
+canfar config set console.width 132
+canfar config path
+```
+
+Data operands use an explicit `Storage Identifier`, for example
+`arc:/home/user/file.fits` or `local:/tmp/file.fits`. See [Data commands](data.md)
+for the embedded command surface. Configuration keys use dotted paths; values
+passed to `config set` are parsed as YAML. See [Authentication and Servers](authentication-contexts.md)
+for the persisted Authentication, Server, and active-selection shape.
+
+## Machine output
+
+The leaf option `-o/--output` accepts only `json` or `yaml`. It is available on
+the data-producing forms `auth` (the default active view), `auth show`,
+`auth ls`, `server ls`, `create`, `ps`, `config show`, and `config get`:
+
+```bash
+canfar auth show -o json
+canfar server ls --output yaml
+canfar create headless skaha/terminal:1.1.2 -o json
+canfar config get active.server -o json
+```
+
+The payload is the same Python result used by that command after its normal
+filtering. For example, `create -o json` is a raw list of Session IDs and
+`ps -o json` is a filtered array of Session response objects; neither is
+wrapped in a command-specific envelope. Human active-Server banners and logs
+never precede the machine payload on stdout. Diagnostics and errors use stderr.
+
+Put `-o/--output` after the command that owns it. Root `-o`, `--json`, and
+`--yaml` are not options, and commands without machine output reject `-o`.
+For `create`, `-o` is parsed only before `--`; after the delimiter it is a
+container-command token.

--- a/docs/cli/data.md
+++ b/docs/cli/data.md
@@ -1,179 +1,88 @@
 # Data commands
 
-Use `canfar data` to work with configured VOSpace Services and the local
-filesystem through the embedded `fsspec-cli` command application.
+`canfar data` delegates to the embedded `fsspec-cli` command application. It
+maps every configured VOSpace Service by its Storage Identifier and always
+adds the reserved `local` source for the machine running the command.
 
-## Install and authenticate
+## Sources and operands
 
-Data commands are included in the standard installation:
-
-```bash
-pip install canfar
-canfar login cadc
-```
-
-## Address mapped sources
-
-Every operand starts with a Storage Identifier: the handle of a configured
-VOSpace Service, or the reserved `local` identifier for the machine where the
-command runs. Operands always pair an identifier with an absolute path:
+Run `canfar login` for the IDP that owns a remote VOSpace Service, then use an
+explicit source-qualified operand:
 
 ```text
 storage-identifier:/absolute/path
 local:/absolute/path
 ```
 
-Every mapped source is available concurrently, regardless of the active Server
-Selection. A default CADC login maps two VOSpace Services, `arc` and `vault`,
-plus `local`:
+The default CADC configuration provides `arc`, `vault`, and `local` when its
+default Server record is present:
 
 ```bash
-canfar data ls -lh arc:/
-canfar data ls -lh arc:/home/[username]
+canfar data ls -lh arc:/home/user
 canfar data ls -lh vault:/
+canfar data ls -lh local:/tmp
 ```
 
-Use `ls -lh`, or the `ll -h` long-form command, for a human-readable listing.
-The `-h` flag reports human-readable sizes and requires a long listing, so
-`ls -h` on its own exits with `ls: -h: requires long listing`.
+Storage Identifiers are configuration keys, not protocols. There is no
+`active:/` source, bare local-path shorthand, empty `:/path` source, or
+`canfar storage` command. A data command sees all configured sources, not only
+the active Server Selection.
 
-Operands must name a mapped source. Empty `:/path`, bare local paths such as
-`/tmp/file`, and `active:/path` are all rejected; there is no `active` alias
-and no `canfar storage` command.
+## Command surface
 
-## Copy files and directories
+Use `canfar data --help` for the installed upstream options. The available
+commands are:
 
-Copy one file between local and remote sources:
+| Command | Purpose |
+| --- | --- |
+| `basename`, `dirname` | Transform a path string. |
+| `info`, `size`, `stat`, `test` | Inspect a file or evaluate a predicate. |
+| `ls`, `ll` | List directory contents; `ls` accepts `-A`, `-l`, and `-h`, while `ll` accepts `-A` and `-h`. |
+| `du` | Estimate file space usage; supports `-s` and `-h`. |
+| `find`, `tree` | Traverse recursively; `find` supports `--maxdepth` and `--type f|d`, while `tree` supports `--maxdepth`. |
+| `head`, `tail`, `cat` | Read leading bytes, trailing bytes, or file contents. |
+| `cp` | Copy files or one directory; `-R`/`-r` enables recursive copy. |
+| `mv` | Move or rename files on one mapped filesystem. |
+| `mkdir`, `rmdir`, `unlink`, `rm` | Create directories, remove empty directories, remove one file, or remove files. |
+
+Recursive removal is disabled by CANFAR policy, so `data rm` has no `-R` or
+`-r` option. `data mv` does not implement a cross-source move; copy between
+sources and verify the destination before removing the source separately.
+
+## Examples
+
+List and inspect a remote object:
 
 ```bash
-canfar data cp local:/absolute/path/file.fits arc:/home/[username]/file.fits
-canfar data cp arc:/home/[username]/file.fits local:/absolute/path/file.fits
+canfar data ls -lh arc:/home/user
+canfar data info arc:/home/user/file.fits
+canfar data cat arc:/home/user/file.fits
 ```
 
-Copy between two VOSpace Services, for example a public test cutout from
-`vault` into your `arc` home directory:
+Copy between local and remote sources:
 
 ```bash
-canfar data cp vault:/ALMA/test-data/cutouts/test-4d-cube-cutout.fits arc:/home/[username]/test-4d-cube-cutout.fits
-canfar data ls -lh arc:/home/[username]/test-4d-cube-cutout.fits
+canfar data cp local:/tmp/file.fits arc:/home/user/file.fits
+canfar data cp arc:/home/user/file.fits local:/tmp/file.fits
 ```
 
-Recursive copy is enabled for admitted local and remote source pairs:
+Recursive copy is available for one directory and its descendants:
 
 ```bash
-canfar data cp -R local:/absolute/path/dataset arc:/home/[username]/dataset
+canfar data cp -R local:/tmp/dataset arc:/home/user/dataset
 ```
 
-The tagged upstream implementation builds a bounded manifest, copies files
-through host-local staging when sources differ, and verifies destination
-metadata. Recursive copy is not atomic and does not create a snapshot; inspect
-the destination before removing any source data.
-
-## Move data between sources
-
-Cross-source `mv` is unsupported and exits with status 2:
-
-```text
-mv: cross-source move unsupported
-```
-
-Move a file between sources explicitly by copying it, verifying the
-destination, and only then issuing a separate source removal:
+For a cross-source move, make the verification and removal explicit:
 
 ```bash
-canfar data cp vault:/folder/file.fits arc:/home/[username]/file.fits
-canfar data ls -lh arc:/home/[username]/file.fits
+canfar data cp vault:/folder/file.fits arc:/home/user/file.fits
+canfar data info arc:/home/user/file.fits
 canfar data rm vault:/folder/file.fits
 ```
 
-Do not use this sequence as a one-command or atomic move.
+Data command stdout belongs to the embedded command. CANFAR does not prepend
+the active-Server banner or add a JSON/YAML envelope, and data commands do not
+provide the CANFAR `-o/--output` option.
 
-Recursive removal is disabled by application policy, so `rm` accepts no `-R` or
-`-r` flag at all and exits with status 2:
-
-```text
-No such option: -R
-```
-
-Because recursive directory removal is disabled, directory movement is not a
-supported workflow in this release. Any future one-command relocation would be a
-separately named, opt-in orchestration feature with stronger destination
-verification and residual-state semantics—not portable `mv`.
-
-## Cache data locally
-
-### Directory listings
-
-Each command uses a fresh filesystem with a bounded in-memory directory-listing
-cache. The cache is closed with the command and never persists object contents.
-It is not controlled by environment variables.
-
-### Files and byte ranges
-
-There is no CLI flag for caching file contents, but `vosfs` is a normal
-[fsspec](https://filesystem-spec.readthedocs.io/) filesystem, so an fsspec
-cache can wrap the explicit CANFAR Python filesystem. Caching is always a user
-choice: `/scratch` is a useful Session-local directory when named explicitly,
-but its presence or any `skaha_*` environment variable never enables a cache.
-
-For example, cache whole files under an explicitly named directory. The first
-read fetches over the network, and later reads come from that directory:
-
-```python
-from fsspec.implementations.cached import WholeFileCacheFileSystem
-from canfar.storage import filesystem
-
-vault = filesystem("vault")
-cached = WholeFileCacheFileSystem(fs=vault, cache_storage="/scratch/vault-cache")
-
-data = cached.cat_file("/ALMA/test-data/cutouts/test-4d-cube-cutout.fits")
-```
-
-Use `SimpleCacheFileSystem` instead when you do not need the expiry and
-staleness metadata that `WholeFileCacheFileSystem` keeps. Passing
-`cache_storage` a list of directories tries each in order and treats only the
-last as writable, so a shared read-only cache can back your own.
-
-### Byte ranges
-
-For an explicit partial read, `vosfs` sends an HTTP `Range` request and uses a
-validated `206` response. If the byte endpoint returns `200`, it downloads the
-whole object and slices locally. Capability is deployment-specific; do not
-infer it from a Storage Identifier's spelling. The staged file-object path is
-whole-object, even when `cat_file(path, start, end)` can use a range.
-
-The `blockcache` filesystem remains unavailable over a VOSpace Service because
-the opened object is a staged file rather than a ranged buffered reader:
-
-```text
-AttributeError: 'StagedReadFile' object has no attribute 'blocksize'
-```
-
-Use one explicitly selected cache layer on a local directory you own; do not
-silently stack caches or select one from environment variables.
-
-The shown cache wrapper uses the synchronous filesystem returned by
-`canfar.storage.filesystem`.
-
-## Output and accepted omissions
-
-Data command stdout belongs to the embedded command; CANFAR does not prepend
-the active-Server banner or add JSON/YAML envelopes. Diagnostics are written to
-stderr.
-
-The Python equivalent of these commands is documented in
-[Data Access](../client/data.md).
-
-This release intentionally provides no FUSE mount, signed-URL extension,
-progress display, confirmation prompt, `:/path` or bare-path shorthand,
-`active` alias, `canfar storage` alias, recursive removal, or cross-source `mv`
-workflow.
-
-## Upstream releases
-
-CANFAR installs pinned, tagged releases of
-[`vosfs`](https://github.com/shinybrar/vosfs/releases/tag/v0.8.0) and
-[`fsspec-cli`](https://github.com/shinybrar/vosfs/releases/tag/fsspec-cli-v0.7.0).
-CANFAR tests its composition, configuration, authentication, and output seams;
-exhaustive filesystem-command and backend matrices remain in the upstream
-project.
+For Python access, explicit `Storage Identifier` resolution and cache guidance
+are documented in [Data Access](../client/data.md).

--- a/docs/cli/logging.md
+++ b/docs/cli/logging.md
@@ -1,16 +1,12 @@
 # Logging
 
-CANFAR configures logging only at an explicit application entry point. The CLI
-does this once before dispatching a command. Python applications can call
-`canfar.configure_logging(...)` themselves; importing `canfar` does not configure
-handlers or consoles.
+The CLI configures Python standard-library logging once at the root entry
+point. Human logs use Rich on stderr. File logging is opt-in and writes a
+rotating JSON Lines file.
 
-Logging uses Python's standard `logging` library with Rich for human stderr
-output, plus an optional rotating JSON Lines file sink.
+## Controls and precedence
 
-## CLI controls and precedence
-
-Logging controls are root options, so put them before the command:
+Root controls must precede the command:
 
 ```bash
 canfar --log-level debug ps
@@ -18,98 +14,29 @@ canfar -vvv ps
 canfar --log-file ./logs/canfar.jsonl ps
 ```
 
-The supported controls are:
-
-| Control | Effect |
+| Control | Result |
 | --- | --- |
 | No CLI control | Use `CANFAR_LOGLEVEL`, or `critical` when it is unset. |
-| `-v` | `error` |
-| `-vv` | `warning` |
-| `-vvv` | `info` |
-| `-vvvv` or more | `debug` |
+| `-v` | `error`; `-vv` is `warning`; `-vvv` is `info`; `-vvvv` and above are `debug`. |
 | `--log-level LEVEL` | Select `critical`, `error`, `warning`, `info`, or `debug`. |
-| `--log-file PATH` | Add the rotating JSON Lines file sink described below. |
+| `--log-file PATH` | Add the rotating JSON Lines file sink. |
 
-Precedence is:
+Precedence is `--log-level`, repeated `-v`, `CANFAR_LOGLEVEL`, then the
+packaged `critical` default. Level names are case-insensitive. A value in
+`CANFAR_LOGLEVEL` is validated only when it is the effective source; unknown
+`CANFAR_*` variables do not affect logging.
 
-1. `--log-level`
-2. repeated `-v`
-3. `CANFAR_LOGLEVEL`
-4. the packaged default, `critical`
-
-`--log-level` therefore wins when it is combined with `-v`. Level names are
-case-insensitive.
-
-The machine-output option remains a leaf option after the command. For example:
+The machine-output option remains owned by the leaf command:
 
 ```bash
 canfar --log-level debug ps -o json
 ```
 
-The corresponding environment setting is:
+## Streams and machine output
 
-```bash
-CANFAR_LOGLEVEL=info canfar ps
-```
-
-Only the documented CANFAR logging variables affect this policy. Unknown
-CANFAR logging variables are ignored.
-
-## Python applications
-
-Call the same runtime seam explicitly in a Python application:
-
-```python
-from canfar import configure_logging
-
-configure_logging(loglevel="debug")
-```
-
-Calling `configure_logging()` without a level uses `CANFAR_LOGLEVEL`, then the
-packaged `critical` default. A Python process that never calls this function
-retains the logging configuration chosen by its application.
-
-To add a file sink, pass a `pathlib.Path`:
-
-```python
-from pathlib import Path
-
-from canfar import configure_logging
-
-configure_logging(
-    loglevel="info",
-    log_file=Path("logs/canfar.jsonl"),
-)
-```
-
-There is no per-`HTTPClient`, `Session`, or `AsyncSession` log-level setting.
-
-## HTTP request and response debug
-
-At `debug` (for example `--log-level debug` or `-vvvv`), every Science Platform
-HTTP call logs the request method and full URL, then the response status and
-body:
-
-```text
-DEBUG  GET https://ws-uv.canfar.net/skaha/v0/session?status=Running
-DEBUG  HTTP STATUS CODE -> 200
-[{"id":"...","status":"Running",...}]
-```
-
-These lines follow the normal logging policy: stderr (and the optional file
-sink), never mixed into `-o json`/`--output yaml` stdout payloads.
-
-## stdout and stderr
-
-CANFAR keeps command data separate from diagnostics:
-
-| Stream | Content |
-| --- | --- |
-| stdout | Human command results or the selected JSON/YAML data payload. |
-| stderr | Rich-oriented logs, warnings, and errors; structured diagnostics in machine mode. |
-
-JSON and YAML stdout remain data-only at every log level. Redirect the streams
-independently when a script needs both:
+Human command results go to stdout. Logs, warnings, and errors go to stderr.
+With `-o json` or `--output yaml`, stdout contains only the selected command
+payload; logs and structured diagnostics remain on stderr:
 
 ```bash
 canfar --log-level debug ps -o json \
@@ -117,86 +44,64 @@ canfar --log-level debug ps -o json \
   2> diagnostics.log
 ```
 
-In `-o json` or `--output yaml` mode, logging setup failures and file-sink warnings are
-serialized in the selected format on stderr. They never add a banner or log
-line to the command payload on stdout.
+Logging setup warnings use the selected machine format on stderr when a leaf
+output mode is present. They never add a banner or log record to the machine
+payload on stdout.
 
-## Rotating JSON Lines file sink
+At `debug`, Science Platform HTTP hooks log the request method and URL and the
+response status and body. These records follow the same stderr/file routing;
+do not enable debug logging if response bodies must remain private.
 
-File logging is opt-in. Use the root option or the Python `Path` argument shown
-above. Relative paths resolve from the current working directory, and missing
-parent directories are created.
+## JSON Lines file sink
 
-When enabled, events go to both stderr and the file. The file policy is fixed:
+File logging is enabled only with `--log-file PATH`. Relative paths resolve
+from the current working directory and missing parent directories are created.
+There is no default log file and no temporary-file fallback. `-` and an
+existing directory are invalid targets.
 
-- UTF-8 JSON Lines, one object per physical line;
-- size-based rotation at 10 MiB;
-- 10 backup files; and
-- escaped exception and stack text so a record never spans physical lines.
+The sink is UTF-8 JSON Lines with size-based rotation at 10 MiB and ten backup
+files. Each event contains:
 
-There is no default log file, configuration-file log path, or temporary-file
-fallback. In particular, CANFAR does not write `~/.canfar/client.log` unless
-that exact path is explicitly requested.
-
-An existing directory and the pseudo-target `-` are invalid file paths. Other
-initialization, write, or rollover failures disable only the file sink, keep
-stderr logging and command execution active, and emit one
-`logging.file_sink_unavailable` warning.
-
-### JSON Lines schema
-
-Every file event contains:
-
-| Field | Required | Meaning |
-| --- | --- | --- |
-| `timestamp` | Yes | UTC RFC3339 timestamp with `Z` suffix and millisecond precision. |
-| `level` | Yes | Logging level name, such as `INFO` or `ERROR`. |
-| `logger` | Yes | Logger name, such as `canfar.sessions`. |
-| `message` | Yes | Rendered message. |
-| `exception` | No | Escaped exception or stack text. |
-
-Example shape:
-
-```json
-{"timestamp":"2026-07-11T12:34:56.789Z","level":"INFO","logger":"canfar.sessions","message":"Session request accepted"}
-```
-
-Authentication Record secrets use Pydantic `SecretStr` and render as masked
-values in Configuration dumps. Do not log raw token or certificate material.
-
-## Stable logging diagnostics
-
-Logging diagnostics use stable dotted-domain codes:
-
-| Code | Behavior and details |
+| Field | Meaning |
 | --- | --- |
-| `logging.invalid_env_value` | Fatal setup error. Includes `env_var`, `provided_value`, and `expected`. |
-| `logging.invalid_file_path` | Fatal setup error for `-` or an existing directory. Includes the standard `code`, `message`, and `hint` fields. |
-| `logging.file_sink_unavailable` | Non-fatal warning for initialization, write, or rollover failure. The command continues with stderr logging; machine mode emits a structured warning on stderr. |
+| `timestamp` | UTC RFC3339 timestamp with millisecond precision and a `Z` suffix. |
+| `level` | Logging level such as `INFO` or `ERROR`. |
+| `logger` | Logger name such as `canfar.sessions`. |
+| `message` | Rendered message. |
+| `exception` | Escaped exception or stack text when present. |
 
-Fatal logging setup errors exit with status 2 before the command executes.
-The file-sink warning does not replace the command's normal exit status.
+One JSON object occupies one physical line. Authentication Record secrets are
+masked by their secret types; do not treat log output as a place to expose
+credential material.
 
-## Domain `--debug` flags
+## Setup diagnostics
 
-Root logging controls and command diagnostics are separate. These retained
-leaf flags have domain-specific meanings and do not select the logging level:
+| Code | Meaning |
+| --- | --- |
+| `logging.invalid_env_value` | `CANFAR_LOGLEVEL` is invalid. Setup stops before the command. |
+| `logging.invalid_file_path` | `--log-file` is `-` or an existing directory. Setup stops before the command. |
+| `logging.file_sink_unavailable` | The file sink cannot initialize, write, or rotate. The command continues with stderr logging. |
 
-| Command | `--debug` meaning |
+The first two are fatal setup errors and exit with status `2`. A file-sink
+failure is non-fatal and disables only that sink. In machine mode its warning
+is a structured payload on stderr; the command's normal exit status is kept.
+
+## Domain `--debug` options
+
+Root logging controls and command diagnostics are separate. These are the
+retained leaf `--debug` meanings:
+
+| Command | Meaning |
 | --- | --- |
 | `canfar version --debug` | Show environment and dependency details for a bug report. |
 | `canfar info SESSION_ID --debug` | Show Session response warnings. |
 | `canfar ps --debug` | Show Session response warnings. |
 | `canfar create KIND IMAGE --debug` | Print parsed Session request details. |
 
-Logging-only `--debug` flags were removed from `login`, `delete`, `events`,
-`logs`, `open`, `prune`, and `stats`.
-Use a root control instead:
+Other leaves do not use `--debug` as a logging switch. Use a root control,
+for example:
 
 ```bash
-canfar --log-level debug login cadc --force
-canfar --log-level debug info abc123 --debug
+canfar --log-level debug login srcnet
+canfar --log-level debug info SESSION_ID --debug
 ```
-
-The second example requests both debug-level logs and the independent Session
-response-anomaly details.

--- a/docs/cli/quick-start.md
+++ b/docs/cli/quick-start.md
@@ -1,131 +1,108 @@
-# CLI Quickstart
+# CLI quickstart
 
-Create a notebook Session from a terminal, open it, inspect it, and clean it up.
+This walkthrough logs in, launches a Session, checks it, opens it, and removes
+it. Replace `SESSION_ID` with the ID printed by `canfar create` or `canfar ps`.
 
-## 1. Install
-
-```bash
-pip install canfar --upgrade
-```
-
-## 2. Log in
+## Install and log in
 
 ```bash
+pip install --upgrade canfar
 canfar login cadc
 ```
 
-Use SRCNet when that is your IDP:
+Use SRCNet OIDC instead when that is your Identity Provider:
 
 ```bash
 canfar login srcnet
 ```
 
-Check the active Authentication and available Servers:
+Inspect the active Authentication and available Servers:
 
 ```bash
 canfar auth show
 canfar server ls
 ```
 
-## 3. Work with data
+For the OIDC Device Authorization steps, see [Authentication and Servers](authentication-contexts.md).
 
-The standard installation includes data commands. Use a configured Storage Identifier
-or the reserved `local` name with an absolute path. A default CADC login maps
-`arc` and `vault`:
+## Optional data check
 
-```bash
-canfar data ls -lh arc:/home/[username]
-canfar data cp local:/absolute/path/file.fits arc:/home/[username]/file.fits
-```
-
-Cross-source `mv` is unsupported. Copy the file, verify the destination, and
-then remove the source with a separate command:
+Use a configured Storage Identifier and an absolute path:
 
 ```bash
-canfar data cp vault:/folder/file.fits arc:/home/[username]/file.fits
-canfar data ls -lh arc:/home/[username]/file.fits
-canfar data rm vault:/folder/file.fits
+canfar data ls -lh arc:/home/user
 ```
 
-## 4. Create a notebook
+See [Data commands](data.md) for copy, recursive-copy, and cross-source
+workflows.
+
+## Create a notebook Session
 
 ```bash
 canfar create notebook skaha/astroml:latest
 ```
 
-The image shorthand `skaha/astroml:latest` resolves to the CANFAR image
-registry. Use the full image name when you want to be explicit:
-
-```bash
-canfar create notebook images.canfar.net/skaha/astroml:latest
-```
-
-## 5. Check status
-
-```bash
-canfar ps
-canfar info $(canfar ps -q)
-```
-
-Use machine output in scripts:
-
-```bash
-canfar ps -o json
-```
-
-## 6. Open the notebook
-
-```bash
-canfar open $(canfar ps -q)
-```
-
-Notebook Sessions usually take 60-120 seconds to become reachable.
-
-## 7. Inspect startup events
-
-```bash
-canfar events $(canfar ps -q)
-canfar logs $(canfar ps -q)
-```
-
-## 8. Clean up
-
-```bash
-canfar delete $(canfar ps -q)
-```
-
-Skip the confirmation prompt when you are scripting:
-
-```bash
-canfar delete $(canfar ps -q) --force
-```
-
-## Fixed resources
-
-Omit resources for flexible allocation. Set `--cpu`, `--memory`, or `--gpu`
-when you need fixed resources.
+The image shorthand is normalized to the CANFAR Container Registry. Fixed
+resources are optional:
 
 ```bash
 canfar create notebook skaha/astroml:latest --cpu 4 --memory 16
 ```
 
-## Headless job
-
-Use `--` before the command that should run inside the container.
+For a headless command, put the command delimiter before the container
+command. Every token after `--` belongs to that command:
 
 ```bash
 canfar create headless skaha/terminal:1.1.2 -- python /arc/projects/demo/run.py
 ```
 
+## Check and open the Session
+
+```bash
+canfar ps
+canfar info SESSION_ID
+canfar open SESSION_ID
+```
+
+`ps` shows `Pending` and `Running` Sessions by default. Use `--all` for every
+status, or `-o json` when a script needs a data-only payload:
+
+```bash
+canfar ps --all
+canfar ps -o json
+```
+
+`ps -q` is a human-only ID shortcut and can include the active-Server banner;
+use machine output when passing results between tools.
+
+Inspect startup events or logs when a Session is not ready:
+
+```bash
+canfar events SESSION_ID
+canfar logs SESSION_ID
+```
+
+## Remove the Session
+
+```bash
+canfar delete SESSION_ID
+```
+
+The command asks for confirmation. Use `--force` in a controlled script:
+
+```bash
+canfar delete SESSION_ID --force
+```
+
 ## Troubleshooting
 
-| Symptom | Command |
-| --- | --- |
-| Need fresh credentials | `canfar --log-level debug login cadc --force` |
-| Need another Server | `canfar server ls` then `canfar server use <name-or-uri>` |
-| Session is pending | `canfar events $(canfar ps -q)` |
-| Need cluster capacity | `canfar stats` |
-| Need structured output | `canfar ps -o json` |
+Put logging controls before the command:
 
-Logging controls belong before the command. See
-[Logging and observability](logging.md) for the complete policy.
+```bash
+canfar --log-level debug login cadc --force
+canfar --log-level debug ps
+```
+
+See [Logging](logging.md) for level precedence, stderr routing, and the
+optional JSON Lines file sink. See the [CLI reference](cli-help.md) for every
+leaf and option.


### PR DESCRIPTION
## Summary

- audit all five CLI documentation pages against the shipped Typer command surface and actual help
- document canonical root leaves/groups, authentication and Server Selection, Session operations, data commands, logging, and configuration
- lock the leaf-only json/yaml output contract, data-only stdout, normal filtering, and create's delimiter boundary
- remove stale aliases, options, fallback behavior, repetition, and speculative prose

## Validation

- 245 focused CLI tests passed.
- Deterministic non-slow suite: 854 passed.
- Actual help/example probes and removed-alias checks passed.
- MkDocs build passed.
- Internal link targets and git diff check passed.

5 CLI documentation files: +389 / -569 lines.

Partial implementation of #261; Python client and platform/site lanes are separate Wave 7 PRs.
