### PR TITLE
test(client): replace private helper assertions with request contracts

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,8 +1,5 @@
 """Test CANFAR Python Client API."""
-# ruff: noqa: SLF001
 
-import re
-import ssl
 import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -18,6 +15,7 @@ from cryptography.x509.oid import NameOID
 from pydantic import AnyUrl, SecretStr, ValidationError
 
 from canfar.client import HTTPClient
+from canfar.exceptions.context import AuthExpiredError
 from canfar.models.auth import X509Credential
 from canfar.models.config import Configuration
 from canfar.models.http import Server
@@ -37,26 +35,24 @@ def canfar_client_fixture():
     return _create_client
 
 
-@pytest.fixture
-def mock_httpx_client():
-    """Mock httpx.Client to prevent actual network calls."""
-    with patch("httpx.Client") as mock_client:
-        yield mock_client
+def _sync_client_factory(transport: httpx.BaseTransport):
+    """Build native sync HTTPX clients over a supplied transport."""
+    return lambda **kwargs: httpx.Client(transport=transport, **kwargs)
 
 
-@pytest.fixture
-def mock_httpx_async_client():
-    """Mock httpx.AsyncClient to prevent actual network calls."""
-    with patch("httpx.AsyncClient") as mock_async_client:
-        yield mock_async_client
+def _async_client_factory(transport: httpx.BaseTransport):
+    """Build native async HTTPX clients over a supplied transport."""
+    return lambda **kwargs: httpx.AsyncClient(transport=transport, **kwargs)
 
 
-@pytest.fixture
-def mock_cryptography():
-    """Mock cryptography functions for certificate validation."""
-    with patch("canfar.auth.x509.inspect") as mock_inspect:
-        mock_inspect.return_value = {"expiry": 9999999999}  # Far future
-        yield mock_inspect
+def _response_transport(requests: list[httpx.Request]) -> httpx.MockTransport:
+    """Record requests and return one successful native HTTPX response."""
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"ok": True}, request=request)
+
+    return httpx.MockTransport(respond)
 
 
 class TestInitializationAndConfiguration:
@@ -145,47 +141,54 @@ class TestInitializationAndConfiguration:
 class TestRuntimeCredentialHandling:
     """Test runtime credential handling including mutual exclusivity and validation."""
 
