### PR TITLE
docs(client): close filesystem examples

### DIFF
--- a/docs/client/advanced-examples.md
+++ b/docs/client/advanced-examples.md
@@ -96,10 +96,13 @@ from canfar.helpers import distributed
 
 paths = ["/project/observations/a.fits", "/project/observations/b.fits"]
 
-with filesystem("vault") as vault:
+vault = filesystem("vault")
+try:
     for path in distributed.chunk(paths):
         raw = vault.cat_file(path)
         print(path, len(raw))
+finally:
+    vault.close()
 ```
 
 For staged or memory-mapped access, use an explicit fsspec cache or

--- a/docs/client/data.md
+++ b/docs/client/data.md
@@ -16,18 +16,19 @@ from canfar.storage import filesystem, identifiers
 
 available = identifiers()          # e.g. ["arc", "vault", "local"]
 
-with filesystem("vault") as vault:
+vault = filesystem("vault")
+try:
     path = "/ALMA/test-data/cutouts/test-4d-cube-cutout.fits"
     print(vault.info(path)["size"])
     raw = vault.cat_file(path)
-
-local = filesystem("local")        # the machine running this code
+finally:
+    vault.close()
 ```
 
-`local` is always available and does not require a credential. Every other
-identifier must be present in the saved Configuration. The returned object is a
-normal synchronous fsspec filesystem; use its standard methods rather than a
-CANFAR-specific wrapper.
+The `local` identifier is always available and does not require a credential.
+Every other identifier must be present in the saved Configuration. The returned
+object is a normal synchronous fsspec filesystem; use its standard methods
+rather than a CANFAR-specific wrapper.
 
 `filesystem()` accepts runtime credentials when a caller must override saved
 state. A non-empty `token` takes precedence over a saved Authentication Record;
@@ -38,7 +39,18 @@ used only for that filesystem and do not rewrite the saved Configuration.
 from canfar.storage import filesystem
 
 vault = filesystem("vault", token="runtime-bearer-token")
+try:
+    # use vault here
+    ...
+finally:
+    vault.close()
+
 archive = filesystem("arc", certificate="/path/to/cadcproxy.pem")
+try:
+    # use archive here
+    ...
+finally:
+    archive.close()
 ```
 
 An unknown Storage Identifier raises `KeyError`. If a saved credential is
@@ -53,7 +65,8 @@ Storage operations use the ordinary fsspec vocabulary:
 ```python
 from canfar.storage import filesystem
 
-with filesystem("vault") as vault:
+vault = filesystem("vault")
+try:
     directory = "/ALMA/test-data/cutouts"
     target = f"{directory}/test-4d-cube-cutout.fits"
 
@@ -69,6 +82,8 @@ with filesystem("vault") as vault:
 
     with vault.open(target, "rb") as handle:
         first_bytes = handle.read(80)
+finally:
+    vault.close()
 ```
 
 `cat_file(path, start, end)` returns the requested slice. Whether the VOSpace
@@ -81,9 +96,12 @@ VOSpace writes use the corresponding fsspec methods (`put_file`, `pipe_file`,
 `mkdir`, and `rm`) when the authenticated account has permission:
 
 ```python
-with filesystem("vault") as vault:
+vault = filesystem("vault")
+try:
     vault.pipe_file("/tmp/example.txt", b"hello CANFAR\n")
     vault.rm("/tmp/example.txt")
+finally:
+    vault.close()
 ```
 
 Directory listings use an in-memory fsspec listing cache for the lifetime of
@@ -99,11 +117,14 @@ responsibility:
 ```python
 from canfar.storage import filesystem
 
-with filesystem("vault") as vault:
+vault = filesystem("vault")
+try:
     vault.get_file(
         "/ALMA/test-data/cutouts/test-4d-cube-cutout.fits",
         "/scratch/cutout.fits",
     )
+finally:
+    vault.close()
 ```
 
 For example, a local path can then be opened by a memory-mapping library:
@@ -129,16 +150,21 @@ from fsspec.implementations.cached import SimpleCacheFileSystem
 from canfar.storage import filesystem
 
 remote = filesystem("vault")
-cached = SimpleCacheFileSystem(
-    fs=remote,
-    cache_storage="/scratch/canfar-vault",
-)
-cached.cat_file("/ALMA/test-data/cutouts/test-4d-cube-cutout.fits")
+try:
+    cached = SimpleCacheFileSystem(
+        fs=remote,
+        cache_storage="/scratch/canfar-vault",
+    )
+    cached.cat_file("/ALMA/test-data/cutouts/test-4d-cube-cutout.fits")
+finally:
+    remote.close()
 ```
 
 One whole-file cache layer is the supported simple choice. Do not stack cache
 wrappers, pass a URL as `cache_storage`, or advertise `blockcache`: the staged
-VOSpace file object does not provide the fsspec block-cache interface.
+VOSpace file object does not provide the fsspec block-cache interface. The
+cache wrapper forwards `close()` only when its wrapped filesystem provides it,
+so close the known VOSpace client (`remote`) explicitly.
 
 ## Python API boundary
 

--- a/docs/client/home.md
+++ b/docs/client/home.md
@@ -34,8 +34,8 @@ by Python clients. Python OIDC login is also available as `canfar.login()` and
 
 -   **Inspect platform state**
 
-    Query available resources, Container Images, and Science Platform
-    availability.
+    Query available resources, Container Images, and Science Platform Server
+    capacity.
 
     [:octicons-arrow-right-16: Python API reference](session.md)
 
@@ -83,7 +83,7 @@ async def main() -> None:
 | `canfar.images` | List Container Images or fetch parsed image details. |
 | `canfar.storage` | List Storage Identifiers and build explicit fsspec filesystems. |
 | `canfar.context` | Read resource limits advertised by a Science Platform Server. |
-| `canfar.overview` | Check Science Platform availability. |
+| `canfar.overview` | Check Science Platform Server capacity. |
 | `canfar.authentication` | Login and manage saved Authentication Records. |
 | `canfar.client` | Compose lower-level synchronous or asynchronous HTTP clients. |
 

--- a/docs/client/migration.md
+++ b/docs/client/migration.md
@@ -68,8 +68,11 @@ explicit Storage Identifiers:
 from canfar.storage import filesystem, identifiers
 
 print(identifiers())
-with filesystem("vault") as vault:
+vault = filesystem("vault")
+try:
     data = vault.cat_file("/project/observations/example.fits")
+finally:
+    vault.close()
 ```
 
 Storage Identifiers are not dynamic module members or fsspec schemes. See


### PR DESCRIPTION
## Summary
- replace invalid direct filesystem context-manager examples with the lifecycle guaranteed by configured vosfs filesystems
- close every configured remote filesystem explicitly while keeping local fsspec behavior generic
- document cache-wrapper ownership without inventing a generic close contract
- align remaining client wording with Science Platform Server terminology

## Validation
- 54 Python fences compile
- filesystem lifecycle assertions: pass
- focused tests: 1 passed, 1 skipped
- deterministic non-slow suite: 854 passed
- Ruff: clean
- ty: clean
- MkDocs: successful; existing external GitHub 403 warning only

Part of #261 and #244.