### PR TITLE
test(server): use one public import style

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -13,7 +13,6 @@ import pytest
 import yaml
 from pydantic import AnyHttpUrl, AnyUrl
 
-import canfar.server as platform
 from canfar._server_discovery import (
     _discover_for_idp,
     _discovered_to_server,
@@ -34,6 +33,9 @@ from canfar.server import (
     discover,
     enrich,
     use,
+)
+from canfar.server import (
+    __all__ as server_exports,
 )
 from canfar.server import (
     list_servers as server_list,
@@ -74,8 +76,7 @@ def test_public_exports_declare_server_api() -> None:
         "use",
     }
 
-    assert set(platform.__all__) == expected
-    assert all(hasattr(platform, name) for name in expected)
+    assert set(server_exports) == expected
 
 
 def test_enrich_preserves_storage_resource_annotation() -> None:


### PR DESCRIPTION
## Summary
- remove the redundant module-form canfar.server import
- inspect the declared public exports through the existing from-import style
- resolve the final github-code-quality thread on #276

## Validation
- focused export test passed
- 844 deterministic non-slow tests passed
- Ruff, formatting, ty, and diff checks passed

Part of #244.