-    @pytest.mark.parametrize("asynchronous", [False, True])
-    def test_empty_token_is_saved_oidc_authentication(
+    def test_empty_token_uses_saved_oidc_authentication(
         self,
         canfar_client_fixture,
-        asynchronous: bool,
     ) -> None:
-        """An empty runtime token does not mask saved OIDC state."""
+        """A sync request uses saved OIDC state when the runtime token is empty."""
         config = oidc_config(idp="oidc")
-        client = canfar_client_fixture(
-            config=config,
-            token=SecretStr(""),
-        )
+        requests: list[httpx.Request] = []
 
-        assert not client.uses_runtime_credentials
-        credential = client._resolved_authentication_record()
-        assert credential is not None
-        assert credential.mode == "oidc"
-        headers = client._get_http_headers(credential=credential)
-        assert headers["Authorization"] == "Bearer access-token"
-        assert headers["X-Skaha-Authentication-Type"] == "OIDC"
+        with (
+            patch(
+                "canfar.client.Client",
+                side_effect=_sync_client_factory(_response_transport(requests)),
+            ),
+            canfar_client_fixture(config=config, token=SecretStr("")) as client,
+        ):
+            assert not client.uses_runtime_credentials
+            response = client.client.get("probe")
 
-        kwargs = client._get_client_kwargs(
-            asynchronous=asynchronous,
-            credential=credential,
-        )
-        request_hooks = kwargs["event_hooks"]["request"]
-        assert request_hooks[0].__name__ == ("ahook" if asynchronous else "hook")
+        assert response.json() == {"ok": True}
+        assert len(requests) == 1
+        request = requests[0]
+        assert str(request.url) == "https://oidc.example.com//v1/probe"
+        assert request.headers["Authorization"] == "Bearer access-token"
+        assert request.headers["X-Skaha-Authentication-Type"] == "OIDC"
 
-    async def test_empty_token_materializes_saved_oidc_access_token(
+    async def test_empty_token_uses_saved_oidc_authentication_async(
         self,
         canfar_client_fixture,
     ) -> None:
-        """Credential materialization falls through to saved OIDC state."""
-        client = canfar_client_fixture(
-            config=oidc_config(idp="oidc"),
-            token=SecretStr(""),
-        )
+        """An async request uses saved OIDC state when the runtime token is empty."""
+        requests: list[httpx.Request] = []
 
-        credential = await client._materialize_credentials()
+        with patch(
+            "canfar.client.AsyncClient",
+            side_effect=_async_client_factory(_response_transport(requests)),
+        ):
+            async with canfar_client_fixture(
+                config=oidc_config(idp="oidc"),
+                token=SecretStr(""),
+            ) as client:
+                response = await client.asynclient.get("probe")
 
-        assert credential.token == "access-token"
+        assert response.json() == {"ok": True}
+        assert len(requests) == 1
+        request = requests[0]
+        assert str(request.url) == "https://oidc.example.com//v1/probe"
+        assert request.headers["Authorization"] == "Bearer access-token"
+        assert request.headers["X-Skaha-Authentication-Type"] == "OIDC"
 
     def test_token_only(self, canfar_client_fixture) -> None:
         """Test instantiation with token only."""
@@ -252,15 +255,6 @@ class TestRuntimeCredentialHandling:
             canfar_client_fixture(
                 certificate=Path("/nonexistent/path.pem"), url="https://example.com"
             )
-
-    def test_token_setup_headers(self, canfar_client_fixture) -> None:
-        """Test token setup creates correct headers."""
-        token = "abcdef"
-        client = canfar_client_fixture(
-            token=SecretStr(token), url="https://example.com"
-        )
-        assert client.token.get_secret_value() == token
-        assert client.client.headers["Authorization"] == f"Bearer {token}"
 
 
 def _create_test_certificate(
@@ -335,24 +329,41 @@ class TestBaseURLConstruction:
     """Test base URL construction based on precedence."""
 
     def test_runtime_url_precedence(self, canfar_client_fixture) -> None:
-        """Test that runtime URL takes precedence."""
-        client = canfar_client_fixture(
-            token=SecretStr("test-token"), url="https://runtime.com/api"
-        )
-        base_url = client._get_base_url()
-        assert str(base_url) == "https://runtime.com/api"
+        """A request uses the runtime URL when runtime credentials are supplied."""
+        requests: list[httpx.Request] = []
+
+        with (
+            patch(
+                "canfar.client.Client",
+                side_effect=_sync_client_factory(_response_transport(requests)),
+            ),
+            canfar_client_fixture(
+                token=SecretStr("test-token"), url="https://runtime.com/api"
+            ) as client,
+        ):
+            response = client.client.get("probe")
+
+        assert response.status_code == 200
+        assert str(requests[0].url) == "https://runtime.com/api/probe"
+        assert requests[0].headers["Authorization"] == "Bearer test-token"
 
     def test_configured_url_from_context(self, canfar_client_fixture) -> None:
-        """Test base URL construction from configuration context."""
-        config = x509_config(
-            server_name="TestServer",
-            server_url="https://config.example.com",
-            path=Path("/test/cert.pem"),
-        )
+        """A request uses the configured Science Platform Server URL."""
+        requests: list[httpx.Request] = []
 
-        client = canfar_client_fixture(config=config)
-        base_url = client._get_base_url()
-        assert str(base_url) == "https://config.example.com//v1"
+        with (
+            patch(
+                "canfar.client.Client",
+                side_effect=_sync_client_factory(_response_transport(requests)),
+            ),
+            canfar_client_fixture(
+                config=oidc_config(server_url="https://config.example.com")
+            ) as client,
+        ):
+            response = client.client.get("probe")
+
+        assert response.status_code == 200
+        assert str(requests[0].url) == "https://config.example.com//v1/probe"
 
     def test_no_server_in_context_raises_error(self, canfar_client_fixture) -> None:
         """Test that missing server in context raises ValueError."""
@@ -362,11 +373,13 @@ class TestBaseURLConstruction:
             ),
         )
 
-        client = canfar_client_fixture(config=config)
-        with pytest.raises(
-            ValueError, match="Server not found for Authentication Record"
+        with (
+            canfar_client_fixture(config=config) as client,
+            pytest.raises(
+                ValueError, match="Server not found for Authentication Record"
+            ),
         ):
-            client._get_base_url()
+            client.client.get("probe")
 
     def test_active_server_without_url_raises_error(
         self, canfar_client_fixture
@@ -383,36 +396,60 @@ class TestBaseURLConstruction:
             ),
         )
 
-        client = canfar_client_fixture(config=config)
-        with pytest.raises(ValueError, match="Active server has no URL configured"):
-            client._get_base_url()
+        with (
+            canfar_client_fixture(config=config) as client,
+            pytest.raises(ValueError, match="Active server has no URL configured"),
+        ):
+            client.client.get("probe")
 
 
 class TestCertificateValidation:
     """Test certificate validation functionality."""
 
     def test_certificate_validation_with_token_skips_validation(self, tmp_path) -> None:
-        """Test certificate validation when token provided takes precedence."""
+        """A runtime-token request ignores a supplied certificate."""
         # Create a valid certificate file for this test
         cert_path = tmp_path / "valid.pem"
         _create_test_certificate(cert_path)
 
-        # Even with a valid certificate, when token is provided, it should use the token
-        client = HTTPClient(
-            token=SecretStr("test-token"),
-            certificate=cert_path,
-            url="https://example.com",
-        )
-        assert client.token is not None
-        assert client.certificate is None  # Certificate should be nullified
+        requests: list[httpx.Request] = []
+        with (
+            patch(
+                "canfar.client.Client",
+                side_effect=_sync_client_factory(_response_transport(requests)),
+            ),
+            HTTPClient(
+                token=SecretStr("test-token"),
+                certificate=cert_path,
+                url="https://example.com",
+            ) as client,
+        ):
+            response = client.client.get("probe")
 
-        # Verify that the client uses token authentication
-        headers = client._get_http_headers(
-            credential=client._resolved_authentication_record()
-        )
-        assert "Authorization" in headers
-        assert headers["Authorization"] == "Bearer test-token"
-        assert headers["X-Skaha-Authentication-Type"] == "RUNTIME-TOKEN"
+        assert response.status_code == 200
+        assert len(requests) == 1
+        assert str(requests[0].url) == "https://example.com/probe"
+        assert requests[0].headers["Authorization"] == "Bearer test-token"
+        assert requests[0].headers["X-Skaha-Authentication-Type"] == "RUNTIME-TOKEN"
+
+    def test_certificate_validates_for_native_request(self, tmp_path) -> None:
+        """A valid certificate can build a native client and complete a request."""
+        cert_path = tmp_path / "valid.pem"
+        _create_test_certificate(cert_path)
+        requests: list[httpx.Request] = []
+
+        with (
+            patch(
+                "canfar.client.Client",
+                side_effect=_sync_client_factory(_response_transport(requests)),
+            ),
+            HTTPClient(certificate=cert_path, url="https://example.com") as client,
+        ):
+            response = client.client.get("probe")
+
+        assert response.status_code == 200
+        assert len(requests) == 1
+        assert requests[0].headers["X-Skaha-Authentication-Type"] == "RUNTIME-X509"
 
     def test_certificate_file_not_exists(self, tmp_path) -> None:
         """Test certificate validation when file doesn't exist."""
@@ -437,359 +474,219 @@ class TestCertificateValidation:
         ):
             HTTPClient(certificate=cert_path, url="https://example.com")
 
