### PR TITLE
docs: resolve wave 7 review findings

### DIFF
--- a/docs/client/advanced-examples.md
+++ b/docs/client/advanced-examples.md
@@ -25,25 +25,9 @@ async def launch_batch() -> list[str]:
         )
 ```
 
-Pass `cores` and `ram` when every replica needs fixed resources:
-
-```python
-from canfar.sessions import AsyncSession
-
-
-async def launch_fixed_batch() -> list[str]:
-    async with AsyncSession() as session:
-        return await session.create(
-            name="fits-processing",
-            image="images.canfar.net/project/analysis:latest",
-            kind="headless",
-            cores=8,
-            ram=32,
-            cmd="python",
-            args="/app/process_observations.py",
-            replicas=100,
-        )
-```
+Omitting `cores` and `ram` keeps each replica on the platform's flexible
+allocation policy. Add both arguments to the same `create()` call (for example,
+`cores=8, ram=32`) when every replica needs a fixed resource allocation.
 
 The return value contains only successfully launched Session IDs. Check for an
 empty list before treating the batch as submitted.

--- a/docs/client/examples.md
+++ b/docs/client/examples.md
@@ -166,7 +166,7 @@ config = Configuration(
 )
 with Session(config=config) as session:
     ids = session.create(
-        name="private-job",
+        name="private-session",
         image="images.canfar.net/project/private-image:latest",
         kind="headless",
         cmd="python",

--- a/docs/client/home.md
+++ b/docs/client/home.md
@@ -67,7 +67,7 @@ async def main() -> None:
         ids = await session.create(
             kind="headless",
             image="images.canfar.net/skaha/astroml:latest",
-            name="batch-job",
+            name="batch-session",
             cmd="python",
             args="/arc/projects/demo/run.py",
         )

--- a/docs/client/migration.md
+++ b/docs/client/migration.md
@@ -22,7 +22,7 @@ from canfar.sessions import Session
 
 with Session() as session:
     ids = session.create(
-        name="migrated-job",
+        name="migrated-session",
         image="images.canfar.net/skaha/terminal:latest",
     )
 ```

--- a/docs/demos/srcnet-workshop.md
+++ b/docs/demos/srcnet-workshop.md
@@ -5,7 +5,7 @@
 
     - **Run code on the cloud** without complex setup.
     - Use familiar tools like **Jupyter Notebooks**.
-    - Scale their analysis from a single interactive session to **hundreds of parallel jobs**.
+    - Scale their analysis from a single interactive Session to **hundreds of parallel Sessions**.
     - **Process large datasets** efficiently.
 
     **Whether you're new to coding or a seasoned power-user, these tools are designed to be intuitive and powerful.**
@@ -147,7 +147,7 @@ canfar create headless IMAGE_NAME -- python echo.py
 !!! tip "Interactive to Batch, Seamlessly"
     You can develop your analysis interactively in a **notebook** session, save your code to a python script, and then run it at scale using a **headless** session. **No changes to your environment are needed.**
 
-To check the output of your headless job, you can use the `logs` command.
+To check the output of your headless Session, you can use the `logs` command.
 
 ```bash
 canfar logs <SESSION_ID>
@@ -157,7 +157,7 @@ canfar logs <SESSION_ID>
 
 ## Scaling Up: From One to Many
 
-Need to process hundreds of files? You can launch multiple copies (replicas) of your headless job with a single command.
+Need to process hundreds of files? You can launch multiple copies (replicas) of your headless Session with a single command.
 
 ```bash
 canfar create --replicas 10 headless IMAGE_NAME -- python echo.py
@@ -169,7 +169,7 @@ You now have 10 containers in parallel. But how do you divide the work?
 
 ## The Python Client: Distributing Your Workload
 
-For complex logic like distributing data across many jobs, we switch to the `canfar` Python Client.
+For complex logic like distributing data across many Sessions, we switch to the `canfar` Python Client.
 
 ### The Problem
 
@@ -208,9 +208,9 @@ print("Done!")
 
 ## Putting It All Together: A Complete Workflow
 
-Here is the complete workflow, from launching jobs programmatically to processing data in parallel.
+Here is the complete workflow, from launching Sessions programmatically to processing data in parallel.
 
-```python title="Launching Jobs Programmatically"
+```python title="Launching Sessions Programmatically"
 from canfar.sessions import Session
 
 # This uses the same Authentication from `canfar login`
@@ -225,5 +225,5 @@ with Session() as session:
         replicas=100,
     )
 
-print(f"Successfully launched {len(ids)} processing jobs!")
+print(f"Successfully launched {len(ids)} processing Sessions!")
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ hide:
     <h3>
     **Canadian Advanced Network for Astronomical Research is a scalable, cloud-native workspace for astronomy research.**
  
-    *Spin up JupyterLab, submit batch jobs, and collaborate in shared project spaces. <br> The CANFAR Science Platform gives researchers the tools they need with minimal setup.*
+    *Spin up JupyterLab, submit batch Sessions, and collaborate in shared project spaces. <br> The CANFAR Science Platform gives researchers the tools they need with minimal setup.*
     </h3>
     </center>
     
