### PR TITLE
fix(quality): resolve PR 276 analyzer findings

### DIFF
--- a/canfar/authentication.py
+++ b/canfar/authentication.py
@@ -445,7 +445,7 @@ def _authenticate_oidc(info: IdpInfo) -> OIDCCredential:
             on_challenge=_print_device_challenge,
         )
     except _OIDC_DEVICE_LOGIN_ERRORS as exc:
-        _raise_oidc_authentication_error(exc)
+        return _raise_oidc_authentication_error(exc)
 
 
 async def _authenticate_oidc_async(info: IdpInfo) -> OIDCCredential:
@@ -458,7 +458,7 @@ async def _authenticate_oidc_async(info: IdpInfo) -> OIDCCredential:
             on_challenge=_print_device_challenge,
         )
     except _OIDC_DEVICE_LOGIN_ERRORS as exc:
-        _raise_oidc_authentication_error(exc)
+        return _raise_oidc_authentication_error(exc)
 
 
 __all__ = [

--- a/canfar/models/config.py
+++ b/canfar/models/config.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Literal
@@ -36,8 +35,6 @@ from canfar.models.auth import (
 )
 from canfar.models.http import Server, VOSpaceService
 from canfar.models.registry import ContainerRegistry
-
-log = logging.getLogger(__name__)
 
 _CADC_URI = AnyUrl("ivo://cadc.nrc.ca/skaha")
 _CONFIG_KEY_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*$")

--- a/canfar/server.py
+++ b/canfar/server.py
@@ -7,14 +7,28 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict
 
 from canfar._server_discovery import (
-    ServerDiscoveryError,  # noqa: F401
-    ServerFetchError,  # noqa: F401
+    ServerDiscoveryError,
+    ServerFetchError,
     _validate_server,
     discover,
-    enrich,  # noqa: F401
+    enrich,
 )
 from canfar.models.config import Configuration
 from canfar.models.http import Server  # noqa: TC001
+
+__all__ = [
+    "ServerActivation",
+    "ServerDiscoveryError",
+    "ServerFetchError",
+    "ServerSelectionRequiredError",
+    "ServerSelectorError",
+    "activate",
+    "activate_authentication",
+    "discover",
+    "enrich",
+    "list_servers",
+    "use",
+]
 
 
 class ServerSelectorError(ValueError):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -13,6 +13,7 @@ import pytest
 import yaml
 from pydantic import AnyHttpUrl, AnyUrl
 
+import canfar.server as platform
 from canfar._server_discovery import (
     _discover_for_idp,
     _discovered_to_server,
@@ -55,6 +56,26 @@ _VOSPACE_CAPABILITIES = """
       </capability>
     </capabilities>
 """
+
+
+def test_public_exports_declare_server_api() -> None:
+    """The module's public and compatibility exports remain explicit."""
+    expected = {
+        "ServerActivation",
+        "ServerDiscoveryError",
+        "ServerFetchError",
+        "ServerSelectionRequiredError",
+        "ServerSelectorError",
+        "activate",
+        "activate_authentication",
+        "discover",
+        "enrich",
+        "list_servers",
+        "use",
+    }
+
+    assert set(platform.__all__) == expected
+    assert all(hasattr(platform, name) for name in expected)
 
 
 def test_enrich_preserves_storage_resource_annotation() -> None:


### PR DESCRIPTION
## Summary
- remove the unused Configuration module logger
- make OIDC failure branches explicitly non-fallthrough
- declare the intentional canfar.server compatibility exports through __all__
- lock the public server export contract

Resolves all current github-code-quality threads on #276 without deleting compatibility interfaces.

## Validation
- 116 focused tests passed
- 844 deterministic non-slow tests passed
- Ruff passed
- ty passed
- formatting and diff checks passed

Part of #244.