-    def test_certificate_valid(self, tmp_path) -> None:
-        """Test certificate validation with valid certificate."""
-        cert_path = tmp_path / "valid.pem"
-        _create_test_certificate(cert_path)
-
-        # Should not raise an error
-        client = HTTPClient(certificate=cert_path, url="https://example.com")
-        assert client.certificate == cert_path
-
 
 class TestHTTPClientCreationAndHeaders:
-    """Test HTTP client creation and header generation."""
+    """Test HTTP client requests and header generation."""
 
-    def test_lazy_client_initialization(self, canfar_client_fixture) -> None:
-        """Test that httpx clients are created only on first access."""
-        client = canfar_client_fixture(
-            token=SecretStr("test-token"), url="https://example.com"
-        )
-
-        # Initially, private attributes should be None
-        assert client._client is None
-        assert client._asynclient is None
-
-        # Access client property to trigger creation
-        sync_client = client.client
-        assert client._client is not None
-        assert isinstance(sync_client, httpx.Client)
-
-        # Access asynclient property to trigger creation
-        async_client = client.asynclient
-        assert client._asynclient is not None
-        assert isinstance(async_client, httpx.AsyncClient)
-
-    def test_default_headers_present(self, canfar_client_fixture) -> None:
-        """Test that common headers are present."""
-        client = canfar_client_fixture(
-            token=SecretStr("test-token"), url="https://example.com"
-        )
-        with patch(
-            "canfar.client.formatdate",
-            return_value="Wed, 09 Jun 2026 12:00:00 GMT",
-        ) as mock_formatdate:
-            headers = client._get_http_headers(
-                credential=client._resolved_authentication_record()
-            )
-
-        mock_formatdate.assert_called_once_with(usegmt=True)
-        assert "Content-Type" in headers
-        assert "Accept" in headers
-        assert "User-Agent" in headers
-        assert headers["Date"] == "Wed, 09 Jun 2026 12:00:00 GMT"
-        assert re.match(
-            r"^\w{3}, \d{2} \w{3} \d{4} \d{2}:\d{2}:\d{2} GMT$",
-            headers["Date"],
-        )
-        assert headers["Content-Type"] == "application/x-www-form-urlencoded"
-        assert headers["Accept"] == "application/json"
-        assert "python-canfar" in headers["User-Agent"]
-
-    def test_runtime_token_headers(self, canfar_client_fixture) -> None:
-        """Test headers for runtime token authentication."""
-        client = canfar_client_fixture(
-            token=SecretStr("test-token"), url="https://example.com"
-        )
-        headers = client._get_http_headers(
-            credential=client._resolved_authentication_record()
-        )
-
-        assert headers["Authorization"] == "Bearer test-token"
-        assert headers["X-Skaha-Authentication-Type"] == "RUNTIME-TOKEN"
-
-    def test_runtime_certificate_headers(self, canfar_client_fixture, tmp_path) -> None:
-        """Test headers for runtime certificate authentication."""
-        cert_path = tmp_path / "test.pem"
-        _create_test_certificate(cert_path)
-
-        client = canfar_client_fixture(certificate=cert_path, url="https://example.com")
-        headers = client._get_http_headers(
-            credential=client._resolved_authentication_record()
-        )
-
-        assert headers["X-Skaha-Authentication-Type"] == "RUNTIME-X509"
-        assert "Authorization" not in headers
-
-    def test_oidc_context_headers(self, canfar_client_fixture) -> None:
-        """Test headers for OIDC context authentication."""
-        config = oidc_config(
-            idp="oidc",
-            access="oidc-access-token",
-            access_expiry=9999999999.0,
-            refresh_expiry=9999999999.0,
-        )
-
-        client = canfar_client_fixture(config=config)
-        headers = client._get_http_headers(
-            credential=client._resolved_authentication_record()
-        )
-
-        assert headers["Authorization"] == "Bearer oidc-access-token"
-        assert headers["X-Skaha-Authentication-Type"] == "OIDC"
-
-    def test_x509_context_headers(self, canfar_client_fixture) -> None:
-        """Test headers for X509 context authentication."""
-        config = x509_config(
-            idp="x509",
-            server_name="TestX509",
-            path=Path("/test/cert.pem"),
-        )
-
-        client = canfar_client_fixture(config=config)
-        headers = client._get_http_headers(
-            credential=client._resolved_authentication_record()
-        )
-
-        assert headers["X-Skaha-Authentication-Type"] == "X509"
-        assert "Authorization" not in headers
-
-    def test_registry_headers(self, canfar_client_fixture) -> None:
-        """Test headers with registry authentication."""
-        registry = ContainerRegistry(username="test", secret="test")
+    def test_sync_request_includes_common_and_registry_headers(
+        self,
+    ) -> None:
+        """A native sync request carries common and registry headers."""
         config = Configuration()
