### PR TITLE
refactor(auth): share OIDC coordinator policy and align glossary

### DIFF
--- a/canfar/auth/oidc.py
+++ b/canfar/auth/oidc.py
@@ -163,14 +163,39 @@ def _userinfo_username(response: httpx.Response) -> str | None:
     return response.json().get("preferred_username")
 
 
-def _set_discovered_endpoints(
+def _apply_discovery(
     credential: OIDCCredential,
     discovery: dict[str, Any],
 ) -> None:
-    """Install Identity Provider endpoints while preserving the credential object."""
+    """Apply discovered Identity Provider endpoints and log their values."""
     credential.endpoints.device = discovery["device_authorization_endpoint"]
     credential.endpoints.registration = discovery["registration_endpoint"]
     credential.endpoints.token = discovery["token_endpoint"]
+    log.debug("Discovered OIDC configuration:")
+    log.debug("Device Registration Endpoint: %s", credential.endpoints.registration)
+    log.debug("Device Authorization Endpoint: %s", credential.endpoints.device)
+    log.debug("Token Endpoint: %s", credential.endpoints.token)
+
+
+def _install_client_credentials(
+    credential: OIDCCredential,
+    device: Any,
+) -> tuple[str, str]:
+    """Install registered client credentials and return their values."""
+    identity, secret = _client_credentials(device)
+    credential.client.identity = identity
+    credential.client.secret = SecretStr(secret)
+    return identity, secret
+
+
+def _finalize_authentication(
+    response: httpx.Response,
+    on_authenticated: Callable[[str | None], None] | None,
+) -> None:
+    """Validate UserInfo and notify observers of the authenticated username."""
+    username = _userinfo_username(response)
+    if on_authenticated is not None:
+        on_authenticated(username)
 
 
 async def discover(
@@ -641,19 +666,12 @@ async def authenticate_credential(
             client,
             expected_issuer=expected_issuer,
         )
-        _set_discovered_endpoints(credential, response)
-
-        log.debug("Discovered OIDC configuration:")
-        log.debug("Device Registration Endpoint: %s", credential.endpoints.registration)
-        log.debug("Device Authorization Endpoint: %s", credential.endpoints.device)
-        log.debug("Token Endpoint: %s", credential.endpoints.token)
+        _apply_discovery(credential, response)
 
         device: dict[str, Any] = await register(
             str(credential.endpoints.registration), client
         )
-        identity, client_secret = _client_credentials(device)
-        credential.client.identity = identity
-        credential.client.secret = SecretStr(client_secret)
+        identity, client_secret = _install_client_credentials(credential, device)
 
         from authlib.integrations.httpx_client import (  # noqa: PLC0415
             AsyncOAuth2Client,
@@ -696,9 +714,7 @@ async def authenticate_credential(
 
         url: str = response["userinfo_endpoint"]
         user = await client.get(url, headers=_userinfo_headers(credential))
-        username = _userinfo_username(user)
-        if on_authenticated is not None:
-            on_authenticated(username)
+        _finalize_authentication(user, on_authenticated)
         return credential
 
 
@@ -860,17 +876,10 @@ def sync_authenticate_credential(
             client,
             expected_issuer=expected_issuer,
         )
-        _set_discovered_endpoints(credential, response)
-
-        log.debug("Discovered OIDC configuration:")
-        log.debug("Device Registration Endpoint: %s", credential.endpoints.registration)
-        log.debug("Device Authorization Endpoint: %s", credential.endpoints.device)
-        log.debug("Token Endpoint: %s", credential.endpoints.token)
+        _apply_discovery(credential, response)
 
         device = sync_register(str(credential.endpoints.registration), client)
-        identity, client_secret = _client_credentials(device)
-        credential.client.identity = identity
-        credential.client.secret = SecretStr(client_secret)
+        identity, client_secret = _install_client_credentials(credential, device)
 
         if request_timeout is None:
             oauth_context = OAuth2Client(
@@ -908,7 +917,5 @@ def sync_authenticate_credential(
 
         url: str = response["userinfo_endpoint"]
         user = client.get(url, headers=_userinfo_headers(credential))
-        username = _userinfo_username(user)
-        if on_authenticated is not None:
-            on_authenticated(username)
+        _finalize_authentication(user, on_authenticated)
         return credential

--- a/docs/platform/permissions.md
+++ b/docs/platform/permissions.md
@@ -7,7 +7,7 @@ login does not grant access to every server, project, image, or data object.
 
 ## Identity and server access
 
-Authenticate with the identity provider that owns the target server:
+Authenticate with the Identity Provider (IDP) that owns the target Science Platform Server:
 
 ```bash
 canfar login cadc

--- a/docs/platform/support/index.md
+++ b/docs/platform/support/index.md
@@ -26,7 +26,7 @@ canfar server use SERVER_NAME
 canfar config get active.server -o json
 ```
 
-Use the identity provider and Server Name supplied by your platform operator.
+Use the Identity Provider (IDP) and Server Name supplied by your platform operator.
 Do not paste certificates, tokens, or passwords into a support request.
 
 ### A Session is not ready
@@ -72,7 +72,7 @@ Email [support@canfar.net](mailto:support@canfar.net) for account access,
 project membership, persistent data errors, service outages, or a Session that
 remains Pending after the platform's normal queue interval. Include:
 
-- the Server Name and identity provider;
+- the Server Name and Identity Provider (IDP);
 - the command or UI action, with paths and image references redacted as needed;
 - the Session ID and status, if applicable;
 - the time and timezone;

--- a/tests/test_auth_oidc_authenticate.py
+++ b/tests/test_auth_oidc_authenticate.py
@@ -21,6 +21,7 @@ class TestAuthenticateCredentialFunction:
         *,
         credential: OIDCCredential | None = None,
         userinfo_error: Exception | None = None,
+        authenticated: list[str | None] | None = None,
     ) -> OIDCCredential:
         credential = credential or OIDCCredential(
             idp="test",
@@ -66,6 +67,9 @@ class TestAuthenticateCredentialFunction:
                 credential,
                 expected_issuer="https://example.com",
                 device_flow=AsyncMock(return_value=tokens),
+                on_authenticated=(
+                    authenticated.append if authenticated is not None else None
+                ),
             )
 
     @pytest.mark.asyncio
@@ -131,6 +135,18 @@ class TestAuthenticateCredentialFunction:
         assert result.token.refresh.get_secret_value() == "test_refresh_token"
         assert result.expiry.access == 1234567890
         assert result.expiry.refresh is None
+
+    @pytest.mark.asyncio
+    async def test_authenticate_notifies_authenticated_username(self) -> None:
+        """Authentication reports the same UserInfo username as the sync flow."""
+        authenticated: list[str | None] = []
+
+        await self._authenticate_with_tokens(
+            {"access_token": "test_access_token"},
+            authenticated=authenticated,
+        )
+
+        assert authenticated == ["testuser"]
 
     @pytest.mark.asyncio
     async def test_authenticate_accepts_token_without_refresh_token(self) -> None:

--- a/tests/test_auth_oidc_sync.py
+++ b/tests/test_auth_oidc_sync.py
@@ -202,6 +202,7 @@ def test_sync_authenticate_credential_runs_complete_native_flow() -> None:
         "expires_at": 1893456000,
     }
     presented: list[DeviceAuthorization] = []
+    authenticated: list[str | None] = []
 
     with (
         patch("canfar.auth.oidc.httpx.Client") as client_class,
@@ -214,6 +215,7 @@ def test_sync_authenticate_credential_runs_complete_native_flow() -> None:
             credential,
             expected_issuer="https://example.com",
             on_challenge=presented.append,
+            on_authenticated=authenticated.append,
         )
 
     assert result.client.identity == "client-id"
@@ -221,6 +223,7 @@ def test_sync_authenticate_credential_runs_complete_native_flow() -> None:
     assert result.token.access == SecretStr("access-token")
     assert result.token.refresh == SecretStr("refresh-token")
     assert presented[0].user_code == SecretStr("ABC123")
+    assert authenticated == ["test-user"]
     sync_client.get.assert_any_call(
         "https://example.com/.well-known/openid-configuration"
     )


### PR DESCRIPTION
## Summary

- Share the identical OIDC coordinator policy for discovery application/logging, registered-client credential installation, and UserInfo notification while retaining native async and sync transports.
- Add async/sync authenticated-user callback parity coverage.
- Align the requested platform docs with `Identity Provider (IDP)`, `Science Platform Server`, and `Server Name` terminology.

## Validation

- `uv run --no-sync pytest tests/test_auth_oidc_authenticate.py tests/test_auth_oidc_sync.py --no-cov -q` (11 passed)
- `uv run --no-sync pytest tests -m 'not slow' --no-cov -q` (855 passed)
- `uv run --no-sync ruff check . --no-cache`
- `uv run ty check canfar`
- `uv run --group docs mkdocs build` (build completed; existing git-committers rate-limit warning)

Target branch is `feat/interfaces`; this draft is intentionally not merged or submitted for review.
