### PR TITLE
fix(cli): document ps default status filter

### DIFF
--- a/canfar/cli/ps.py
+++ b/canfar/cli/ps.py
@@ -153,7 +153,7 @@ def show(
     everything: Annotated[
         bool,
         typer.Option(
-            "--all", "-a", help="Show all sessions (default shows just running)."
+            "--all", "-a", help="Show all sessions (default shows Pending and Running)."
         ),
     ] = False,
     quiet: Annotated[

--- a/tests/test_cli_stats_ps.py
+++ b/tests/test_cli_stats_ps.py
@@ -6,6 +6,7 @@ import json
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import click
 import pytest
 import yaml
 from typer.testing import CliRunner
@@ -90,7 +91,7 @@ def test_ps_help_describes_default_status_filter() -> None:
     result = runner.invoke(cli, ["ps", "--help"])
 
     assert result.exit_code == 0
-    help_text = " ".join(result.stdout.replace("│", " ").split())
+    help_text = " ".join(click.unstyle(result.output).replace("│", " ").split())
     assert "default shows Pending and Running" in help_text
 
 

--- a/tests/test_cli_stats_ps.py
+++ b/tests/test_cli_stats_ps.py
@@ -85,6 +85,15 @@ def test_ps_command_help() -> None:
     assert result.exit_code == 0
 
 
+def test_ps_help_describes_default_status_filter() -> None:
+    """Test ps help names the statuses shown by the default filter."""
+    result = runner.invoke(cli, ["ps", "--help"])
+
+    assert result.exit_code == 0
+    help_text = " ".join(result.stdout.replace("│", " ").split())
+    assert "default shows Pending and Running" in help_text
+
+
 def test_ps_outputs_running_table_and_debug_anomalies() -> None:
     """Test ps table rendering with debug anomaly output."""
     payloads = [


### PR DESCRIPTION
## Summary
- make the canfar ps --all help text match the shipped default filter
- lock Pending plus Running behavior through the public CliRunner help seam

## Validation
- focused CLI tests: 43 passed
- deterministic non-slow suite: 855 passed
- Ruff: clean
- ty: clean
- MkDocs: successful

Part of #261 and #244.