-        config.registry = registry
+        config.registry = ContainerRegistry(username="test", secret="test")
+        requests: list[httpx.Request] = []
 
-        client = canfar_client_fixture(
-            token=SecretStr("test-token"), url="https://example.com", config=config
-        )
-        headers = client._get_http_headers(
-            credential=client._resolved_authentication_record()
-        )
+        with (
+            patch(
+                "canfar.client.formatdate",
+                return_value="Wed, 09 Jun 2026 12:00:00 GMT",
+            ) as mock_formatdate,
+            patch(
+                "canfar.client.Client",
+                side_effect=_sync_client_factory(_response_transport(requests)),
+            ),
+            HTTPClient(
+                token=SecretStr("test-token"),
+                url="https://example.com",
+                config=config,
+            ) as client,
+        ):
+            response = client.client.get("probe")
 
-        assert "X-Skaha-Registry-Auth" in headers
+        assert response.status_code == 200
+        mock_formatdate.assert_called_once_with(usegmt=True)
+        request = requests[0]
+        assert str(request.url) == "https://example.com/probe"
+        assert request.headers["Authorization"] == "Bearer test-token"
+        assert request.headers["X-Skaha-Authentication-Type"] == "RUNTIME-TOKEN"
+        assert request.headers["Content-Type"] == "application/x-www-form-urlencoded"
+        assert request.headers["Accept"] == "application/json"
+        assert request.headers["Date"] == "Wed, 09 Jun 2026 12:00:00 GMT"
+        assert "python-canfar" in request.headers["User-Agent"]
+        assert request.headers["X-Skaha-Registry-Auth"] == "dGVzdDp0ZXN0"
 