@@ -53,4 +53,3 @@ hide:
     <span style="font-family: 'Roboto Mono', monospace; font-size: 12px; font-style: italic;">
     The authors acknowledge the use of the Canadian Advanced Network for Astronomy Research (CANFAR) Science Platform operated by the Canadian Astronomy Data Centre (CADC) and the Digital Research Alliance of Canada, with support from the National Research Council of Canada (NRC), the Canadian Space Agency (CSA), CANARIE, and the Canadian Foundation for Innovation (CFI).
     </span>
-

--- a/docs/platform/sessions/batch.md
+++ b/docs/platform/sessions/batch.md
@@ -6,7 +6,7 @@ container and mounted-storage environment as an interactive Session; only the
 entrypoint and lifecycle differ.
 
 This page keeps the guidance requested in [#209](https://github.com/opencadc/canfar/issues/209):
-creation output, `Pending` status, queue expectations, and checks for a job that
+creation output, `Pending` status, queue expectations, and checks for a Session that
 does not start.
 
 ## Submit a headless Session
@@ -87,7 +87,7 @@ opens a Session once it is ready.
 
 The client does not promise a relative priority between `headless` and
 interactive Sessions. Queue order and admission policy are deployment-owned;
-do not assume that a headless job will outrank an interactive Session, or that
+do not assume that a headless Session will outrank an interactive Session, or that
 increasing a request will make it run sooner. If queue policy matters for a
 project, ask the platform operator for the current policy.
 

--- a/docs/platform/storage/filesystem.md
+++ b/docs/platform/storage/filesystem.md
@@ -3,72 +3,36 @@
 Use a normal `/arc` path inside a Science Platform Session whenever the data is
 already mounted. Use `canfar.storage` when Python is running outside the
 Session, or when the object lives in a configured VOSpace Service. The module
-keeps the CANFAR-owned work—Storage Identifier lookup and Authentication
-Record materialization—at one explicit boundary and returns the upstream
-fsspec filesystem for everything else.
+keeps the CANFAR-owned work at one explicit boundary and returns the upstream
+fsspec filesystem for everything else. The [Python client data
+guide](../../client/data.md) is the canonical contract for Storage Identifier
+lookup, credential selection, fsspec operations, local staging, and
+`SimpleCacheFileSystem`.
 
 ## Construct a filesystem explicitly
 
-```python
-from canfar.storage import filesystem, identifiers
-
-names = identifiers()
-print(names)  # configured Storage Identifiers, plus "local"
-
-remote = filesystem("vault")
-try:
-    print(remote.ls("/project", detail=False))
-finally:
-    remote.close()
-```
-
-`filesystem(identifier)` accepts one configured Storage Identifier. The reserved
-identifier `local` returns the local fsspec filesystem and does not use CANFAR
-credentials:
-
-```python
-from canfar.storage import filesystem
-
-local = filesystem("local")
-with local.open("/scratch/result.txt", "w") as handle:
-    handle.write("done\n")
-```
-
-Configured identifiers are resolved when `filesystem()` is called. Saved
-X.509 credentials are validated and saved OIDC records may be refreshed before
-the literal credential is handed to `vosfs`. A runtime `token=` or
-`certificate=` can be supplied when the application owns the credential:
-
-```python
-remote = filesystem("vault", certificate="/path/to/cadcproxy.pem")
-try:
-    data = remote.cat_file("/project/table.csv")
-finally:
-    remote.close()
-```
-
-The identifier is an argument, not a dynamically imported member. CANFAR does
-not register `vault://`, `arc://`, or arbitrary configured names as process-wide
-fsspec protocols, and there is no `storage.configure()` call. This keeps
-configuration lookup visible and leaves fsspec operations portable to workers.
+See [Find and open a Storage Identifier](../../client/data.md#find-and-open-a-storage-identifier)
+for the construction examples and the complete contract, including the
+reserved `local` identifier, runtime credentials, saved Authentication Records,
+error behavior, and the fact that identifiers are explicit arguments rather
+than dynamic fsspec schemes.
 
 ## Read shape and backend capability
 
-There are two distinct ways to read a remote object:
+The [client data guide](../../client/data.md#standard-fsspec-operations) defines
+the supported read methods and staging behavior. This page adds the
+deployment-specific capability guidance:
 
-1. `cat_file(path, start, end)` or `cat_ranges(...)` requests explicit bytes.
-   `vosfs` validates a ranged `206` response and falls back to a complete
-   response when the service does not provide ranges. A successful call is
-   therefore correct on both kinds of backend, but a fallback still transfers
-   the whole object.
-2. `open(path, "rb")` gives a seekable file-like object backed by a staged local
-   copy. It is convenient for libraries, but it is not a network-efficient
-   random-access reader: opening it stages the complete object.
+- `vosfs` validates a ranged `206` response for explicit byte reads and falls
+  back to a complete response when the service does not provide ranges. A
+  successful call is therefore correct on both kinds of backend, but a fallback
+  still transfers the whole object.
+- The read-only CADC measurements used for this guide saw validated ranges from
+  Vault/minoc and whole-object fallback from ARC/Cavern.
 
 The response capability belongs to the deployment, not the name `vault` or
-`arc`. The read-only CADC measurements used for this guide saw validated ranges
-from Vault/minoc and whole-object fallback from ARC/Cavern. Treat another
-deployment or Storage Identifier as unknown until its responses are observed.
+`arc`. Treat another deployment or Storage Identifier as unknown until its
+responses are observed.
 
 For data already mounted at `/arc`, use the path directly. For remote data used
 once, a single explicit transfer is often clearer:
@@ -79,37 +43,20 @@ canfar data cp vault:/project/cube.fits local:/scratch/cube.fits
 
 ## Ephemeral and persistent caches
 
-`filesystem()` does not enable a content cache. The fsspec directory-listing
-cache used by the constructed VOSpace filesystem is separate from object-byte
-caching. Select one content cache explicitly when repeated reads justify it.
+The [client data guide's content-caching
+contract](../../client/data.md#content-caching) explains the distinction between
+the fsspec directory-listing cache and object-byte caching. Select one content
+cache explicitly when repeated reads justify it.
 
 ### Session-local cache
 
-`SimpleCacheFileSystem` stores complete objects in the directory you choose.
-`/scratch` is a useful default inside a Science Platform Session because it is
-local and is deleted with the Session. Key the directory by Storage Identifier
-so objects from different endpoints cannot collide:
-
-```python
-from fsspec.implementations.cached import SimpleCacheFileSystem
-
-from canfar.storage import filesystem
-
-remote = filesystem("vault")
-cached = SimpleCacheFileSystem(
-    fs=remote,
-    cache_storage="/scratch/canfar-cache/vault",
-)
-try:
-    with cached.open("/project/cube.fits", "rb") as handle:
-        process(handle)
-finally:
-    remote.close()
-```
-
-This is opt-in. It does not make a staged file into a ranged reader, and it
-does not survive Session deletion. Remove the cache when its data is no longer
-needed or when `/scratch` is under pressure.
+See the [client data guide's SimpleCache example](../../client/data.md#content-caching)
+for the supported whole-file composition. `/scratch` is a useful default inside
+a Science Platform Session because it is local and is deleted with the Session.
+Key the directory by Storage Identifier so objects from different endpoints
+cannot collide. This cache is opt-in, does not make a staged file into a ranged
+reader, and does not survive Session deletion; remove it when its data is no
+longer needed or when `/scratch` is under pressure.
 
 ### Persistent cache
 

--- a/docs/platform/storage/filesystem.md
+++ b/docs/platform/storage/filesystem.md
@@ -71,13 +71,13 @@ from fsspec.implementations.cached import WholeFileCacheFileSystem
 from canfar.storage import filesystem
 
 remote = filesystem("vault")
-cached = WholeFileCacheFileSystem(
-    fs=remote,
-    cache_storage="/arc/home/<user>/.cache/canfar/vault",
-    expiry_time=24 * 60 * 60,
-    check_files=True,
-)
 try:
+    cached = WholeFileCacheFileSystem(
+        fs=remote,
+        cache_storage="/arc/home/<user>/.cache/canfar/vault",
+        expiry_time=24 * 60 * 60,
+        check_files=True,
+    )
     with cached.open("/project/catalog.csv", "rb") as handle:
         process(handle)
 finally:

--- a/tests/test_cli_stats_ps.py
+++ b/tests/test_cli_stats_ps.py
@@ -80,12 +80,6 @@ def test_stats_command_help() -> None:
     assert result.exit_code == 0
 
 
-def test_ps_command_help() -> None:
-    """Test ps command help executes successfully."""
-    result = runner.invoke(cli, ["ps", "--help"])
-    assert result.exit_code == 0
-
-
 def test_ps_help_describes_default_status_filter() -> None:
     """Test ps help names the statuses shown by the default filter."""
     result = runner.invoke(cli, ["ps", "--help"])


### PR DESCRIPTION
## Summary
- use Session terminology consistently across user-facing documentation
- make the client data guide the single authority for filesystem construction, credentials, staging, and SimpleCache behavior
- retain platform-specific backend capability, persistent-cache, scratch, and scientific-tool guidance without duplicating the API contract
- collapse the duplicate fixed-resource replica example
- remove the redundant ps help test and preserve the semantic assertion
- close the remote filesystem if persistent-cache construction fails

## Validation
- 14 focused tests passed
- deterministic non-slow suite: 854 passed
- 68 Python fences compiled
- 392 links and 4 local images checked
- no user-facing Job or jobs terminology remains
- Ruff: clean
- ty: clean
- MkDocs: successful; existing external git-committers 403 only

Resolves the Wave 7 Standards and Simplify checkpoint findings for #261 and #244.