-    def test_client_kwargs_timeout_and_concurrency(self, canfar_client_fixture) -> None:
-        """Test that httpx clients are initialized with correct timeout and limits."""
-        client = canfar_client_fixture(
-            token=SecretStr("test-token"),
-            url="https://example.com",
-            timeout=45,
-            concurrency=16,
-        )
+    async def test_async_request_includes_common_headers(
+        self,
+        canfar_client_fixture,
+    ) -> None:
+        """A native async request carries common headers and returns its result."""
+        requests: list[httpx.Request] = []
 
-        # Test sync client kwargs
-        sync_kwargs = client._get_client_kwargs(
-            asynchronous=False, credential=client._resolved_authentication_record()
-        )
-        assert "timeout" in sync_kwargs
-        # httpx.Timeout doesn't have a .timeout attribute, it's the object itself
-        assert isinstance(sync_kwargs["timeout"], httpx.Timeout)
-        assert "limits" not in sync_kwargs  # Only for async
+        with (
+            patch(
+                "canfar.client.AsyncClient",
+                side_effect=_async_client_factory(_response_transport(requests)),
+            ),
+            canfar_client_fixture(
+                token=SecretStr("test-token"), url="https://example.com"
+            ) as client,
+        ):
+            response = await client.asynclient.get("probe")
 
-        # Test async client kwargs
-        async_kwargs = client._get_client_kwargs(
-            asynchronous=True, credential=client._resolved_authentication_record()
-        )
-        assert "timeout" in async_kwargs
-        assert isinstance(async_kwargs["timeout"], httpx.Timeout)
-        assert "limits" in async_kwargs
-        assert async_kwargs["limits"].max_connections == 16
-
-    def test_oidc_refresh_hook_added(self, canfar_client_fixture) -> None:
-        """Test that OIDC refresh hook is added for OIDC contexts."""
-        config = oidc_config(
-            idp="oidc",
-            access="oidc-access-token",
-            access_expiry=9999999999.0,
-            refresh_expiry=9999999999.0,
-        )
-
-        client = canfar_client_fixture(config=config)
-
-        # Test sync client kwargs
-        sync_kwargs = client._get_client_kwargs(
-            asynchronous=False, credential=client._resolved_authentication_record()
-        )
-        assert "event_hooks" in sync_kwargs
-        assert "request" in sync_kwargs["event_hooks"]
-
-        # Test async client kwargs
-        async_kwargs = client._get_client_kwargs(
-            asynchronous=True, credential=client._resolved_authentication_record()
-        )
-        assert "event_hooks" in async_kwargs
-        assert "request" in async_kwargs["event_hooks"]
+        assert response.status_code == 200
+        assert len(requests) == 1
+        request = requests[0]
+        assert str(request.url) == "https://example.com/probe"
+        assert request.headers["Authorization"] == "Bearer test-token"
+        assert request.headers["X-Skaha-Authentication-Type"] == "RUNTIME-TOKEN"
+        assert request.headers["Content-Type"] == "application/x-www-form-urlencoded"
+        assert request.headers["Accept"] == "application/json"
 
 
 class TestContextManagerBehavior:
     """Test context manager functionality."""
 
     def test_sync_context_manager_enter_exit(self, canfar_client_fixture) -> None:
-        """Test synchronous context manager entry and exit."""
-        client = canfar_client_fixture(
-            token=SecretStr("test-token"), url="https://example.com"
-        )
+        """The sync context manager returns the client and closes HTTPX."""
+        requests: list[httpx.Request] = []
+        created: list[httpx.Client] = []
 
-        # Test __enter__
-        with client as ctx_client:
-            assert ctx_client is client
-            # Verify client is created
-            assert isinstance(ctx_client.client, httpx.Client)
+        def factory(**kwargs: object) -> httpx.Client:
+            native = httpx.Client(transport=_response_transport(requests), **kwargs)
+            created.append(native)
+            return native
 
-        # After exit, client should be closed
-        assert client._client is None
+        with (
+            patch("canfar.client.Client", side_effect=factory),
+            canfar_client_fixture(
+                token=SecretStr("test-token"), url="https://example.com"
+            ) as client,
+        ):
+            response = client.client.get("probe")
 
-    def test_close_sync_client(self, canfar_client_fixture) -> None:
-        """Test closing synchronous client."""
-        client = canfar_client_fixture(
-            token=SecretStr("test-token"), url="https://example.com"
-        )
-
-        # Access client to create it
-        _ = client.client
-        assert client._client is not None
-
-        # Close it
-        client._close()
-        assert client._client is None
-
-    def test_close_sync_client_when_none(self, canfar_client_fixture) -> None:
-        """Test closing synchronous client when it's None."""
-        client = canfar_client_fixture(
-            token=SecretStr("test-token"), url="https://example.com"
-        )
-
-        # Don't access client, so it remains None
-        assert client._client is None
-
-        # Close should not raise an error
-        client._close()
-        assert client._client is None
+        assert response.status_code == 200
+        assert len(requests) == 1
+        assert created[0].is_closed
 
     async def test_async_context_manager_enter_exit(
         self, canfar_client_fixture
     ) -> None:
-        """Test asynchronous context manager entry and exit."""
-        client = canfar_client_fixture(
-            token=SecretStr("test-token"), url="https://example.com"
-        )
+        """The async context manager returns the client and closes HTTPX."""
+        requests: list[httpx.Request] = []
+        created: list[httpx.AsyncClient] = []
 
-        # Test __aenter__
-        async with client as ctx_client:
-            assert ctx_client is client
-            # Verify asynclient is created
-            assert isinstance(ctx_client.asynclient, httpx.AsyncClient)
+        def factory(**kwargs: object) -> httpx.AsyncClient:
+            native = httpx.AsyncClient(
+                transport=_response_transport(requests), **kwargs
+            )
+            created.append(native)
+            return native
 
-        # After exit, asynclient should be closed
-        assert client._asynclient is None
+        with patch("canfar.client.AsyncClient", side_effect=factory):
+            async with canfar_client_fixture(
+                token=SecretStr("test-token"), url="https://example.com"
+            ) as client:
+                response = await client.asynclient.get("probe")
 
-    async def test_aclose_async_client(self, canfar_client_fixture) -> None:
-        """Test closing asynchronous client."""
-        client = canfar_client_fixture(
-            token=SecretStr("test-token"), url="https://example.com"
-        )
-
-        # Access asynclient to create it
-        _ = client.asynclient
-        assert client._asynclient is not None
-
-        # Close it
-        await client._aclose()
-        assert client._asynclient is None
-
-    async def test_aclose_async_client_when_none(self, canfar_client_fixture) -> None:
-        """Test closing asynchronous client when it's None."""
-        client = canfar_client_fixture(
-            token=SecretStr("test-token"), url="https://example.com"
-        )
-
-        # Don't access asynclient, so it remains None
-        assert client._asynclient is None
-
-        # Close should not raise an error
-        await client._aclose()
-        assert client._asynclient is None
+        assert response.status_code == 200
+        assert len(requests) == 1
+        assert created[0].is_closed
 
 
 class TestSSLContextAndClientKwargs:
-    """Test SSL context creation and client kwargs generation."""
+    """Test observable TLS validation and request-hook behavior."""
 
     def test_expiry_hook_omitted_for_runtime_token(
         self, canfar_client_fixture, tmp_path
     ) -> None:
-        """Runtime token must not install saved-config expiry request hook."""
+        """Runtime credentials bypass expiry checks from saved X.509 state."""
         cert_path = tmp_path / "expired.pem"
         generate_cert(cert_path, expired=True)
-        config = x509_config(idp="x509", path=cert_path)
-        client = canfar_client_fixture(
-            config=config,
-            token=SecretStr("runtime-token"),
-            url="https://runtime.com",
-        )
+        requests: list[httpx.Request] = []
+        config = x509_config(idp="x509", path=cert_path, expiry=0.0)
 
-        sync_kwargs = client._get_client_kwargs(
-            asynchronous=False, credential=client._resolved_authentication_record()
-        )
-        async_kwargs = client._get_client_kwargs(
-            asynchronous=True, credential=client._resolved_authentication_record()
-        )
+        with (
+            patch(
+                "canfar.client.Client",
+                side_effect=_sync_client_factory(_response_transport(requests)),
+            ),
+            canfar_client_fixture(
+                config=config,
+                token=SecretStr("runtime-token"),
+                url="https://runtime.com",
+            ) as client,
+        ):
+            response = client.client.get("probe")
 
-        assert len(sync_kwargs["event_hooks"]["request"]) == 1
-        assert len(async_kwargs["event_hooks"]["request"]) == 1
-        assert sync_kwargs["event_hooks"]["request"][0].__name__ == "request"
-        assert async_kwargs["event_hooks"]["request"][0].__name__ == "arequest"
+        assert response.status_code == 200
+        assert len(requests) == 1
+        assert requests[0].headers["Authorization"] == "Bearer runtime-token"
+
+    async def test_async_expiry_hook_omitted_for_runtime_token(
+        self, canfar_client_fixture, tmp_path
+    ) -> None:
+        """Async runtime credentials bypass saved X.509 expiry checks."""
+        cert_path = tmp_path / "expired.pem"
+        generate_cert(cert_path, expired=True)
+        requests: list[httpx.Request] = []
+
+        with patch(
+            "canfar.client.AsyncClient",
+            side_effect=_async_client_factory(_response_transport(requests)),
+        ):
+            async with canfar_client_fixture(
+                config=x509_config(idp="x509", path=cert_path, expiry=0.0),
+                token=SecretStr("runtime-token"),
+                url="https://runtime.com",
+            ) as client:
+                response = await client.asynclient.get("probe")
+
+        assert response.status_code == 200
+        assert len(requests) == 1
+        assert requests[0].headers["Authorization"] == "Bearer runtime-token"
 
     def test_expiry_hook_present_for_saved_expired_x509(
         self, canfar_client_fixture, tmp_path
     ) -> None:
-        """Saved expired x509 config must still install expiry request hook."""
+        """A sync request rejects an expired saved X.509 record."""
         cert_path = tmp_path / "expired.pem"
         generate_cert(cert_path, expired=True)
-        config = x509_config(idp="x509", path=cert_path)
-        client = canfar_client_fixture(config=config)
+        requests: list[httpx.Request] = []
+        config = x509_config(idp="x509", path=cert_path, expiry=0.0)
 
-        sync_kwargs = client._get_client_kwargs(
-            asynchronous=False, credential=client._resolved_authentication_record()
-        )
-        async_kwargs = client._get_client_kwargs(
-            asynchronous=True, credential=client._resolved_authentication_record()
-        )
+        with (
+            patch(
+                "canfar.client.Client",
+                side_effect=_sync_client_factory(_response_transport(requests)),
+            ),
+            canfar_client_fixture(config=config) as client,
+            pytest.raises(AuthExpiredError, match="expired"),
+        ):
+            client.client.get("probe")
 
-        assert len(sync_kwargs["event_hooks"]["request"]) == 2
-        assert len(async_kwargs["event_hooks"]["request"]) == 2
-        assert sync_kwargs["event_hooks"]["request"][0].__name__ == "hook"
-        assert async_kwargs["event_hooks"]["request"][0].__name__ == "hook"
-        assert sync_kwargs["event_hooks"]["request"][1].__name__ == "request"
-        assert async_kwargs["event_hooks"]["request"][1].__name__ == "arequest"
+        assert requests == []
 
-    def test_get_client_kwargs_with_certificate(
+    async def test_async_expiry_hook_present_for_saved_expired_x509(
         self, canfar_client_fixture, tmp_path
     ) -> None:
-        """Test client kwargs with certificate authentication."""
-        cert_path = tmp_path / "test.pem"
-        _create_test_certificate(cert_path)
+        """An async request rejects an expired saved X.509 record."""
+        cert_path = tmp_path / "expired.pem"
+        generate_cert(cert_path, expired=True)
+        requests: list[httpx.Request] = []
 
-        client = canfar_client_fixture(certificate=cert_path, url="https://example.com")
-        kwargs = client._get_client_kwargs(
-            asynchronous=False, credential=client._resolved_authentication_record()
-        )
+        with (
+            patch(
+                "canfar.client.AsyncClient",
+                side_effect=_async_client_factory(_response_transport(requests)),
+            ),
+            pytest.raises(AuthExpiredError, match="expired"),
+        ):
+            async with canfar_client_fixture(
+                config=x509_config(idp="x509", path=cert_path, expiry=0.0)
+            ) as client:
+                await client.asynclient.get("probe")
 
-        assert "verify" in kwargs
-        assert isinstance(kwargs["verify"], ssl.SSLContext)
-
-    def test_get_ssl_context_valid_certificate(
-        self, canfar_client_fixture, tmp_path
-    ) -> None:
-        """Test SSL context creation with valid certificate."""
-        cert_path = tmp_path / "test.pem"
-        _create_test_certificate(cert_path)
-
-        client = canfar_client_fixture(certificate=cert_path, url="https://example.com")
-        ssl_context = client._get_ssl_context(cert_path)
-
-        assert isinstance(ssl_context, ssl.SSLContext)
-        assert ssl_context.minimum_version == ssl.TLSVersion.TLSv1_2
+        assert requests == []
 
 
 def test_non_readable_certfile() -> None:


### PR DESCRIPTION
## Summary

- Replace `tests/test_client.py` assertions on `HTTPClient` private helpers and lifecycle attributes with native sync/async request contracts over `httpx.MockTransport`.
- Preserve observable coverage for URL selection, runtime/saved credential precedence, headers, expiry hooks, TLS certificate validation/failure, request results, and context-manager closure.
- Delete redundant private kwargs/header-count tests and unused mock fixtures; production code is unchanged.

## Validation

- `uv run --no-sync pytest tests/test_client.py --no-cov -q` (33 passed; 45 before contraction)
- `uv run --no-sync pytest tests/test_client.py tests/test_client_auth_resolution.py --cov=canfar.client --cov-report=term-missing --cov-fail-under=0 -q` (52 passed; `canfar.client` 82.89%)
- `uv run --no-sync pytest tests -m 'not slow' --no-cov -q` (842 passed)
- `uv run --no-sync ruff check . --no-cache`
- `uv run ty check canfar`

The changed test file is formatted and Ruff-clean. Repository-wide `ruff format --check .` still reports 10 unrelated pre-existing documentation formatting issues.

Target branch is `feat/interfaces`; this draft is intentionally not merged or submitted for review.
